### PR TITLE
Use toast for login error feedback

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import Link from "next/link";
 import { supabasebrowser } from '@/lib/supabaseClient'
 import { useRouter } from 'next/navigation'
+import { toast } from "sonner";
 
 export default function LoginPage() {
   const router = useRouter();
@@ -27,7 +28,7 @@ export default function LoginPage() {
     e.preventDefault();
     const { error } = await supabasebrowser.auth.signInWithPassword({ email, password });
     if (error) {
-      alert('Falha no login: ' + error.message);
+      toast.error('Falha no login: ' + error.message);
     } else {
       router.push('/dashboard');
     }


### PR DESCRIPTION
## Summary
- show toast error when login fails

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype; Unexpected any; etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688ebb255864832facb4030ecf6e2350