### PR TITLE
feat: add input validation for signup and profile

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "sonner": "^2.0.7",
-    "tailwind-merge": "^3.3.1"
+    "tailwind-merge": "^3.3.1",
+    "country-state-city": "^4.0.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -1,11 +1,28 @@
 // src/app/api/auth/signup/route.ts
 import { NextResponse } from "next/server";
 import { supabaseadmin } from '@/lib/supabaseAdmin'
+import {
+  isValidCompanyName,
+  isValidEmail,
+  isValidPassword,
+} from "@/lib/validators";
 
 export async function POST(req: Request) {
   const { name, email, password } = await req.json();
   if (!name || !email || !password) {
     return NextResponse.json({ error: "Dados incompletos" }, { status: 400 });
+  }
+  if (!isValidCompanyName(name)) {
+    return NextResponse.json(
+      { error: "Nome da empresa inválido" },
+      { status: 400 }
+    );
+  }
+  if (!isValidEmail(email)) {
+    return NextResponse.json({ error: "Email inválido" }, { status: 400 });
+  }
+  if (!isValidPassword(password)) {
+    return NextResponse.json({ error: "Senha inválida" }, { status: 400 });
   }
 
   const { data, error } = await supabaseadmin.auth.admin.createUser({

--- a/src/app/api/profile/complete/route.ts
+++ b/src/app/api/profile/complete/route.ts
@@ -1,5 +1,11 @@
 import { NextResponse } from "next/server";
 import { supabaseadmin } from "@/lib/supabaseAdmin";
+import { COUNTRIES, STATES, CITIES } from "@/lib/locations";
+import {
+  isValidCpfCnpj,
+  isValidAddress,
+  isValidResponsible,
+} from "@/lib/validators";
 
 export async function POST(req: Request) {
   const {
@@ -20,10 +26,22 @@ export async function POST(req: Request) {
     !city ||
     !state ||
     !country ||
-    !responsible_name 
+    !responsible_name
     // !language
   ) {
     return NextResponse.json({ error: "Dados incompletos" }, { status: 400 });
+  }
+  if (!isValidCpfCnpj(cpf_cnpj)) {
+    return NextResponse.json({ error: "CPF/CNPJ inválido" }, { status: 400 });
+  }
+  if (!isValidAddress(address)) {
+    return NextResponse.json({ error: "Endereço inválido" }, { status: 400 });
+  }
+  if (!CITIES.includes(city) || !STATES.includes(state) || !COUNTRIES.includes(country)) {
+    return NextResponse.json({ error: "Localização inválida" }, { status: 400 });
+  }
+  if (!isValidResponsible(responsible_name)) {
+    return NextResponse.json({ error: "Responsável inválido" }, { status: 400 });
   }
 
   const { data: company, error: companyError } = await supabaseadmin

--- a/src/app/complete-profile/page.tsx
+++ b/src/app/complete-profile/page.tsx
@@ -6,6 +6,19 @@ import { supabasebrowser } from "@/lib/supabaseClient";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { COUNTRIES, STATES, CITIES } from "@/lib/locations";
+import {
+  isValidCpfCnpj,
+  isValidAddress,
+  isValidResponsible,
+} from "@/lib/validators";
 
 export default function CompleteProfilePage() {
   const router = useRouter();
@@ -15,7 +28,7 @@ export default function CompleteProfilePage() {
   const [address, setAddress] = useState("");
   const [city, setCity] = useState("");
   const [state, setState] = useState("");
-  const [country, setCountry] = useState("");
+  const [country, setCountry] = useState("Brasil");
   const [responsible, setResponsible] = useState("");
   // const [language, setLanguage] = useState("");
 
@@ -59,6 +72,22 @@ export default function CompleteProfilePage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!userId) return;
+    if (!isValidCpfCnpj(cpfCnpj)) {
+      toast.error("CPF/CNPJ inválido");
+      return;
+    }
+    if (!isValidAddress(address)) {
+      toast.error("Endereço deve ter entre 3 e 200 caracteres");
+      return;
+    }
+    if (!CITIES.includes(city) || !STATES.includes(state) || !COUNTRIES.includes(country)) {
+      toast.error("Localização inválida");
+      return;
+    }
+    if (!isValidResponsible(responsible)) {
+      toast.error("Responsável deve ter entre 4 e 80 caracteres");
+      return;
+    }
     setLoading(true);
     const res = await fetch("/api/profile/complete", {
       method: "POST",
@@ -110,6 +139,7 @@ export default function CompleteProfilePage() {
             value={cpfCnpj}
             onChange={(e) => setCpfCnpj(e.target.value)}
             required
+            maxLength={18}
           />
         </div>
         <div>
@@ -122,46 +152,57 @@ export default function CompleteProfilePage() {
             value={address}
             onChange={(e) => setAddress(e.target.value)}
             required
+            minLength={3}
+            maxLength={200}
           />
         </div>
         <div className="grid grid-cols-2 gap-4">
           <div>
-            <label htmlFor="city" className="block text-sm font-medium">
-              Cidade
-            </label>
-            <Input
-              id="city"
-              type="text"
-              value={city}
-              onChange={(e) => setCity(e.target.value)}
-              required
-            />
+            <label className="block text-sm font-medium">Cidade</label>
+            <Select value={city} onValueChange={setCity}>
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Selecione" />
+              </SelectTrigger>
+              <SelectContent>
+                {CITIES.map((c) => (
+                  <SelectItem key={c} value={c}>
+                    {c}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
           <div>
-            <label htmlFor="state" className="block text-sm font-medium">
-              Estado
-            </label>
-            <Input
-              id="state"
-              type="text"
-              value={state}
-              onChange={(e) => setState(e.target.value)}
-              required
-            />
+            <label className="block text-sm font-medium">Estado</label>
+            <Select value={state} onValueChange={setState}>
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Selecione" />
+              </SelectTrigger>
+              <SelectContent>
+                {STATES.map((s) => (
+                  <SelectItem key={s} value={s}>
+                    {s}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
         </div>
         <div className="grid grid-cols-2 gap-4">
           <div>
-            <label htmlFor="country" className="block text-sm font-medium">
-              País
-            </label>
-            <Input
-              id="country"
-              type="text"
-              value={country}
-              onChange={(e) => setCountry(e.target.value)}
-              required
-            />
+            <label className="block text-sm font-medium">País</label>
+            <Select value={country} onValueChange={setCountry}>
+              <SelectTrigger className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {COUNTRIES.map((c) => (
+                  <SelectItem key={c} value={c}>
+                    {c}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
           {/* <div>
             <label htmlFor="language" className="block text-sm font-medium">
@@ -186,6 +227,8 @@ export default function CompleteProfilePage() {
             value={responsible}
             onChange={(e) => setResponsible(e.target.value)}
             required
+            minLength={4}
+            maxLength={80}
           />
         </div>
         <Button type="submit" className="w-full" disabled={loading}>

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -6,6 +6,11 @@ import Link from "next/link";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
+import {
+  isValidCompanyName,
+  isValidEmail,
+  isValidPassword,
+} from "@/lib/validators";
 
 export default function SignupPage() {
   const router = useRouter();
@@ -19,6 +24,20 @@ export default function SignupPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
+    if (!isValidCompanyName(name)) {
+      setError("Nome da empresa deve ter entre 4 e 80 caracteres");
+      return;
+    }
+    if (!isValidEmail(email)) {
+      setError("Email inválido");
+      return;
+    }
+    if (!isValidPassword(password)) {
+      setError(
+        "Senha deve ter pelo menos 8 caracteres, incluindo maiúscula, minúscula, número e símbolo"
+      );
+      return;
+    }
     if (password !== confirm) {
       setError("As senhas não coincidem");
       return;
@@ -68,6 +87,8 @@ export default function SignupPage() {
             value={name}
             onChange={(e) => setName(e.target.value)}
             required
+            minLength={4}
+            maxLength={80}
           />
         </div>
 
@@ -81,6 +102,7 @@ export default function SignupPage() {
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             required
+            maxLength={320}
           />
         </div>
 
@@ -94,6 +116,9 @@ export default function SignupPage() {
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             required
+            minLength={8}
+            pattern="(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[^A-Za-z0-9]).{8,}"
+            title="Deve conter letra maiúscula, minúscula, número e símbolo"
           />
         </div>
 
@@ -107,6 +132,9 @@ export default function SignupPage() {
             value={confirm}
             onChange={(e) => setConfirm(e.target.value)}
             required
+            minLength={8}
+            pattern="(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[^A-Za-z0-9]).{8,}"
+            title="Deve conter letra maiúscula, minúscula, número e símbolo"
           />
         </div>
 

--- a/src/lib/locations.ts
+++ b/src/lib/locations.ts
@@ -1,0 +1,7 @@
+import { Country, State, City } from "country-state-city";
+
+export const COUNTRIES = Country.getAllCountries().map((c) => c.name);
+
+export const STATES = State.getStatesOfCountry("BR").map((s) => s.isoCode);
+
+export const CITIES = City.getCitiesOfCountry("BR").map((c) => c.name);

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -1,0 +1,59 @@
+export function isValidCompanyName(name: string): boolean {
+  return name.length >= 4 && name.length <= 80;
+}
+
+export function isValidEmail(email: string): boolean {
+  return (
+    email.length <= 320 &&
+    /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)
+  );
+}
+
+export function isValidPassword(password: string): boolean {
+  // mínimo 8 caracteres, incluindo maiúscula, minúscula, número e símbolo
+  return /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/.test(password);
+}
+
+function isValidCPF(cpf: string): boolean {
+  cpf = cpf.replace(/\D/g, "");
+  if (cpf.length !== 11 || /^(\d)\1+$/.test(cpf)) return false;
+  let sum = 0;
+  for (let i = 0; i < 9; i++) sum += parseInt(cpf.charAt(i)) * (10 - i);
+  let rev = 11 - (sum % 11);
+  if (rev === 10 || rev === 11) rev = 0;
+  if (rev !== parseInt(cpf.charAt(9))) return false;
+  sum = 0;
+  for (let i = 0; i < 10; i++) sum += parseInt(cpf.charAt(i)) * (11 - i);
+  rev = 11 - (sum % 11);
+  if (rev === 10 || rev === 11) rev = 0;
+  return rev === parseInt(cpf.charAt(10));
+}
+
+function isValidCNPJ(cnpj: string): boolean {
+  cnpj = cnpj.replace(/\D/g, "");
+  if (cnpj.length !== 14 || /^(\d)\1+$/.test(cnpj)) return false;
+  const calc = (x: number) => {
+    let n = 0;
+    for (let i = 0; i < x; i++) {
+      n += parseInt(cnpj.charAt(i)) * ((x + 1 - i) % 8 || 9);
+    }
+    return n % 11 < 2 ? 0 : 11 - (n % 11);
+  };
+  const d1 = calc(12);
+  if (d1 !== parseInt(cnpj.charAt(12))) return false;
+  const d2 = calc(13);
+  return d2 === parseInt(cnpj.charAt(13));
+}
+
+export function isValidCpfCnpj(value: string): boolean {
+  const numbers = value.replace(/\D/g, "");
+  return numbers.length === 11 ? isValidCPF(numbers) : numbers.length === 14 ? isValidCNPJ(numbers) : false;
+}
+
+export function isValidAddress(address: string): boolean {
+  return address.length >= 3 && address.length <= 200;
+}
+
+export function isValidResponsible(name: string): boolean {
+  return name.length >= 4 && name.length <= 80;
+}


### PR DESCRIPTION
## Summary
- enforce company, email and password validation during signup
- add CPF/CNPJ, address and location checks to complete profile flow
- introduce shared validators and location constants
- source location lists from country-state-city

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688edd34dc14832fb313bd83f07ea340