### PR TITLE
feat: add form validations and fields

### DIFF
--- a/migration.sql
+++ b/migration.sql
@@ -4,10 +4,12 @@ create table public.company_profile (
   created_at timestamp with time zone not null default now(),
   cpf_cnpj text not null,
   address text not null,
+  zip_code text not null,
   city text not null,
   state text not null,
   country text not null,
   responsible_name text not null,
+  phone text not null,
   language text not null,
   constraint company_profile_pkey primary key (id),
   constraint company_profile_id_key unique (id)

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -1,11 +1,38 @@
 // src/app/api/auth/signup/route.ts
 import { NextResponse } from "next/server";
-import { supabaseadmin } from '@/lib/supabaseAdmin'
+import { supabaseadmin } from "@/lib/supabaseAdmin";
+import {
+  isValidCompanyName,
+  isValidEmail,
+  isValidPassword,
+} from "@/lib/validators";
 
 export async function POST(req: Request) {
   const { name, email, password } = await req.json();
   if (!name || !email || !password) {
     return NextResponse.json({ error: "Dados incompletos" }, { status: 400 });
+  }
+
+  if (!isValidCompanyName(name)) {
+    return NextResponse.json(
+      { error: "Nome da empresa deve ter entre 4 e 80 caracteres" },
+      { status: 400 },
+    );
+  }
+  if (!isValidEmail(email)) {
+    return NextResponse.json(
+      { error: "Email inválido" },
+      { status: 400 },
+    );
+  }
+  if (!isValidPassword(password)) {
+    return NextResponse.json(
+      {
+        error:
+          "Senha deve ter ao menos 8 caracteres com maiúsculas, minúsculas, número e símbolo",
+      },
+      { status: 400 },
+    );
   }
 
   const { data, error } = await supabaseadmin.auth.admin.createUser({

--- a/src/app/api/profile/complete/route.ts
+++ b/src/app/api/profile/complete/route.ts
@@ -1,15 +1,24 @@
 import { NextResponse } from "next/server";
 import { supabaseadmin } from "@/lib/supabaseAdmin";
+import {
+  isValidCpfCnpj,
+  isValidAddress,
+  isValidCep,
+  isValidResponsible,
+  isValidPhone,
+} from "@/lib/validators";
 
 export async function POST(req: Request) {
   const {
     user_id,
     cpf_cnpj,
     address,
+    zip_code,
     city,
     state,
     country,
     responsible_name,
+    phone,
     // language,
   } = await req.json();
 
@@ -17,13 +26,37 @@ export async function POST(req: Request) {
     !user_id ||
     !cpf_cnpj ||
     !address ||
+    !zip_code ||
     !city ||
     !state ||
     !country ||
-    !responsible_name 
+    !responsible_name ||
+    !phone
     // !language
   ) {
     return NextResponse.json({ error: "Dados incompletos" }, { status: 400 });
+  }
+
+  if (!isValidCpfCnpj(cpf_cnpj)) {
+    return NextResponse.json({ error: "CPF/CNPJ inválido" }, { status: 400 });
+  }
+  if (!isValidAddress(address)) {
+    return NextResponse.json(
+      { error: "Endereço deve ter entre 3 e 200 caracteres" },
+      { status: 400 },
+    );
+  }
+  if (!isValidCep(zip_code)) {
+    return NextResponse.json({ error: "CEP inválido" }, { status: 400 });
+  }
+  if (!isValidResponsible(responsible_name)) {
+    return NextResponse.json(
+      { error: "Responsável deve ter entre 4 e 80 caracteres" },
+      { status: 400 },
+    );
+  }
+  if (!isValidPhone(phone)) {
+    return NextResponse.json({ error: "Telefone inválido" }, { status: 400 });
   }
 
   const { data: company, error: companyError } = await supabaseadmin
@@ -47,10 +80,12 @@ export async function POST(req: Request) {
       .update({
         cpf_cnpj,
         address,
+        zip_code,
         city,
         state,
         country,
         responsible_name,
+        phone,
         // language,
       })
       .eq("id", profileId);
@@ -67,10 +102,12 @@ export async function POST(req: Request) {
       .insert({
         cpf_cnpj,
         address,
+        zip_code,
         city,
         state,
         country,
         responsible_name,
+        phone,
         // language,
       })
       .select("id")

--- a/src/app/api/profile/complete/route.ts
+++ b/src/app/api/profile/complete/route.ts
@@ -37,7 +37,11 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "Dados incompletos" }, { status: 400 });
   }
 
-  if (!isValidCpfCnpj(cpf_cnpj)) {
+  const cleanCpfCnpj = cpf_cnpj.replace(/\D/g, "");
+  const cleanZip = zip_code.replace(/\D/g, "");
+  const cleanPhone = phone.replace(/\D/g, "");
+
+  if (!isValidCpfCnpj(cleanCpfCnpj)) {
     return NextResponse.json({ error: "CPF/CNPJ inválido" }, { status: 400 });
   }
   if (!isValidAddress(address)) {
@@ -46,7 +50,7 @@ export async function POST(req: Request) {
       { status: 400 },
     );
   }
-  if (!isValidCep(zip_code)) {
+  if (!isValidCep(cleanZip)) {
     return NextResponse.json({ error: "CEP inválido" }, { status: 400 });
   }
   if (!isValidResponsible(responsible_name)) {
@@ -55,7 +59,7 @@ export async function POST(req: Request) {
       { status: 400 },
     );
   }
-  if (!isValidPhone(phone)) {
+  if (!isValidPhone(cleanPhone)) {
     return NextResponse.json({ error: "Telefone inválido" }, { status: 400 });
   }
 
@@ -78,14 +82,14 @@ export async function POST(req: Request) {
     const { error: profileUpdateError } = await supabaseadmin
       .from("company_profile")
       .update({
-        cpf_cnpj,
+        cpf_cnpj: cleanCpfCnpj,
         address,
-        zip_code,
+        zip_code: cleanZip,
         city,
         state,
         country,
         responsible_name,
-        phone,
+        phone: cleanPhone,
         // language,
       })
       .eq("id", profileId);
@@ -100,14 +104,14 @@ export async function POST(req: Request) {
     const { data: profile, error: profileInsertError } = await supabaseadmin
       .from("company_profile")
       .insert({
-        cpf_cnpj,
+        cpf_cnpj: cleanCpfCnpj,
         address,
-        zip_code,
+        zip_code: cleanZip,
         city,
         state,
         country,
         responsible_name,
-        phone,
+        phone: cleanPhone,
         // language,
       })
       .select("id")

--- a/src/app/complete-profile/page.tsx
+++ b/src/app/complete-profile/page.tsx
@@ -199,6 +199,7 @@ export default function CompleteProfilePage() {
             value={cpfCnpj}
             onChange={(e) => handleCpfCnpjChange(e.target.value)}
             maxLength={18}
+            placeholder="000.000.000-00"
             required
           />
         </div>
@@ -225,6 +226,7 @@ export default function CompleteProfilePage() {
               value={zipCode}
               onChange={(e) => handleZipChange(e.target.value)}
               maxLength={9}
+              placeholder="00000-000"
               required
             />
           </div>
@@ -293,6 +295,7 @@ export default function CompleteProfilePage() {
               value={phone}
               onChange={(e) => handlePhoneChange(e.target.value)}
               maxLength={19}
+              placeholder="+00 (00) 00000-0000"
               required
             />
           </div>

--- a/src/app/complete-profile/page.tsx
+++ b/src/app/complete-profile/page.tsx
@@ -35,6 +35,35 @@ export default function CompleteProfilePage() {
   const [phone, setPhone] = useState("");
   // const [language, setLanguage] = useState("");
 
+  const handleCpfCnpjChange = (value: string) => {
+    let digits = value.replace(/\D/g, "");
+    if (digits.length > 14) digits = digits.slice(0, 14);
+    if (digits.length <= 11) {
+      digits = digits
+        .replace(/(\d{3})(\d)/, "$1.$2")
+        .replace(/(\d{3})(\d)/, "$1.$2")
+        .replace(/(\d{3})(\d{1,2})$/, "$1-$2");
+    } else {
+      digits = digits
+        .replace(/(\d{2})(\d)/, "$1.$2")
+        .replace(/(\d{3})(\d)/, "$1.$2")
+        .replace(/(\d{3})(\d)/, "$1/$2")
+        .replace(/(\d{4})(\d{1,2})$/, "$1-$2");
+    }
+    setCpfCnpj(digits);
+  };
+
+  const handlePhoneChange = (value: string) => {
+    let digits = value.replace(/\D/g, "");
+    if (digits.length > 13) digits = digits.slice(0, 13);
+    let formatted = "";
+    if (digits.length > 0) formatted += "+" + digits.slice(0, 2);
+    if (digits.length >= 3) formatted += " (" + digits.slice(2, 4) + ")";
+    if (digits.length >= 5) formatted += " " + digits.slice(4, 9);
+    if (digits.length >= 10) formatted += "-" + digits.slice(9, 13);
+    setPhone(formatted);
+  };
+
   useEffect(() => {
     supabasebrowser.auth.getUser().then(async ({ data, error }) => {
       if (error || !data?.user) {
@@ -59,14 +88,14 @@ export default function CompleteProfilePage() {
           .eq("id", company.company_profile_id)
           .single();
         if (profile) {
-          setCpfCnpj(profile.cpf_cnpj || "");
+          handleCpfCnpjChange(profile.cpf_cnpj || "");
           setAddress(profile.address || "");
           setZipCode(profile.zip_code || "");
           setCity(profile.city || "");
           setState(profile.state || "");
           setCountry(profile.country || "Brasil");
           setResponsible(profile.responsible_name || "");
-          setPhone(profile.phone || "");
+          handlePhoneChange(profile.phone || "");
           // setLanguage(profile.language || "");
         }
       }
@@ -159,7 +188,8 @@ export default function CompleteProfilePage() {
             id="cpfCnpj"
             type="text"
             value={cpfCnpj}
-            onChange={(e) => setCpfCnpj(e.target.value)}
+            onChange={(e) => handleCpfCnpjChange(e.target.value)}
+            maxLength={18}
             required
           />
         </div>
@@ -251,7 +281,8 @@ export default function CompleteProfilePage() {
               id="phone"
               type="tel"
               value={phone}
-              onChange={(e) => setPhone(e.target.value)}
+              onChange={(e) => handlePhoneChange(e.target.value)}
+              maxLength={19}
               required
             />
           </div>

--- a/src/app/complete-profile/page.tsx
+++ b/src/app/complete-profile/page.tsx
@@ -64,6 +64,15 @@ export default function CompleteProfilePage() {
     setPhone(formatted);
   };
 
+  const handleZipChange = (value: string) => {
+    let digits = value.replace(/\D/g, "");
+    if (digits.length > 8) digits = digits.slice(0, 8);
+    if (digits.length > 5) {
+      digits = digits.replace(/(\d{5})(\d{1,3})/, "$1-$2");
+    }
+    setZipCode(digits);
+  };
+
   useEffect(() => {
     supabasebrowser.auth.getUser().then(async ({ data, error }) => {
       if (error || !data?.user) {
@@ -90,7 +99,7 @@ export default function CompleteProfilePage() {
         if (profile) {
           handleCpfCnpjChange(profile.cpf_cnpj || "");
           setAddress(profile.address || "");
-          setZipCode(profile.zip_code || "");
+          handleZipChange(profile.zip_code || "");
           setCity(profile.city || "");
           setState(profile.state || "");
           setCountry(profile.country || "Brasil");
@@ -214,7 +223,8 @@ export default function CompleteProfilePage() {
               id="zip"
               type="text"
               value={zipCode}
-              onChange={(e) => setZipCode(e.target.value)}
+              onChange={(e) => handleZipChange(e.target.value)}
+              maxLength={9}
               required
             />
           </div>

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -6,6 +6,11 @@ import Link from "next/link";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
+import {
+  isValidCompanyName,
+  isValidEmail,
+  isValidPassword,
+} from "@/lib/validators";
 
 export default function SignupPage() {
   const router = useRouter();
@@ -19,6 +24,20 @@ export default function SignupPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
+    if (!isValidCompanyName(name)) {
+      setError("Nome da empresa deve ter entre 4 e 80 caracteres");
+      return;
+    }
+    if (!isValidEmail(email)) {
+      setError("Email inválido");
+      return;
+    }
+    if (!isValidPassword(password)) {
+      setError(
+        "Senha deve ter ao menos 8 caracteres com maiúsculas, minúsculas, número e símbolo",
+      );
+      return;
+    }
     if (password !== confirm) {
       setError("As senhas não coincidem");
       return;

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -1,0 +1,72 @@
+export function isValidCompanyName(name: string) {
+  const len = name.trim().length;
+  return len >= 4 && len <= 80;
+}
+
+export function isValidEmail(email: string) {
+  if (email.length > 320) return false;
+  const regex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  return regex.test(email);
+}
+
+export function isValidPassword(password: string) {
+  // At least 8 characters, one upper, one lower, one number and one special char
+  const regex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/;
+  return regex.test(password);
+}
+
+export function isValidCpfCnpj(value: string) {
+  const digits = value.replace(/\D/g, "");
+  if (digits.length === 11) return validateCPF(digits);
+  if (digits.length === 14) return validateCNPJ(digits);
+  return false;
+}
+
+function validateCPF(cpf: string) {
+  if (/^(\d)\1+$/.test(cpf)) return false;
+  let sum = 0;
+  for (let i = 0; i < 9; i++) sum += parseInt(cpf.charAt(i)) * (10 - i);
+  let d1 = (sum * 10) % 11;
+  if (d1 === 10) d1 = 0;
+  if (d1 !== parseInt(cpf.charAt(9))) return false;
+  sum = 0;
+  for (let i = 0; i < 10; i++) sum += parseInt(cpf.charAt(i)) * (11 - i);
+  let d2 = (sum * 10) % 11;
+  if (d2 === 10) d2 = 0;
+  return d2 === parseInt(cpf.charAt(10));
+}
+
+function validateCNPJ(cnpj: string) {
+  if (/^(\d)\1+$/.test(cnpj)) return false;
+  const calc = (x: number) => {
+    let n = 0;
+    let y = x - 7;
+    for (let i = 0; i < x; i++) {
+      n += parseInt(cnpj.charAt(i)) * y--;
+      if (y < 2) y = 9;
+    }
+    const r = n % 11;
+    return r < 2 ? 0 : 11 - r;
+  };
+  const d1 = calc(12);
+  const d2 = calc(13);
+  return d1 === parseInt(cnpj.charAt(12)) && d2 === parseInt(cnpj.charAt(13));
+}
+
+export function isValidAddress(address: string) {
+  const len = address.trim().length;
+  return len >= 3 && len <= 200;
+}
+
+export function isValidResponsible(name: string) {
+  const len = name.trim().length;
+  return len >= 4 && len <= 80;
+}
+
+export function isValidCep(cep: string) {
+  return /^\d{8}$/.test(cep.replace(/\D/g, ""));
+}
+
+export function isValidPhone(phone: string) {
+  return /^\d{10,11}$/.test(phone.replace(/\D/g, ""));
+}

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -68,5 +68,5 @@ export function isValidCep(cep: string) {
 }
 
 export function isValidPhone(phone: string) {
-  return /^\d{10,11}$/.test(phone.replace(/\D/g, ""));
+  return /^\d{13}$/.test(phone.replace(/\D/g, ""));
 }


### PR DESCRIPTION
## Summary
- validate signup inputs both client and server side
- expand complete profile with CEP, phone and country select
- add shared validators

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688ee449e25c832f807436321ec4b384