### PR TITLE
feat: add password reset flow

### DIFF
--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { supabasebrowser } from '@/lib/supabaseClient';
+import { toast } from 'sonner';
+
+export default function ForgotPasswordPage() {
+  const [email, setEmail] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    const { error } = await supabasebrowser.auth.resetPasswordForEmail(email, {
+      redirectTo: `${window.location.origin}/update-password`,
+    });
+    if (error) {
+      toast.error('Erro ao enviar email: ' + error.message);
+    } else {
+      toast.success('Email de recuperação enviado');
+    }
+    setLoading(false);
+  };
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-gray-50 p-4">
+      <form
+        onSubmit={handleSubmit}
+        className="max-w-md w-full bg-white rounded-lg shadow p-6 space-y-4"
+      >
+        <h1 className="text-2xl font-semibold text-center">Recuperar senha</h1>
+
+        <div>
+          <label htmlFor="email" className="block text-sm font-medium">Email</label>
+          <Input
+            id="email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+        </div>
+
+        <Button type="submit" className="w-full" disabled={loading}>
+          {loading ? 'Enviando...' : 'Enviar link'}
+        </Button>
+
+        <p className="text-center text-sm">
+          Lembrou a senha?{' '}
+          <Link href="/login" className="text-teal-600 hover:underline">
+            Voltar ao login
+          </Link>
+        </p>
+      </form>
+    </div>
+  );
+}
+

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -81,6 +81,12 @@ export default function LoginPage() {
           />
         </div>
 
+        <div className="text-right">
+          <Link href="/forgot-password" className="text-sm text-teal-600 hover:underline">
+            Esqueci minha senha
+          </Link>
+        </div>
+
         <Button type="submit" className="w-full">
           Entrar                                     {/* ← não deixe vazio */}
         </Button>

--- a/src/app/update-password/page.tsx
+++ b/src/app/update-password/page.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { supabasebrowser } from '@/lib/supabaseClient';
+import { toast } from 'sonner';
+
+export default function UpdatePasswordPage() {
+  const router = useRouter();
+  const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (password !== confirm) {
+      toast.error('As senhas não coincidem');
+      return;
+    }
+    setLoading(true);
+    const { error } = await supabasebrowser.auth.updateUser({ password });
+    if (error) {
+      toast.error('Erro ao redefinir senha: ' + error.message);
+    } else {
+      toast.success('Senha atualizada');
+      router.push('/login');
+    }
+    setLoading(false);
+  };
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-gray-50 p-4">
+      <form
+        onSubmit={handleSubmit}
+        className="max-w-md w-full bg-white rounded-lg shadow p-6 space-y-4"
+      >
+        <h1 className="text-2xl font-semibold text-center">Nova senha</h1>
+
+        <div>
+          <label htmlFor="password" className="block text-sm font-medium">Senha</label>
+          <Input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+        </div>
+
+        <div>
+          <label htmlFor="confirm" className="block text-sm font-medium">Confirmar senha</label>
+          <Input
+            id="confirm"
+            type="password"
+            value={confirm}
+            onChange={(e) => setConfirm(e.target.value)}
+            required
+          />
+        </div>
+
+        <Button type="submit" className="w-full" disabled={loading}>
+          {loading ? 'Salvando...' : 'Salvar'}
+        </Button>
+      </form>
+    </div>
+  );
+}
+

--- a/src/app/update-password/page.tsx
+++ b/src/app/update-password/page.tsx
@@ -15,6 +15,13 @@ export default function UpdatePasswordPage() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    const strong = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).{8,}$/;
+    if (!strong.test(password)) {
+      toast.error(
+        'A senha deve ter pelo menos 8 caracteres e incluir letras maiúsculas, minúsculas e números'
+      );
+      return;
+    }
     if (password !== confirm) {
       toast.error('As senhas não coincidem');
       return;
@@ -46,6 +53,7 @@ export default function UpdatePasswordPage() {
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             required
+            minLength={8}
           />
         </div>
 
@@ -57,6 +65,7 @@ export default function UpdatePasswordPage() {
             value={confirm}
             onChange={(e) => setConfirm(e.target.value)}
             required
+            minLength={8}
           />
         </div>
 

--- a/src/app/update-password/page.tsx
+++ b/src/app/update-password/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { supabasebrowser } from '@/lib/supabaseClient';
@@ -9,6 +9,10 @@ import { toast } from 'sonner';
 
 export default function UpdatePasswordPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const errorDescription = searchParams.get('error_description');
+  const expiresAt = searchParams.get('expires_at');
+  const isExpired = expiresAt ? Date.now() > Number(expiresAt) * 1000 : false;
   const [password, setPassword] = useState('');
   const [confirm, setConfirm] = useState('');
   const [loading, setLoading] = useState(false);
@@ -31,11 +35,27 @@ export default function UpdatePasswordPage() {
     if (error) {
       toast.error('Erro ao redefinir senha: ' + error.message);
     } else {
+      await supabasebrowser.auth.signOut();
       toast.success('Senha atualizada');
       router.push('/login');
     }
     setLoading(false);
   };
+
+  if (errorDescription || isExpired) {
+    return (
+      <div className="fixed inset-0 flex items-center justify-center bg-gray-50 p-4">
+        <div className="max-w-md w-full bg-white rounded-lg shadow p-6 space-y-4 text-center">
+          <p className="text-lg font-medium">
+            {errorDescription || 'O link de recuperação expirou.'}
+          </p>
+          <Button onClick={() => router.push('/login')} className="w-full">
+            Voltar ao login
+          </Button>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-gray-50 p-4">


### PR DESCRIPTION
## Summary
- add link to password recovery on login
- enable requesting password reset email
- allow setting a new password after email link

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68900bce6188832fafaee5b19804fdca