### PR TITLE
feat: verify email on signup and settings

### DIFF
--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -39,7 +39,8 @@ export async function POST(req: Request) {
     email,
     password,
     user_metadata: { name },
-    email_confirm: true,
+    // Envia email de confirmação em vez de confirmar automaticamente
+    email_confirm: false,
   });
 
   if (error) {

--- a/src/app/dashboard/config/page.tsx
+++ b/src/app/dashboard/config/page.tsx
@@ -25,6 +25,7 @@ export default function ConfigPage() {
   const [userId, setUserId] = useState<string | null>(null);
   const [companyName, setCompanyName] = useState("");
   const [email, setEmail] = useState("");
+  const [initialEmail, setInitialEmail] = useState("");
   const [password, setPassword] = useState("");
   const [confirm, setConfirm] = useState("");
   const [cpfCnpj, setCpfCnpj] = useState("");
@@ -82,7 +83,9 @@ export default function ConfigPage() {
       }
       const uid = data.user.id;
       setUserId(uid);
-      setEmail(data.user.email || "");
+      const userEmail = data.user.email || "";
+      setEmail(userEmail);
+      setInitialEmail(userEmail);
       const { data: company } = await supabasebrowser
         .from("company")
         .select("company_name, company_profile_id")
@@ -167,6 +170,7 @@ export default function ConfigPage() {
       return;
     }
 
+    const emailChanged = email !== initialEmail;
     const { error: authError } = await supabasebrowser.auth.updateUser({
       email,
       password: password || undefined,
@@ -210,7 +214,11 @@ export default function ConfigPage() {
       return;
     }
 
+    if (emailChanged) {
+      toast.info("Verifique seu novo e-mail para confirmar a alteração");
+    }
     toast.success("Configurações salvas");
+    setInitialEmail(email);
     setPassword("");
     setConfirm("");
     setSaving(false);

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -55,6 +55,7 @@ export default function SignupPage() {
       if (!res.ok) {
         setError(data.error || "Falha no cadastro");
       } else {
+        toast.success("Verifique seu email para confirmar o cadastro");
         router.push("/login");
       }
     } catch {


### PR DESCRIPTION
## Summary
- require email confirmation during sign-up and notify user to check their inbox
- warn users to verify new email addresses when updated in settings

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689017da3cac832f9046639167b75097