### PR TITLE
Use session user for profile updates

### DIFF
--- a/src/app/complete-profile/page.tsx
+++ b/src/app/complete-profile/page.tsx
@@ -149,7 +149,6 @@ export default function CompleteProfilePage() {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        user_id: userId,
         cpf_cnpj: cpfCnpj,
         address,
         zip_code: zipCode,

--- a/src/app/dashboard/config/page.tsx
+++ b/src/app/dashboard/config/page.tsx
@@ -196,7 +196,6 @@ export default function ConfigPage() {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        user_id: userId,
         cpf_cnpj: cpfCnpj,
         address,
         zip_code: zipCode,


### PR DESCRIPTION
## Summary
- use Supabase session inside profile API route
- remove `user_id` from profile update requests

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68901f64268c832fbaa1230d28c3f90d