### PR TITLE
Secure support ticket creation with session and company validation

### DIFF
--- a/src/app/api/support/new/route.ts
+++ b/src/app/api/support/new/route.ts
@@ -1,16 +1,55 @@
 // src/app/api/support/new/route.ts
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { cookies } from "next/headers";
 import { supabaseadmin } from "@/lib/supabaseAdmin";
 
-export async function POST(req: Request) {
-  const { title, reason, description, attachmentPath, company_id } = await req.json();
+export async function POST(req: NextRequest) {
+  const supabase = createRouteHandlerClient({ cookies });
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
 
-  // monta a URL pública do anexo, se houver
+  if (authError || !user) {
+    return NextResponse.json({ error: "Não autenticado" }, { status: 401 });
+  }
+
+  const {
+    data: company,
+    error: companyError,
+  } = await supabase
+    .from("company")
+    .select("id")
+    .eq("user_id", user.id)
+    .single();
+
+  if (companyError || !company) {
+    return NextResponse.json(
+      { error: companyError?.message || "Empresa não encontrada" },
+      { status: 403 }
+    );
+  }
+
+  const {
+    title,
+    reason,
+    description,
+    attachmentPath,
+    company_id: requestedCompanyId,
+  } = await req.json();
+
+  if (requestedCompanyId && requestedCompanyId !== company.id) {
+    return NextResponse.json(
+      { error: "Empresa inválida" },
+      { status: 403 }
+    );
+  }
+
   const attachment_url = attachmentPath
     ? `${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/ticket-attachments/${attachmentPath}`
     : null;
 
-  // faz o insert usando service role (ignora RLS)
   const { error } = await supabaseadmin
     .from("tickets")
     .insert([
@@ -19,7 +58,7 @@ export async function POST(req: Request) {
         reason,
         description,
         attachment_url,
-        company_id: company_id,
+        company_id: company.id,
       },
     ]);
 


### PR DESCRIPTION
## Summary
- validate user session for new support ticket API route
- look up company id for authenticated user and enforce match
- reject unauthorized or cross-company requests when creating tickets

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68901f6a8ce0832fbb78ebc37d9dc0a6