### PR TITLE
refactor: hide detailed errors from clients

### DIFF
--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -44,7 +44,8 @@ export async function POST(req: Request) {
   });
 
   if (error) {
-    return NextResponse.json({ error: error.message }, { status: 409 });
+    console.error('Erro ao criar usuário:', error.message);
+    return NextResponse.json({ error: 'Erro ao criar usuário' }, { status: 409 });
   }
 
   const userId = data.user.id;
@@ -53,7 +54,8 @@ export async function POST(req: Request) {
     .from('company')
     .insert({ user_id: userId, company_name: name, profile_complete: false });
   if (bizError) {
-    return NextResponse.json({ error: bizError.message }, { status: 500 });
+    console.error('Erro ao criar company:', bizError.message);
+    return NextResponse.json({ error: 'Erro ao criar company' }, { status: 500 });
   }
 
   return NextResponse.json({ user: data.user }, { status: 201 });

--- a/src/app/api/support/new/route.ts
+++ b/src/app/api/support/new/route.ts
@@ -24,8 +24,9 @@ export async function POST(req: Request) {
     ]);
 
   if (error) {
+    console.error('Erro ao criar ticket:', error.message);
     return NextResponse.json(
-      { error: error.message },
+      { error: 'Erro ao criar ticket' },
       { status: 500 }
     );
   }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -51,7 +51,8 @@ export default function DashboardPage() {
       .single()          // pega apenas um registro
       .then(({ data, error }) => {
         if (error) {
-          toast.error('Erro ao buscar company: ' + error.message);
+          console.error('Erro ao buscar company:', error.message);
+          toast.error('Erro ao buscar company.');
         } else {
           setCompany(data);
         }

--- a/src/app/dashboard/payments/[id]/page.tsx
+++ b/src/app/dashboard/payments/[id]/page.tsx
@@ -98,8 +98,8 @@ export default function PaymentPage() {
             const { asaas } = await res.json();
             setPaymentLink(asaas.invoiceUrl || asaas.paymentLink);
         } catch (err: unknown) {
-            const message = err instanceof Error ? err.message : "Falha ao gerar link";
-            toast.error(message);
+            console.error('Erro ao gerar link de pagamento:', err);
+            toast.error('Erro ao gerar link de pagamento. Tente novamente mais tarde.');
         }
     };
 

--- a/src/app/dashboard/support/new/page.tsx
+++ b/src/app/dashboard/support/new/page.tsx
@@ -55,7 +55,8 @@ export default function NewSupportPage() {
             .single()          // pega apenas um registro
             .then(({ data, error }) => {
                 if (error) {
-                    toast.error('Erro ao buscar company: ' + error.message);
+                    console.error('Erro ao buscar company:', error.message);
+                    toast.error('Erro ao buscar company.');
                 } else {
                     setCompany(data);
                 }

--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -18,7 +18,8 @@ export default function ForgotPasswordPage() {
       redirectTo: `${window.location.origin}/update-password`,
     });
     if (error) {
-      toast.error('Erro ao enviar email: ' + error.message);
+      console.error('Erro ao enviar email:', error.message);
+      toast.error('Erro ao enviar email. Tente novamente mais tarde.');
     } else {
       toast.success('Email de recuperação enviado');
     }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -39,7 +39,8 @@ export default function LoginPage() {
     e.preventDefault();
     const { data, error } = await supabasebrowser.auth.signInWithPassword({ email, password });
     if (error) {
-      toast.error('Falha no login: ' + error.message);
+      console.error('Falha no login:', error.message);
+      toast.error('Falha no login. Tente novamente mais tarde.');
     } else {
       const { data: company } = await supabasebrowser
         .from('company')

--- a/src/app/update-password/update-password-form.tsx
+++ b/src/app/update-password/update-password-form.tsx
@@ -33,7 +33,8 @@ export default function UpdatePasswordForm() {
     setLoading(true);
     const { error } = await supabasebrowser.auth.updateUser({ password });
     if (error) {
-      toast.error('Erro ao redefinir senha: ' + error.message);
+      console.error('Erro ao redefinir senha:', error.message);
+      toast.error('Erro ao redefinir senha. Tente novamente mais tarde.');
     } else {
       await supabasebrowser.auth.signOut();
       toast.success('Senha atualizada');


### PR DESCRIPTION
## Summary
- avoid exposing internal error messages to end users across UI and API handlers
- log detailed errors internally for diagnosis

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68901f8db750832fb988b9bd4a2399a9