### PR TITLE
Add Supabase session authorization to payment link generation

### DIFF
--- a/src/app/dashboard/payments/[id]/page.tsx
+++ b/src/app/dashboard/payments/[id]/page.tsx
@@ -89,9 +89,18 @@ export default function PaymentPage() {
         if (isGenerating || paymentLink) return;
         setIsGenerating(true);
         try {
+            const {
+                data: { session },
+                error: sessionError,
+            } = await supabasebrowser.auth.getSession();
+            if (sessionError || !session) throw new Error("Sessão não encontrada");
+
             const res = await fetch("/api/payments/pay", {
                 method: "POST",
-                headers: { "Content-Type": "application/json" },
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: `Bearer ${session.access_token}`,
+                },
                 body: JSON.stringify({ id, date, total }),
             });
             if (!res.ok) throw await res.text();


### PR DESCRIPTION
## Summary
- retrieve Supabase session before generating payment link
- send Authorization header with access token when calling payment API

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68902648cd54832fbd1c6b5c0ed75cd9