### PR TITLE
refactor: streamline company profile access

### DIFF
--- a/src/app/api/payments/pay/route.ts
+++ b/src/app/api/payments/pay/route.ts
@@ -82,7 +82,7 @@ export async function POST(request: Request) {
     );
   }
 
-  const { company_name, company_profile } = company as {
+  const { company_name, company_profile } = company as unknown as {
     company_name: string | null;
     company_profile: {
       cpf_cnpj: string;

--- a/src/app/api/payments/pay/route.ts
+++ b/src/app/api/payments/pay/route.ts
@@ -88,20 +88,18 @@ export async function POST(request: Request) {
       cpf_cnpj: string;
       responsible_name: string;
       phone: string;
-    }[];
+    };
   };
-
-  const profile = company_profile?.[0];
-  if (!profile) {
+  if (!company_profile) {
     return NextResponse.json(
       { error: 'Company profile not found' },
       { status: 400 }
     );
   }
 
-  const cpfCnpj = profile.cpf_cnpj;
-  const phone = profile.phone;
-  const name = company_name || profile.responsible_name;
+  const cpfCnpj = company_profile.cpf_cnpj;
+  const phone = company_profile.phone;
+  const name = company_name || company_profile.responsible_name;
   const email = userData.user.email;
 
   let customerId: string | null = null;


### PR DESCRIPTION
## Summary
- access company profile directly instead of through an array

## Testing
- `npm run lint`
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68902d2f7d20832fbfc698ef59b4e888