### PR TITLE
feat: add landing page with hero features and pricing

### DIFF
--- a/components/landing/Features.tsx
+++ b/components/landing/Features.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Bot, MessageSquare, Users, LayoutKanban } from "lucide-react";
+
+const features = [
+  {
+    title: "Agente de IA",
+    description: "Automatize respostas e agilize atendimentos com inteligência artificial.",
+    icon: Bot,
+  },
+  {
+    title: "Atendimento multicanal",
+    description: "Conecte-se com clientes por e-mail, chat e redes sociais em um só lugar.",
+    icon: MessageSquare,
+  },
+  {
+    title: "CRM",
+    description: "Gerencie contatos e oportunidades com uma visão completa do cliente.",
+    icon: Users,
+  },
+  {
+    title: "Kanban",
+    description: "Organize tarefas e fluxos de trabalho com quadros visuais intuitivos.",
+    icon: LayoutKanban,
+  },
+];
+
+export default function Features() {
+  return (
+    <section className="bg-white py-24" id="features">
+      <div className="container mx-auto max-w-6xl px-4">
+        <h2 className="mb-12 text-center text-3xl font-bold">Recursos principais</h2>
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+          {features.map(({ title, description, icon: Icon }) => (
+            <Card key={title} className="h-full">
+              <CardHeader>
+                <Icon className="mb-2 h-8 w-8 text-primary" />
+                <CardTitle>{title}</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm text-muted-foreground">{description}</p>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/landing/Features.tsx
+++ b/components/landing/Features.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
-import { Bot, MessageSquare, Users, LayoutKanban } from "lucide-react";
+import { Bot, MessageSquare, Users, Kanban } from "lucide-react";
 
 const features = [
   {
@@ -22,7 +22,7 @@ const features = [
   {
     title: "Kanban",
     description: "Organize tarefas e fluxos de trabalho com quadros visuais intuitivos.",
-    icon: LayoutKanban,
+    icon: Kanban,
   },
 ];
 

--- a/components/landing/Footer.tsx
+++ b/components/landing/Footer.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import Link from "next/link";
+
+export default function Footer() {
+  return (
+    <footer className="bg-gray-100 py-8">
+      <div className="container mx-auto flex flex-col items-center gap-4 px-4 text-center text-sm text-muted-foreground">
+        <div className="flex gap-6">
+          <Link href="/login" className="hover:text-primary">
+            Login
+          </Link>
+          <Link href="/signup" className="hover:text-primary">
+            Cadastrar
+          </Link>
+          <Link href="#pricing" className="hover:text-primary">
+            Planos
+          </Link>
+        </div>
+        <p>© {new Date().getFullYear()} Evoluke. Todos os direitos reservados.</p>
+        <p>contato@evoluke.com</p>
+      </div>
+    </footer>
+  );
+}

--- a/components/landing/Hero.tsx
+++ b/components/landing/Hero.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+export default function Hero() {
+  return (
+    <section className="bg-gradient-to-b from-white to-gray-50 py-24 text-center">
+      <div className="container mx-auto flex max-w-5xl flex-col items-center gap-6 px-4">
+        <h1 className="text-4xl font-bold sm:text-5xl">
+          Atendimento eficiente com IA
+        </h1>
+        <p className="max-w-2xl text-lg text-muted-foreground">
+          Centralize conversas, gerencie clientes e otimize processos com
+          ferramentas inteligentes.
+        </p>
+        <div className="flex flex-col gap-4 sm:flex-row">
+          <Link href="/signup">
+            <Button size="lg">Começar agora</Button>
+          </Link>
+          <Link href="#pricing">
+            <Button variant="outline" size="lg">
+              Conhecer planos
+            </Button>
+          </Link>
+        </div>
+        <Link
+          href="/login"
+          className="text-sm text-primary underline-offset-4 hover:underline"
+        >
+          Já possui conta? Entre
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/components/landing/Pricing.tsx
+++ b/components/landing/Pricing.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+  CardFooter,
+} from "@/components/ui/card";
+
+const plans = [
+  {
+    name: "Básico",
+    price: "Grátis",
+    features: ["Agente de IA", "Atendimento multicanal"],
+  },
+  {
+    name: "Pro",
+    price: "R$49/mês",
+    features: ["Todos os recursos do Básico", "CRM completo", "Kanban"],
+  },
+  {
+    name: "Enterprise",
+    price: "Sob consulta",
+    features: ["Todos do Pro", "Suporte dedicado", "Recursos avançados"],
+  },
+];
+
+export default function Pricing() {
+  return (
+    <section id="pricing" className="bg-gray-50 py-24">
+      <div className="container mx-auto max-w-6xl px-4">
+        <h2 className="mb-12 text-center text-3xl font-bold">Planos</h2>
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {plans.map(({ name, price, features }) => (
+            <Card key={name} className="flex flex-col">
+              <CardHeader>
+                <CardTitle className="text-2xl">{name}</CardTitle>
+              </CardHeader>
+              <CardContent className="flex-grow">
+                <p className="mb-4 text-3xl font-bold">{price}</p>
+                <ul className="space-y-2 text-sm">
+                  {features.map((feature) => (
+                    <li key={feature} className="flex items-start gap-2">
+                      <span>•</span>
+                      <span>{feature}</span>
+                    </li>
+                  ))}
+                </ul>
+              </CardContent>
+              <CardFooter>
+                <Link href="/signup" className="w-full">
+                  <Button className="w-full">Assinar</Button>
+                </Link>
+              </CardFooter>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,14 +1,9 @@
-// src/app/page.tsx
-import Hero from "@/components/landing/Hero";
-import Features from "@/components/landing/Features";
 import Pricing from "@/components/landing/Pricing";
 import Footer from "@/components/landing/Footer";
 
-export default function HomePage() {
+export default function PricingPage() {
   return (
     <main className="flex flex-col">
-      <Hero />
-      <Features />
       <Pricing />
       <Footer />
     </main>


### PR DESCRIPTION
## Summary
- replace home page with modular landing sections
- showcase IA, multichannel, CRM, and kanban features
- add pricing plans page with CTA buttons

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6890edbac184832fbe9f9ef8eebced7d