### PR TITLE
fix: remove country code from phone

### DIFF
--- a/src/app/api/payments/client/route.ts
+++ b/src/app/api/payments/client/route.ts
@@ -111,7 +111,9 @@ export async function POST(request: Request) {
 
   const cleanName = name.trim();
   const cleanCpf = cpfCnpj.replace(/\D/g, '');
-  const cleanPhone = phone ? phone.replace(/\D/g, '') : undefined;
+  const cleanPhone = phone
+    ? phone.replace(/\D/g, '').replace(/^55/, '')
+    : undefined;
   const cleanEmail = email?.trim();
 
   if (!isValidResponsible(cleanName)) {

--- a/src/app/api/payments/pay/route.ts
+++ b/src/app/api/payments/pay/route.ts
@@ -98,7 +98,7 @@ export async function POST(request: Request) {
   }
 
   const cpfCnpj = company_profile.cpf_cnpj;
-  const phone = company_profile.phone;
+  const phone = company_profile.phone.replace(/^55/, '');
   const name = company_name || company_profile.responsible_name;
   const email = userData.user.email;
 

--- a/src/app/api/profile/complete/route.ts
+++ b/src/app/api/profile/complete/route.ts
@@ -48,7 +48,7 @@ export async function POST(req: Request) {
 
   const cleanCpfCnpj = cpf_cnpj.replace(/\D/g, "");
   const cleanZip = zip_code.replace(/\D/g, "");
-  const cleanPhone = phone.replace(/\D/g, "");
+  const cleanPhone = phone.replace(/\D/g, "").replace(/^55/, "");
 
   if (!isValidCpfCnpj(cleanCpfCnpj)) {
     return NextResponse.json({ error: "CPF/CNPJ inválido" }, { status: 400 });

--- a/src/app/complete-profile/page.tsx
+++ b/src/app/complete-profile/page.tsx
@@ -48,13 +48,11 @@ export default function CompleteProfilePage() {
 
   const handlePhoneChange = (value: string) => {
     let digits = value.replace(/\D/g, "");
-    if (digits.length > 13) digits = digits.slice(0, 13);
-    let formatted = "";
-    if (digits.length > 0) formatted += "+" + digits.slice(0, 2);
-    if (digits.length >= 3) formatted += " (" + digits.slice(2, 4) + ")";
-    if (digits.length >= 5) formatted += " " + digits.slice(4, 9);
-    if (digits.length >= 10) formatted += "-" + digits.slice(9, 13);
-    setPhone(formatted);
+    if (digits.startsWith("55")) digits = digits.slice(2);
+    if (digits.length > 11) digits = digits.slice(0, 11);
+    digits = digits.replace(/^(\d{2})(\d)/, "($1) $2");
+    digits = digits.replace(/(\d{5})(\d)/, "$1-$2");
+    setPhone(digits);
   };
 
   const handleZipChange = (value: string) => {

--- a/src/app/dashboard/config/page.tsx
+++ b/src/app/dashboard/config/page.tsx
@@ -57,13 +57,11 @@ export default function ConfigPage() {
 
   const handlePhoneChange = (value: string) => {
     let digits = value.replace(/\D/g, "");
-    if (digits.length > 13) digits = digits.slice(0, 13);
-    let formatted = "";
-    if (digits.length > 0) formatted += "+" + digits.slice(0, 2);
-    if (digits.length >= 3) formatted += " (" + digits.slice(2, 4) + ")";
-    if (digits.length >= 5) formatted += " " + digits.slice(4, 9);
-    if (digits.length >= 10) formatted += "-" + digits.slice(9, 13);
-    setPhone(formatted);
+    if (digits.startsWith("55")) digits = digits.slice(2);
+    if (digits.length > 11) digits = digits.slice(0, 11);
+    digits = digits.replace(/^(\d{2})(\d)/, "($1) $2");
+    digits = digits.replace(/(\d{5})(\d)/, "$1-$2");
+    setPhone(digits);
   };
 
   const handleZipChange = (value: string) => {

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -68,5 +68,5 @@ export function isValidCep(cep: string) {
 }
 
 export function isValidPhone(phone: string) {
-  return /^\d{13}$/.test(phone.replace(/\D/g, ""));
+  return /^\d{10,11}$/.test(phone.replace(/\D/g, ""));
 }


### PR DESCRIPTION
## Summary
- remove country code prefix when storing phone
- validate phone numbers with 10-11 digits
- format phone inputs without +55

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890ef79acf8832fa374ab89c41cd87d