### PR TITLE
feat: add agent management

### DIFF
--- a/migration.sql
+++ b/migration.sql
@@ -45,4 +45,18 @@ create table public.payments (
   constraint payments_company_id_fkey foreign KEY (company_id) references company (id)
 ) TABLESPACE pg_default;
 
+-- Enum e tabela de agentes de IA
+create type public.agent_type as enum ('agendamento', 'sdr', 'suporte');
+
+create table public.agents (
+  id uuid not null default gen_random_uuid (),
+  name text not null,
+  type public.agent_type not null,
+  is_active boolean not null default false,
+  created_at timestamp with time zone not null default now(),
+  company_id bigint not null,
+  constraint agents_pkey primary key (id),
+  constraint agents_company_id_fkey foreign key (company_id) references company (id)
+) TABLESPACE pg_default;
+
 

--- a/src/app/api/agents/[id]/route.ts
+++ b/src/app/api/agents/[id]/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import { cookies } from "next/headers";
-import type { RouteContext } from "next";
 import { supabaseadmin } from "@/lib/supabaseAdmin";
 
 const allowedTypes = ["agendamento", "sdr", "suporte"] as const;
@@ -9,7 +8,7 @@ type AgentType = (typeof allowedTypes)[number];
 
 export async function GET(
   _req: NextRequest,
-  { params }: RouteContext<{ id: string }>
+  { params }: { params: { id: string } }
 ) {
   const supabase = createRouteHandlerClient({ cookies });
   const {
@@ -50,7 +49,7 @@ export async function GET(
 
 export async function PUT(
   req: NextRequest,
-  { params }: RouteContext<{ id: string }>
+  { params }: { params: { id: string } }
 ) {
   const supabase = createRouteHandlerClient({ cookies });
   const {

--- a/src/app/api/agents/[id]/route.ts
+++ b/src/app/api/agents/[id]/route.ts
@@ -1,0 +1,107 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { cookies } from "next/headers";
+import { supabaseadmin } from "@/lib/supabaseAdmin";
+
+const allowedTypes = ["agendamento", "sdr", "suporte"] as const;
+type AgentType = (typeof allowedTypes)[number];
+
+export async function GET(_req: NextRequest, { params }: { params: { id: string } }) {
+  const supabase = createRouteHandlerClient({ cookies });
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return NextResponse.json({ error: "Não autenticado" }, { status: 401 });
+  }
+
+  const { data: company, error: companyError } = await supabase
+    .from("company")
+    .select("id")
+    .eq("user_id", user.id)
+    .single();
+
+  if (companyError || !company) {
+    return NextResponse.json(
+      { error: companyError?.message || "Empresa não encontrada" },
+      { status: 403 }
+    );
+  }
+
+  const { data: agent, error } = await supabaseadmin
+    .from("agents")
+    .select("id, name, type, is_active")
+    .eq("id", params.id)
+    .eq("company_id", company.id)
+    .single();
+
+  if (error || !agent) {
+    return NextResponse.json({ error: "Agente não encontrado" }, { status: 404 });
+  }
+
+  return NextResponse.json(agent, { status: 200 });
+}
+
+export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
+  const supabase = createRouteHandlerClient({ cookies });
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return NextResponse.json({ error: "Não autenticado" }, { status: 401 });
+  }
+
+  const { data: company, error: companyError } = await supabase
+    .from("company")
+    .select("id")
+    .eq("user_id", user.id)
+    .single();
+
+  if (companyError || !company) {
+    return NextResponse.json(
+      { error: companyError?.message || "Empresa não encontrada" },
+      { status: 403 }
+    );
+  }
+
+  const { name, type, is_active }: { name?: string; type?: AgentType; is_active?: boolean } = await req.json();
+
+  if (
+    name !== undefined &&
+    (typeof name !== "string" || name.trim().length < 3 || name.trim().length > 80)
+  ) {
+    return NextResponse.json(
+      { error: "Nome do agente deve ter entre 3 e 80 caracteres" },
+      { status: 400 }
+    );
+  }
+
+  if (type !== undefined && !allowedTypes.includes(type)) {
+    return NextResponse.json(
+      { error: "Tipo de agente inválido" },
+      { status: 400 }
+    );
+  }
+
+  const updates: Partial<{ name: string; type: AgentType; is_active: boolean }> = {};
+  if (name !== undefined) updates.name = name.replace(/<[^>]*>?/gm, "").trim();
+  if (type !== undefined) updates.type = type;
+  if (is_active !== undefined) updates.is_active = is_active;
+
+  const { error } = await supabaseadmin
+    .from("agents")
+    .update(updates)
+    .eq("id", params.id)
+    .eq("company_id", company.id);
+
+  if (error) {
+    console.error("Erro ao atualizar agente:", error.message);
+    return NextResponse.json({ error: "Erro ao atualizar agente" }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true }, { status: 200 });
+}

--- a/src/app/api/agents/[id]/route.ts
+++ b/src/app/api/agents/[id]/route.ts
@@ -6,7 +6,11 @@ import { supabaseadmin } from "@/lib/supabaseAdmin";
 const allowedTypes = ["agendamento", "sdr", "suporte"] as const;
 type AgentType = (typeof allowedTypes)[number];
 
-export async function GET(_req: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(
+  _req: NextRequest,
+  context: { params: { id: string } }
+) {
+  const { params } = context;
   const supabase = createRouteHandlerClient({ cookies });
   const {
     data: { user },
@@ -44,7 +48,11 @@ export async function GET(_req: NextRequest, { params }: { params: { id: string 
   return NextResponse.json(agent, { status: 200 });
 }
 
-export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
+export async function PUT(
+  req: NextRequest,
+  context: { params: { id: string } }
+) {
+  const { params } = context;
   const supabase = createRouteHandlerClient({ cookies });
   const {
     data: { user },

--- a/src/app/api/agents/[id]/route.ts
+++ b/src/app/api/agents/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import { cookies } from "next/headers";
+import type { RouteContext } from "next";
 import { supabaseadmin } from "@/lib/supabaseAdmin";
 
 const allowedTypes = ["agendamento", "sdr", "suporte"] as const;
@@ -8,9 +9,8 @@ type AgentType = (typeof allowedTypes)[number];
 
 export async function GET(
   _req: NextRequest,
-  context: { params: { id: string } }
+  { params }: RouteContext<{ id: string }>
 ) {
-  const { params } = context;
   const supabase = createRouteHandlerClient({ cookies });
   const {
     data: { user },
@@ -50,9 +50,8 @@ export async function GET(
 
 export async function PUT(
   req: NextRequest,
-  context: { params: { id: string } }
+  { params }: RouteContext<{ id: string }>
 ) {
-  const { params } = context;
   const supabase = createRouteHandlerClient({ cookies });
   const {
     data: { user },

--- a/src/app/api/agents/new/route.ts
+++ b/src/app/api/agents/new/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { cookies } from "next/headers";
+import { supabaseadmin } from "@/lib/supabaseAdmin";
+
+const allowedTypes = ["agendamento", "sdr", "suporte"] as const;
+
+type AgentType = (typeof allowedTypes)[number];
+
+export async function POST(req: NextRequest) {
+  const supabase = createRouteHandlerClient({ cookies });
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return NextResponse.json({ error: "Não autenticado" }, { status: 401 });
+  }
+
+  const { data: company, error: companyError } = await supabase
+    .from("company")
+    .select("id")
+    .eq("user_id", user.id)
+    .single();
+
+  if (companyError || !company) {
+    return NextResponse.json(
+      { error: companyError?.message || "Empresa não encontrada" },
+      { status: 403 }
+    );
+  }
+
+  const { name, type, company_id: requestedCompanyId }: { name?: string; type?: AgentType; company_id?: number } = await req.json();
+
+  if (!name || typeof name !== "string" || name.trim().length < 3 || name.trim().length > 80) {
+    return NextResponse.json(
+      { error: "Nome do agente deve ter entre 3 e 80 caracteres" },
+      { status: 400 }
+    );
+  }
+
+  if (!type || !allowedTypes.includes(type)) {
+    return NextResponse.json(
+      { error: "Tipo de agente inválido" },
+      { status: 400 }
+    );
+  }
+
+  if (requestedCompanyId && requestedCompanyId !== company.id) {
+    return NextResponse.json({ error: "Empresa inválida" }, { status: 403 });
+  }
+
+  const sanitizedName = name.replace(/<[^>]*>?/gm, "").trim();
+
+  const { data, error } = await supabaseadmin
+    .from("agents")
+    .insert([
+      {
+        name: sanitizedName,
+        type,
+        company_id: company.id,
+        is_active: false,
+      },
+    ])
+    .select("id")
+    .single();
+
+  if (error) {
+    console.error("Erro ao criar agente:", error.message);
+    return NextResponse.json({ error: "Erro ao criar agente" }, { status: 500 });
+  }
+
+  return NextResponse.json({ id: data.id }, { status: 201 });
+}

--- a/src/app/dashboard/agents/[id]/page.tsx
+++ b/src/app/dashboard/agents/[id]/page.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { CardTitle } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { toast } from "sonner";
+
+const agentTypes = [
+  { value: "agendamento", label: "Agendamento: Automação de agendamentos com usuários." },
+  { value: "sdr", label: "SDR: Prospecção e qualificação de leads." },
+  { value: "suporte", label: "Suporte: Atendimento automatizado ao cliente." },
+];
+
+interface Agent {
+  id: string;
+  name: string;
+  type: string;
+  is_active: boolean;
+}
+
+export default function EditAgentPage() {
+  const { id } = useParams<{ id: string }>();
+  const router = useRouter();
+  const [agent, setAgent] = useState<Agent | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchAgent = async () => {
+      const res = await fetch(`/api/agents/${id}`);
+      if (!res.ok) {
+        toast.error("Agente não encontrado");
+        router.push("/dashboard/agents/new");
+        return;
+      }
+      const data = await res.json();
+      setAgent(data);
+      setLoading(false);
+    };
+    fetchAgent();
+  }, [id, router]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!agent) return;
+    if (agent.name.trim().length < 3 || agent.name.trim().length > 80) {
+      toast.error("Nome deve ter entre 3 e 80 caracteres");
+      return;
+    }
+    const res = await fetch(`/api/agents/${id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(agent),
+    });
+    if (!res.ok) {
+      const err = await res.json();
+      toast.error(err.error || "Erro ao atualizar agente");
+    } else {
+      toast.success("Agente atualizado!");
+    }
+  };
+
+  if (loading || !agent) return <p className="text-center py-10">Carregando...</p>;
+
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-gray-50 p-4">
+      <div className="h-full w-full max-w-lg">
+        <form
+          onSubmit={handleSubmit}
+          className="w-full max-w-md bg-white p-6 rounded-lg shadow"
+        >
+          <CardTitle className="text-xl font-semibold text-gray-800 mb-6">
+            Editar agente de IA
+          </CardTitle>
+
+          <label className="block mb-1">Função do Agente</label>
+          <Select
+            onValueChange={(v) => setAgent({ ...agent, type: v })}
+            value={agent.type}
+          >
+            <SelectTrigger className="w-full mb-4">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {agentTypes.map((t) => (
+                <SelectItem key={t.value} value={t.value}>
+                  {t.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          <label className="block mb-1">Nome do Agente</label>
+          <Input
+            value={agent.name}
+            onChange={(e) => setAgent({ ...agent, name: e.target.value })}
+            required
+            minLength={3}
+            maxLength={80}
+            className="mb-2"
+          />
+          <p className="text-sm text-gray-500 mb-4">
+            Escolha um nome interno para seu agente de IA
+          </p>
+
+          <label className="flex items-center space-x-2 mb-4">
+            <input
+              type="checkbox"
+              checked={agent.is_active}
+              onChange={(e) => setAgent({ ...agent, is_active: e.target.checked })}
+            />
+            <span>Ativo</span>
+          </label>
+
+          <Button type="submit" className="w-full">
+            Salvar alterações
+          </Button>
+        </form>
+      </div>
+    </main>
+  );
+}

--- a/src/app/dashboard/agents/new/page.tsx
+++ b/src/app/dashboard/agents/new/page.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { CardTitle } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { User } from "@supabase/supabase-js";
+import { supabasebrowser } from "@/lib/supabaseClient";
+import { toast } from "sonner";
+import { useRouter } from "next/navigation";
+
+interface Company {
+  id: number;
+}
+
+const agentTypes = [
+  { value: "agendamento", label: "Agendamento: Automação de agendamentos com usuários." },
+  { value: "sdr", label: "SDR: Prospecção e qualificação de leads." },
+  { value: "suporte", label: "Suporte: Atendimento automatizado ao cliente." },
+];
+
+export default function NewAgentPage() {
+  const [type, setType] = useState<string | undefined>(undefined);
+  const [name, setName] = useState("");
+  const [user, setUser] = useState<User | null>(null);
+  const [company, setCompany] = useState<Company | null>(null);
+  const router = useRouter();
+
+  useEffect(() => {
+    supabasebrowser.auth.getUser().then(({ data }) => {
+      if (data.user) setUser(data.user);
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!user?.id) return;
+    supabasebrowser
+      .from("company")
+      .select("id")
+      .eq("user_id", user.id)
+      .single()
+      .then(({ data }) => {
+        if (data) setCompany(data);
+      });
+  }, [user]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!type) {
+      toast.error("Selecione a função do agente");
+      return;
+    }
+    if (!company) {
+      toast.error("Empresa não encontrada");
+      return;
+    }
+    if (name.trim().length < 3 || name.trim().length > 80) {
+      toast.error("Nome deve ter entre 3 e 80 caracteres");
+      return;
+    }
+
+    const res = await fetch("/api/agents/new", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name, type, company_id: company.id }),
+    });
+
+    if (!res.ok) {
+      const err = await res.json();
+      toast.error(err.error || "Erro ao criar agente");
+    } else {
+      const { id } = await res.json();
+      toast.success("Agente criado!");
+      router.push(`/dashboard/agents/${id}`);
+    }
+  };
+
+  if (!user) return <p className="text-center py-10">Carregando...</p>;
+
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-gray-50 p-4">
+      <div className="h-full w-full max-w-lg">
+        <form
+          onSubmit={handleSubmit}
+          className="w-full max-w-md bg-white p-6 rounded-lg shadow"
+        >
+          <CardTitle className="text-xl font-semibold text-gray-800 mb-6">
+            Criar novo agente de IA
+          </CardTitle>
+
+          <label className="block mb-1">Função do Agente</label>
+          <Select onValueChange={setType} value={type}>
+            <SelectTrigger className="w-full mb-4">
+              <SelectValue placeholder="Selecione a função" />
+            </SelectTrigger>
+            <SelectContent>
+              {agentTypes.map((t) => (
+                <SelectItem key={t.value} value={t.value}>
+                  {t.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          <label className="block mb-1">Nome do Agente</label>
+          <Input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Ex: Evoluke SDR"
+            required
+            minLength={3}
+            maxLength={80}
+            className="mb-2"
+          />
+          <p className="text-sm text-gray-500 mb-4">
+            Escolha um nome interno para seu agente de IA
+          </p>
+
+          <Button type="submit" className="w-full">
+            Criar Agente de IA
+          </Button>
+        </form>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add API route for fetching and updating agents
- add dashboard page for editing agents by id
- remove unused agents index page
- add API route for creating new agents
- add dashboard page for creating new agents
- show company agents in sidebar with link to create new

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890fc2ba2ac832f9d8ced6205f98a70