### PR TITLE
docs: add branding guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Branding
+
+Refer to the [branding guide](docs/BRANDING.md) for the color palette, typography, spacing and logo usage.
+
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/docs/BRANDING.md
+++ b/docs/BRANDING.md
@@ -1,0 +1,28 @@
+# Guia de Branding
+
+Este documento descreve os princípios básicos de identidade visual do projeto.
+
+## Paleta de cores
+Utilizamos variáveis CSS para garantir consistência. Valores atuais:
+
+| Variável | Valor | Uso sugerido |
+|---------|-------|--------------|
+| `--background` | `#FAFAFA` | Fundo padrão em temas claros |
+| `--foreground` | `oklch(0.145 0 0)` | Cor de texto principal |
+| `--primary` | `#1565FF` | Ações primárias e elementos de destaque |
+| `--primary-hover` | `#0E4DE0` | Estado _hover_ de ações primárias |
+| `--secondary` | `#E5E7EB` | Elementos neutros e secundários |
+| `--accent` | `#FF6B00` | Chamadas de atenção específicas |
+
+## Tipografia
+A família tipográfica oficial é **Geist**, nas variantes Sans e Mono. Utilize Geist Sans para textos e Geist Mono para trechos de código ou números alinhados.
+
+## Espaçamentos
+A unidade base de espaçamento segue o padrão do Tailwind CSS (4 px). Organize margens e paddings em múltiplos desta unidade: 4, 8, 12, 16, 24 px etc.
+
+## Uso de logotipos
+- O logotipo principal está disponível em `public/logo.svg`.
+- Mantenha uma margem de segurança ao redor do logotipo equivalente a 1× a altura do símbolo.
+- Utilize a versão em `#1565FF` sobre fundos claros e a versão branca sobre fundos escuros.
+- Não distorça, rotacione ou altere as cores oficiais.
+


### PR DESCRIPTION
## Summary
- add branding guide detailing palette, typography, spacing, and logo usage
- link branding guide in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6891233fb8b8832f8bf7de24de9035d9