### PR TITLE
feat: use stored payment link before creating new charge

### DIFF
--- a/migration.sql
+++ b/migration.sql
@@ -41,6 +41,8 @@ create table public.payments (
   paid_in timestamp with time zone null,
   due_date timestamp with time zone not null,
   reference text not null default '-'::text,
+  asaas_id text null,
+  payment_link text null,
   constraint payments_pkey primary key (id),
   constraint payments_company_id_fkey foreign KEY (company_id) references company (id)
 ) TABLESPACE pg_default;

--- a/src/app/dashboard/payments/[id]/page.tsx
+++ b/src/app/dashboard/payments/[id]/page.tsx
@@ -18,6 +18,7 @@ interface Payment {
     usage: number;
     created_at: string;
     status: "pendente" | "pago";
+    payment_link: string | null;
 }
 
 export default function PaymentPage() {
@@ -31,6 +32,38 @@ export default function PaymentPage() {
     const [isGenerating, setIsGenerating] = useState(false);
     const [paymentLink, setPaymentLink] = useState<string | null>(null);
     const [user, setUser] = useState<{ id: string } | null>(null);
+
+    const handleGenerateLink = async () => {
+        if (isGenerating || paymentLink || !payment) return;
+        setIsGenerating(true);
+        try {
+            const date = new Date(payment.due_date).toISOString().slice(0, 10);
+            const total = payment.amount;
+
+            const {
+                data: { session },
+                error: sessionError,
+            } = await supabasebrowser.auth.getSession();
+            if (sessionError || !session) throw new Error("Sessão não encontrada");
+
+            const res = await fetch("/api/payments/pay", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: `Bearer ${session.access_token}`,
+                },
+                body: JSON.stringify({ id, date, total }),
+            });
+            if (!res.ok) throw await res.text();
+            const { asaas } = await res.json();
+            setPaymentLink(asaas.invoiceUrl || asaas.paymentLink);
+        } catch (err: unknown) {
+            console.error('Erro ao gerar link de pagamento:', err);
+            toast.error('Erro ao gerar link de pagamento. Tente novamente mais tarde.');
+        } finally {
+            setIsGenerating(false);
+        }
+    };
 
     useEffect(() => {
         supabasebrowser.auth.getUser().then(({ data, error }) => {
@@ -57,6 +90,7 @@ export default function PaymentPage() {
                     .single();
                 if (error) throw error;
                 setPayment(data as Payment);
+                setPaymentLink((data as Payment).payment_link);
             } catch (err: unknown) {
                 setError(err instanceof Error ? err.message : String(err));
             } finally {
@@ -64,13 +98,20 @@ export default function PaymentPage() {
             }
         }
         load();
-    }, [user, id]);
+      }, [user, id]);
 
-    if (loading) return <p className="text-center py-10 min-h-screen flex items-center justify-center">Carregando...</p>;
-    if (error) return <p className="text-red-600 py-10 min-h-screen flex items-center justify-center">Erro: {error}</p>;
-    if (!payment) return <p className="text-center py-10 min-h-screen flex items-center justify-center">Pagamento não encontrado.</p>;
-    if (payment.status === "pago") {
-        return (
+      useEffect(() => {
+          if (payment && !paymentLink && !isGenerating) {
+              handleGenerateLink();
+          }
+          // eslint-disable-next-line react-hooks/exhaustive-deps
+      }, [payment, paymentLink, isGenerating]);
+
+      if (loading) return <p className="text-center py-10 min-h-screen flex items-center justify-center">Carregando...</p>;
+      if (error) return <p className="text-red-600 py-10 min-h-screen flex items-center justify-center">Erro: {error}</p>;
+      if (!payment) return <p className="text-center py-10 min-h-screen flex items-center justify-center">Pagamento não encontrado.</p>;
+      if (payment.status === "pago") {
+          return (
             <Card className="max-w-md mx-auto mt-10">
                 <CardHeader>
                     <CardTitle>Pagamento já quitado</CardTitle>
@@ -82,35 +123,6 @@ export default function PaymentPage() {
         );
     }
 
-    const handleGenerateLink = async () => {
-        if (isGenerating || paymentLink) return;
-        setIsGenerating(true);
-        try {
-            const date = new Date(payment.due_date).toISOString().slice(0, 10);
-            const total = payment.amount;
-
-            const {
-                data: { session },
-                error: sessionError,
-            } = await supabasebrowser.auth.getSession();
-            if (sessionError || !session) throw new Error("Sessão não encontrada");
-
-            const res = await fetch("/api/payments/pay", {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                    Authorization: `Bearer ${session.access_token}`,
-                },
-                body: JSON.stringify({ id, date, total }),
-            });
-            if (!res.ok) throw await res.text();
-            const { asaas } = await res.json();
-            setPaymentLink(asaas.invoiceUrl || asaas.paymentLink);
-        } catch (err: unknown) {
-            console.error('Erro ao gerar link de pagamento:', err);
-            toast.error('Erro ao gerar link de pagamento. Tente novamente mais tarde.');
-        }
-    };
 
     return (
         <div className=" bg-[#FAFAFA] flex items-center justify-center p-6">


### PR DESCRIPTION
## Summary
- add Asaas tracking columns to payments table
- reuse existing Asaas payment record before creating a new one
- auto-generate payment link only when not stored
- drop payment status mapping; n8n manages status updates

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68913ebb2bc4832fac57f979bceb1ea3