### PR TITLE
Display payment link without manual trigger

### DIFF
--- a/src/app/dashboard/payments/[id]/page.tsx
+++ b/src/app/dashboard/payments/[id]/page.tsx
@@ -165,24 +165,22 @@ export default function PaymentPage() {
                             </div>
                         </section>
 
-                        <Button
-                            onClick={handleGenerateLink}
-                            disabled={isGenerating || !!paymentLink}
-                            className="w-full"
-                        >
-                            Gerar link de pagamento
-                        </Button>
-
-                        {/* Exibe link quando disponível */}
-                        {paymentLink && (
+                        {/* Link de pagamento */}
+                        {paymentLink ? (
                             <a
                                 href={paymentLink}
                                 target="_blank"
                                 rel="noopener noreferrer"
-                                className="block mt-2 text-center text-blue-600 underline"
+                                className="block w-full text-center text-blue-600 underline"
                             >
                                 Abrir link de pagamento
                             </a>
+                        ) : (
+                            <p className="text-center text-sm text-gray-500">
+                                {isGenerating
+                                    ? "Gerando link de pagamento..."
+                                    : "Link de pagamento indisponível"}
+                            </p>
                         )}
                     </CardContent>
                 </Card>


### PR DESCRIPTION
## Summary
- remove manual generate payment button
- show payment link automatically once available

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68914dc152c0832f84c2b93e06df3882