### PR TITLE
Refresh sidebar after agent creation

### DIFF
--- a/src/app/dashboard/agents/new/page.tsx
+++ b/src/app/dashboard/agents/new/page.tsx
@@ -72,8 +72,7 @@ export default function NewAgentPage() {
     toast.success(
       "Agente criado com sucesso. Configure-o ou ative-o quando estiver pronto."
     );
-    router.refresh();
-    router.push(`/dashboard/agents/${data.id}`);    
+    window.location.assign(`/dashboard/agents/${data.id}`);
   };
 
   const isFormValid = isValidAgentName(name) && type !== "";


### PR DESCRIPTION
## Summary
- reload dashboard when creating a new agent so sidebar immediately shows it

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68915e58b02c832f82bccb3a20e03843