### PR TITLE
feat: improve landing layout

### DIFF
--- a/components/landing/Features.tsx
+++ b/components/landing/Features.tsx
@@ -1,41 +1,39 @@
 "use client";
 
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
-import { Bot, MessageSquare, Users, Kanban } from "lucide-react";
+import { Bot, MessageSquare, Users } from "lucide-react";
 
 const features = [
   {
     title: "Agente de IA",
-    description: "Automatize respostas e agilize atendimentos com inteligência artificial.",
+    description:
+      "Automatize respostas e agilize atendimentos com inteligência artificial.",
     icon: Bot,
   },
   {
     title: "Atendimento multicanal",
-    description: "Conecte-se com clientes por e-mail, chat e redes sociais em um só lugar.",
+    description:
+      "Conecte-se com clientes por e-mail, chat e redes sociais em um só lugar.",
     icon: MessageSquare,
   },
   {
-    title: "CRM",
-    description: "Gerencie contatos e oportunidades com uma visão completa do cliente.",
+    title: "CRM integrado",
+    description:
+      "Gerencie contatos e oportunidades com uma visão completa do cliente.",
     icon: Users,
-  },
-  {
-    title: "Kanban",
-    description: "Organize tarefas e fluxos de trabalho com quadros visuais intuitivos.",
-    icon: Kanban,
   },
 ];
 
 export default function Features() {
   return (
-    <section className="bg-[#FAFAFA] py-24" id="features">
-      <div className="container mx-auto max-w-6xl px-4">
-        <h2 className="mb-12 text-center text-3xl font-bold">Recursos principais</h2>
-        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+    <section className="bg-[#FAFAFA] py-8 md:py-12 lg:py-16" id="features">
+      <div className="mx-auto max-w-[1140px] px-3 md:px-4 lg:px-6">
+        <h2 className="mb-12 text-center text-3xl font-bold">Por que é melhor</h2>
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
           {features.map(({ title, description, icon: Icon }) => (
             <Card key={title} className="h-full">
               <CardHeader>
-                <Icon className="mb-2 h-8 w-8 text-primary" />
+                <Icon className="mb-2 h-6 w-6 text-primary" />
                 <CardTitle>{title}</CardTitle>
               </CardHeader>
               <CardContent>

--- a/components/landing/Footer.tsx
+++ b/components/landing/Footer.tsx
@@ -4,8 +4,8 @@ import Link from "next/link";
 
 export default function Footer() {
   return (
-    <footer className="bg-[#FAFAFA] py-8">
-      <div className="container mx-auto flex flex-col items-center gap-4 px-4 text-center text-sm text-muted-foreground">
+    <footer className="bg-[#FAFAFA] py-8" id="contato">
+      <div className="mx-auto flex max-w-[1140px] flex-col items-center gap-4 px-3 text-center text-sm text-muted-foreground md:px-4 lg:px-6">
         <div className="flex gap-6">
           <Link href="/login" className="hover:text-primary">
             Login

--- a/components/landing/Header.tsx
+++ b/components/landing/Header.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import Image from "next/image";
+import { Button } from "@/components/ui/button";
+import { Menu, X } from "lucide-react";
+
+export default function Header() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <header className="border-b bg-background">
+      <div className="mx-auto flex h-16 max-w-[1140px] items-center justify-between px-3 md:px-4 lg:px-6">
+        <Link href="/">
+          <Image src="/logo.svg" alt="Logo" width={120} height={32} />
+        </Link>
+        <nav className="hidden md:flex gap-6 text-sm">
+          <Link href="#home">Home</Link>
+          <Link href="#sobre">Sobre</Link>
+          <Link href="#servicos">Serviços</Link>
+          <Link href="#contato">Contato</Link>
+        </nav>
+        <div className="hidden md:flex items-center gap-2">
+          <Link href="/login">
+            <Button variant="outline">Login</Button>
+          </Link>
+          <Link href="/signup">
+            <Button>Registrar</Button>
+          </Link>
+        </div>
+        <button
+          className="md:hidden"
+          aria-label="Abrir menu"
+          onClick={() => setOpen(true)}
+        >
+          <Menu className="h-6 w-6" />
+        </button>
+      </div>
+      {open && (
+        <div className="fixed inset-0 z-50 bg-background px-3 py-6 md:hidden">
+          <div className="flex justify-end">
+            <button
+              aria-label="Fechar menu"
+              onClick={() => setOpen(false)}
+            >
+              <X className="h-6 w-6" />
+            </button>
+          </div>
+          <nav className="mt-6 flex flex-col items-center gap-4 text-lg">
+            <Link href="#home" onClick={() => setOpen(false)}>
+              Home
+            </Link>
+            <Link href="#sobre" onClick={() => setOpen(false)}>
+              Sobre
+            </Link>
+            <Link href="#servicos" onClick={() => setOpen(false)}>
+              Serviços
+            </Link>
+            <Link href="#contato" onClick={() => setOpen(false)}>
+              Contato
+            </Link>
+            <Link href="/login" className="w-full" onClick={() => setOpen(false)}>
+              <Button variant="outline" className="w-full">
+                Login
+              </Button>
+            </Link>
+            <Link href="/signup" className="w-full" onClick={() => setOpen(false)}>
+              <Button className="w-full">Registrar</Button>
+            </Link>
+          </nav>
+        </div>
+      )}
+    </header>
+  );
+}

--- a/components/landing/Hero.tsx
+++ b/components/landing/Hero.tsx
@@ -1,35 +1,34 @@
 "use client";
 
+import Image from "next/image";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 
 export default function Hero() {
   return (
-    <section className="bg-[#FAFAFA] py-24 text-center">
-      <div className="container mx-auto flex max-w-5xl flex-col items-center gap-6 px-4">
-        <h1 className="text-4xl font-bold sm:text-5xl">
-          Atendimento eficiente com IA
-        </h1>
-        <p className="max-w-2xl text-lg text-muted-foreground">
-          Centralize conversas, gerencie clientes e otimize processos com
-          ferramentas inteligentes.
-        </p>
-        <div className="flex flex-col gap-4 sm:flex-row">
-          <Link href="/signup">
-            <Button size="lg">Começar agora</Button>
+    <section className="bg-[#FAFAFA] py-8 md:py-12 lg:py-16" id="home">
+      <div className="mx-auto grid max-w-[1140px] items-center gap-8 px-3 md:px-4 lg:px-6 md:grid-cols-2">
+        <div className="space-y-4 text-center md:text-left">
+          <h1 className="text-4xl font-bold md:text-5xl">
+            Atendimento eficiente com IA
+          </h1>
+          <p className="text-lg text-muted-foreground">
+            Centralize conversas, gerencie clientes e otimize processos com ferramentas inteligentes.
+          </p>
+          <Link href="/signup" className="inline-block w-full md:w-auto">
+            <Button size="lg" className="w-full md:w-auto">Começar agora</Button>
           </Link>
-          <Link href="#pricing">
-            <Button variant="outline" size="lg">
-              Conhecer planos
-            </Button>
-          </Link>
+          <p className="text-sm text-muted-foreground">Sem cartão de crédito.</p>
         </div>
-        <Link
-          href="/login"
-          className="text-sm text-primary underline-offset-4 hover:underline"
-        >
-          Já possui conta? Entre
-        </Link>
+        <div className="flex justify-center md:justify-end">
+          <Image
+            src="/window.svg"
+            alt="Screenshot do produto"
+            width={480}
+            height={480}
+            className="h-auto w-full max-w-[480px] rounded-md object-cover"
+          />
+        </div>
       </div>
     </section>
   );

--- a/components/landing/Pricing.tsx
+++ b/components/landing/Pricing.tsx
@@ -30,10 +30,10 @@ const plans = [
 
 export default function Pricing() {
   return (
-    <section id="pricing" className="bg-[#FAFAFA] py-24">
-      <div className="container mx-auto max-w-6xl px-4">
+    <section id="pricing" className="bg-[#FAFAFA] py-8 md:py-12 lg:py-16">
+      <div className="mx-auto max-w-[1140px] px-3 md:px-4 lg:px-6">
         <h2 className="mb-12 text-center text-3xl font-bold">Planos</h2>
-        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
           {plans.map(({ name, price, features }) => (
             <Card key={name} className="flex flex-col">
               <CardHeader>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 // src/app/page.tsx
+import Header from "@/components/landing/Header";
 import Hero from "@/components/landing/Hero";
 import Features from "@/components/landing/Features";
 import Pricing from "@/components/landing/Pricing";
@@ -7,6 +8,7 @@ import Footer from "@/components/landing/Footer";
 export default function HomePage() {
   return (
     <main className="flex flex-col">
+      <Header />
       <Hero />
       <Features />
       <Pricing />


### PR DESCRIPTION
## Summary
- add responsive header with navigation, auth actions, and mobile overlay
- organize hero into two-column layout with CTA and product image
- revise feature, pricing, and footer sections for unified container spacing

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68922a6679c0832fb8ea0ff9f6961b28