### PR TITLE
feat: expand landing page layout

### DIFF
--- a/components/landing/BenefitOne.tsx
+++ b/components/landing/BenefitOne.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+export default function BenefitOne() {
+  return (
+    <section>
+      <div className="mx-auto grid max-w-[1140px] grid-cols-1 items-center gap-8 px-3 py-8 md:grid-cols-2 md:px-4 md:py-12 lg:px-6 lg:py-16">
+        <div className="flex flex-col gap-4">
+          <span className="text-sm font-medium text-primary">Tag</span>
+          <h2 className="text-3xl font-bold">Benefício 1</h2>
+          <p className="text-muted-foreground">
+            Pequena descrição do benefício e como ele ajuda seu negócio a
+            crescer.
+          </p>
+          <ul className="list-inside list-disc space-y-1">
+            <li>Ponto importante 1</li>
+            <li>Ponto importante 2</li>
+            <li>Ponto importante 3</li>
+            <li>Ponto importante 4</li>
+          </ul>
+          <Link href="#">
+            <Button variant="outline" className="mt-2 w-fit">
+              Saiba mais
+            </Button>
+          </Link>
+        </div>
+        <div className="flex justify-center md:justify-end">
+          <Image
+            src="/globe.svg"
+            alt="Benefício"
+            width={720}
+            height={540}
+            className="h-auto w-full max-w-[720px] rounded-lg"
+          />
+        </div>
+      </div>
+    </section>
+  );
+}
+

--- a/components/landing/BenefitTwo.tsx
+++ b/components/landing/BenefitTwo.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+export default function BenefitTwo() {
+  return (
+    <section className="bg-[#FAFAFA]">
+      <div className="mx-auto grid max-w-[1140px] grid-cols-1 items-center gap-8 px-3 py-8 md:grid-cols-2 md:px-4 md:py-12 lg:px-6 lg:py-16">
+        <div className="order-2 flex flex-col gap-4 md:order-1">
+          <span className="text-sm font-medium text-primary">Tag</span>
+          <h2 className="text-3xl font-bold">Benefício 2</h2>
+          <p className="text-muted-foreground">
+            Outro benefício importante para destacar o valor do produto.
+          </p>
+          <ul className="list-inside list-disc space-y-1">
+            <li>Ponto relevante 1</li>
+            <li>Ponto relevante 2</li>
+            <li>Ponto relevante 3</li>
+            <li>Ponto relevante 4</li>
+          </ul>
+          <Link href="#">
+            <Button className="mt-2 w-fit">Começar agora</Button>
+          </Link>
+        </div>
+        <div className="order-1 flex justify-center md:order-2 md:justify-start">
+          <Image
+            src="/window.svg"
+            alt="Benefício"
+            width={720}
+            height={540}
+            className="h-auto w-full max-w-[720px] rounded-lg"
+          />
+        </div>
+      </div>
+    </section>
+  );
+}
+

--- a/components/landing/FAQ.tsx
+++ b/components/landing/FAQ.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useState } from "react";
+
+const faqs = [
+  {
+    q: "Como funciona o período de teste?",
+    a: "Você pode utilizar a plataforma gratuitamente por 14 dias com acesso completo aos recursos.",
+  },
+  {
+    q: "Posso cancelar a qualquer momento?",
+    a: "Sim, você pode cancelar sua assinatura quando quiser sem taxas adicionais.",
+  },
+  {
+    q: "Há suporte em português?",
+    a: "Nossa equipe oferece suporte completo em português via chat e e-mail.",
+  },
+  {
+    q: "Os dados estão seguros?",
+    a: "Utilizamos criptografia e práticas modernas de segurança para proteger suas informações.",
+  },
+  {
+    q: "Quais formas de pagamento são aceitas?",
+    a: "Aceitamos cartões de crédito das principais bandeiras e boletos bancários.",
+  },
+];
+
+export default function FAQ() {
+  const [openIndex, setOpenIndex] = useState<number | null>(null);
+
+  return (
+    <section className="bg-[#FAFAFA]">
+      <div className="mx-auto max-w-[920px] px-3 py-8 md:px-4 md:py-12 lg:px-6 lg:py-16">
+        <h2 className="mb-12 text-center text-3xl font-bold">Perguntas frequentes</h2>
+        <div className="space-y-4">
+          {faqs.map(({ q, a }, i) => (
+            <div key={q} className="border rounded-lg">
+              <button
+                className="flex w-full items-center justify-between px-4 py-3 text-left text-sm font-medium"
+                onClick={() => setOpenIndex(openIndex === i ? null : i)}
+              >
+                {q}
+                <span>{openIndex === i ? "-" : "+"}</span>
+              </button>
+              {openIndex === i && (
+                <div className="border-t px-4 py-3 text-sm text-muted-foreground">
+                  {a}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+

--- a/components/landing/Features.tsx
+++ b/components/landing/Features.tsx
@@ -1,37 +1,37 @@
 "use client";
 
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
-import { Bot, MessageSquare, Users, Kanban } from "lucide-react";
+import { Bot, MessageSquare, Users } from "lucide-react";
 
 const features = [
   {
     title: "Agente de IA",
-    description: "Automatize respostas e agilize atendimentos com inteligência artificial.",
+    description:
+      "Automatize respostas e agilize atendimentos com inteligência artificial.",
     icon: Bot,
   },
   {
     title: "Atendimento multicanal",
-    description: "Conecte-se com clientes por e-mail, chat e redes sociais em um só lugar.",
+    description:
+      "Conecte-se com clientes por e-mail, chat e redes sociais em um só lugar.",
     icon: MessageSquare,
   },
   {
-    title: "CRM",
-    description: "Gerencie contatos e oportunidades com uma visão completa do cliente.",
+    title: "CRM integrado",
+    description:
+      "Gerencie contatos e oportunidades com uma visão completa do cliente.",
     icon: Users,
-  },
-  {
-    title: "Kanban",
-    description: "Organize tarefas e fluxos de trabalho com quadros visuais intuitivos.",
-    icon: Kanban,
   },
 ];
 
 export default function Features() {
   return (
-    <section className="bg-[#FAFAFA] py-24" id="features">
-      <div className="container mx-auto max-w-6xl px-4">
-        <h2 className="mb-12 text-center text-3xl font-bold">Recursos principais</h2>
-        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+    <section className="bg-[#FAFAFA]" id="features">
+      <div className="mx-auto max-w-[1140px] px-3 py-8 md:px-4 md:py-12 lg:px-6 lg:py-16">
+        <h2 className="mb-12 text-center text-3xl font-bold">
+          Por que é melhor
+        </h2>
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
           {features.map(({ title, description, icon: Icon }) => (
             <Card key={title} className="h-full">
               <CardHeader>

--- a/components/landing/FinalCTA.tsx
+++ b/components/landing/FinalCTA.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+export default function FinalCTA() {
+  return (
+    <section className="bg-primary text-primary-foreground">
+      <div className="mx-auto flex max-w-[1140px] flex-col items-center px-3 py-8 text-center md:px-4 md:py-12 lg:px-6 lg:py-16">
+        <h2 className="mb-2 text-3xl font-bold">Pronto para começar?</h2>
+        <p className="mb-6 max-w-2xl text-lg opacity-90">
+          Experimente todas as funcionalidades e transforme seu atendimento.
+        </p>
+        <Link href="/signup">
+          <Button size="lg" variant="secondary">
+            Criar conta
+          </Button>
+        </Link>
+      </div>
+    </section>
+  );
+}
+

--- a/components/landing/Footer.tsx
+++ b/components/landing/Footer.tsx
@@ -1,24 +1,131 @@
 "use client";
 
+import Image from "next/image";
 import Link from "next/link";
+import { Button } from "@/components/ui/button";
 
 export default function Footer() {
   return (
-    <footer className="bg-[#FAFAFA] py-8">
-      <div className="container mx-auto flex flex-col items-center gap-4 px-4 text-center text-sm text-muted-foreground">
-        <div className="flex gap-6">
-          <Link href="/login" className="hover:text-primary">
-            Login
+    <footer className="bg-[#FAFAFA]">
+      <div className="mx-auto grid max-w-[1140px] grid-cols-1 gap-8 px-3 py-8 text-sm md:grid-cols-2 md:px-4 md:py-12 lg:grid-cols-4 lg:px-6">
+        <div className="space-y-4">
+          <Link href="/">
+            <Image src="/logo.svg" alt="Logo" width={120} height={32} />
           </Link>
-          <Link href="/signup" className="hover:text-primary">
-            Cadastrar
-          </Link>
-          <Link href="#pricing" className="hover:text-primary">
-            Planos
-          </Link>
+          <ul className="space-y-2 text-muted-foreground">
+            <li>
+              <Link href="#" className="hover:text-primary">
+                Sobre
+              </Link>
+            </li>
+            <li>
+              <Link href="#" className="hover:text-primary">
+                Serviços
+              </Link>
+            </li>
+            <li>
+              <Link href="#" className="hover:text-primary">
+                Contato
+              </Link>
+            </li>
+            <li>
+              <Link href="#pricing" className="hover:text-primary">
+                Planos
+              </Link>
+            </li>
+            <li>
+              <Link href="/login" className="hover:text-primary">
+                Login
+              </Link>
+            </li>
+          </ul>
         </div>
-        <p>© {new Date().getFullYear()} Evoluke. Todos os direitos reservados.</p>
-        <p>contato@evoluke.com</p>
+        <div className="space-y-2">
+          <h3 className="font-semibold">Produto</h3>
+          <ul className="space-y-2 text-muted-foreground">
+            <li>
+              <Link href="#" className="hover:text-primary">
+                Recursos
+              </Link>
+            </li>
+            <li>
+              <Link href="#" className="hover:text-primary">
+                Preços
+              </Link>
+            </li>
+            <li>
+              <Link href="#" className="hover:text-primary">
+                Atualizações
+              </Link>
+            </li>
+            <li>
+              <Link href="#" className="hover:text-primary">
+                Blog
+              </Link>
+            </li>
+            <li>
+              <Link href="#" className="hover:text-primary">
+                Ajuda
+              </Link>
+            </li>
+          </ul>
+        </div>
+        <div className="space-y-2">
+          <h3 className="font-semibold">Empresa</h3>
+          <ul className="space-y-2 text-muted-foreground">
+            <li>
+              <Link href="#" className="hover:text-primary">
+                Sobre nós
+              </Link>
+            </li>
+            <li>
+              <Link href="#" className="hover:text-primary">
+                Carreiras
+              </Link>
+            </li>
+            <li>
+              <Link href="#" className="hover:text-primary">
+                Parceiros
+              </Link>
+            </li>
+            <li>
+              <Link href="#" className="hover:text-primary">
+                Contato
+              </Link>
+            </li>
+            <li>
+              <Link href="#" className="hover:text-primary">
+                Notícias
+              </Link>
+            </li>
+          </ul>
+        </div>
+        <div className="space-y-4">
+          <h3 className="font-semibold">Newsletter</h3>
+          <form className="flex flex-col gap-2 sm:flex-row">
+            <input
+              type="email"
+              placeholder="Seu e-mail"
+              className="w-full rounded-md border px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            />
+            <Button type="submit" className="sm:w-auto">
+              Assinar
+            </Button>
+          </form>
+        </div>
+      </div>
+      <div className="border-t">
+        <div className="mx-auto flex max-w-[1140px] flex-col justify-between gap-4 px-3 py-4 text-center text-xs text-muted-foreground md:flex-row md:px-4 lg:px-6">
+          <p>© {new Date().getFullYear()} Evoluke. Todos os direitos reservados.</p>
+          <p>
+            <Link href="#" className="hover:text-primary">
+              Privacidade
+            </Link>{" "}|{" "}
+            <Link href="#" className="hover:text-primary">
+              Termos
+            </Link>
+          </p>
+        </div>
       </div>
     </footer>
   );

--- a/components/landing/Header.tsx
+++ b/components/landing/Header.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { useState } from "react";
+import { Menu, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export default function Header() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <header className="border-b bg-white">
+      <div className="mx-auto flex max-w-[1140px] items-center justify-between px-3 py-4 md:px-4 lg:px-6">
+        <Link href="/">
+          <Image src="/logo.svg" alt="Logo" width={120} height={32} />
+        </Link>
+        <nav className="hidden gap-6 md:flex">
+          <Link href="#" className="text-sm font-medium hover:text-primary">
+            Home
+          </Link>
+          <Link href="#" className="text-sm font-medium hover:text-primary">
+            Sobre
+          </Link>
+          <Link href="#" className="text-sm font-medium hover:text-primary">
+            Serviços
+          </Link>
+          <Link href="#" className="text-sm font-medium hover:text-primary">
+            Contato
+          </Link>
+        </nav>
+        <div className="hidden items-center gap-4 md:flex">
+          <Link href="/login">
+            <Button variant="outline" size="sm">
+              Login
+            </Button>
+          </Link>
+          <Link href="/signup">
+            <Button size="sm">Registrar</Button>
+          </Link>
+        </div>
+        <button
+          className="md:hidden"
+          onClick={() => setOpen(true)}
+          aria-label="Abrir menu"
+        >
+          <Menu className="h-6 w-6" />
+        </button>
+      </div>
+
+      {open && (
+        <div className="fixed inset-0 z-50 flex flex-col bg-white px-6 py-4 md:hidden">
+          <button
+            className="self-end"
+            onClick={() => setOpen(false)}
+            aria-label="Fechar menu"
+          >
+            <X className="h-6 w-6" />
+          </button>
+          <nav className="mt-8 flex flex-col gap-4 text-center">
+            <Link
+              href="#"
+              className="text-lg font-medium hover:text-primary"
+              onClick={() => setOpen(false)}
+            >
+              Home
+            </Link>
+            <Link
+              href="#"
+              className="text-lg font-medium hover:text-primary"
+              onClick={() => setOpen(false)}
+            >
+              Sobre
+            </Link>
+            <Link
+              href="#"
+              className="text-lg font-medium hover:text-primary"
+              onClick={() => setOpen(false)}
+            >
+              Serviços
+            </Link>
+            <Link
+              href="#"
+              className="text-lg font-medium hover:text-primary"
+              onClick={() => setOpen(false)}
+            >
+              Contato
+            </Link>
+          </nav>
+          <div className="mt-auto flex flex-col gap-4">
+            <Link href="/login">
+              <Button variant="outline" className="w-full">
+                Login
+              </Button>
+            </Link>
+            <Link href="/signup">
+              <Button className="w-full">Registrar</Button>
+            </Link>
+          </div>
+        </div>
+      )}
+    </header>
+  );
+}
+

--- a/components/landing/Hero.tsx
+++ b/components/landing/Hero.tsx
@@ -1,35 +1,53 @@
 "use client";
 
+import Image from "next/image";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 
 export default function Hero() {
   return (
-    <section className="bg-[#FAFAFA] py-24 text-center">
-      <div className="container mx-auto flex max-w-5xl flex-col items-center gap-6 px-4">
-        <h1 className="text-4xl font-bold sm:text-5xl">
-          Atendimento eficiente com IA
-        </h1>
-        <p className="max-w-2xl text-lg text-muted-foreground">
-          Centralize conversas, gerencie clientes e otimize processos com
-          ferramentas inteligentes.
-        </p>
-        <div className="flex flex-col gap-4 sm:flex-row">
-          <Link href="/signup">
-            <Button size="lg">Começar agora</Button>
-          </Link>
-          <Link href="#pricing">
-            <Button variant="outline" size="lg">
-              Conhecer planos
-            </Button>
+    <section className="bg-[#FAFAFA]">
+      <div className="mx-auto grid max-w-[1140px] grid-cols-1 items-center gap-8 px-3 py-8 md:grid-cols-2 md:py-12 lg:px-6 lg:py-16">
+        <div className="flex flex-col gap-4 text-center md:text-left">
+          <h1 className="text-4xl font-bold leading-tight sm:text-5xl">
+            Atendimento eficiente com IA
+          </h1>
+          <p className="text-lg text-muted-foreground">
+            Centralize conversas, gerencie clientes e otimize processos com
+            ferramentas inteligentes.
+          </p>
+          <div className="flex flex-col gap-4 sm:flex-row">
+            <Link href="/signup" className="sm:w-auto">
+              <Button size="lg" className="w-full sm:w-auto">
+                Começar agora
+              </Button>
+            </Link>
+            <Link href="#pricing" className="sm:w-auto">
+              <Button
+                variant="outline"
+                size="lg"
+                className="w-full sm:w-auto"
+              >
+                Conhecer planos
+              </Button>
+            </Link>
+          </div>
+          <Link
+            href="/login"
+            className="text-sm text-primary underline-offset-4 hover:underline"
+          >
+            Já possui conta? Entre
           </Link>
         </div>
-        <Link
-          href="/login"
-          className="text-sm text-primary underline-offset-4 hover:underline"
-        >
-          Já possui conta? Entre
-        </Link>
+        <div className="flex justify-center">
+          <Image
+            src="/next.svg"
+            alt="Ilustração"
+            width={480}
+            height={480}
+            className="h-auto w-full max-w-[480px]"
+          />
+        </div>
       </div>
     </section>
   );

--- a/components/landing/Testimonials.tsx
+++ b/components/landing/Testimonials.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import Image from "next/image";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Star } from "lucide-react";
+
+const testimonials = [
+  {
+    name: "Maria Silva",
+    role: "CEO, Empresa X",
+    text: "Plataforma incrível! Aumentamos nossa eficiência em poucos dias.",
+  },
+  {
+    name: "João Souza",
+    role: "Gerente, Startup Y",
+    text: "Ferramenta essencial para o nosso atendimento ao cliente.",
+  },
+  {
+    name: "Ana Lima",
+    role: "Consultora",
+    text: "Interface simples e recursos poderosos. Recomendo!",
+  },
+];
+
+export default function Testimonials() {
+  return (
+    <section>
+      <div className="mx-auto max-w-[1140px] px-3 py-8 md:px-4 md:py-12 lg:px-6 lg:py-16">
+        <h2 className="mb-2 text-center text-3xl font-bold">O que dizem</h2>
+        <p className="mb-12 text-center text-muted-foreground">
+          Depoimentos de alguns clientes
+        </p>
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {testimonials.map(({ name, role, text }) => (
+            <Card key={name} className="h-full">
+              <CardHeader className="flex flex-row gap-1">
+                {[...Array(5)].map((_, i) => (
+                  <Star key={i} className="h-4 w-4 fill-primary text-primary" />
+                ))}
+              </CardHeader>
+              <CardContent className="flex flex-col gap-4">
+                <p className="text-sm text-muted-foreground">&quot;{text}&quot;</p>
+                <div className="flex items-center gap-3">
+                  <Image
+                    src="/logo.svg"
+                    alt="avatar"
+                    width={48}
+                    height={48}
+                    className="rounded-full"
+                  />
+                  <div className="text-sm">
+                    <p className="font-medium">{name}</p>
+                    <p className="text-muted-foreground">{role}</p>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,15 +1,25 @@
 // src/app/page.tsx
+import Header from "@/components/landing/Header";
 import Hero from "@/components/landing/Hero";
 import Features from "@/components/landing/Features";
-import Pricing from "@/components/landing/Pricing";
+import BenefitOne from "@/components/landing/BenefitOne";
+import BenefitTwo from "@/components/landing/BenefitTwo";
+import Testimonials from "@/components/landing/Testimonials";
+import FAQ from "@/components/landing/FAQ";
+import FinalCTA from "@/components/landing/FinalCTA";
 import Footer from "@/components/landing/Footer";
 
 export default function HomePage() {
   return (
     <main className="flex flex-col">
+      <Header />
       <Hero />
       <Features />
-      <Pricing />
+      <BenefitOne />
+      <BenefitTwo />
+      <Testimonials />
+      <FAQ />
+      <FinalCTA />
       <Footer />
     </main>
   );


### PR DESCRIPTION
## Summary
- build responsive header with navigation and mobile menu
- redesign hero and feature sections for new grid
- add benefit highlights, testimonials, FAQ, final CTA, and expanded footer

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68922a6679c0832fb8ea0ff9f6961b28