### PR TITLE
feat: show message when no payments

### DIFF
--- a/src/app/dashboard/payments/page.tsx
+++ b/src/app/dashboard/payments/page.tsx
@@ -118,6 +118,11 @@ export default function PaymentsPage() {
               ))}
             </tbody>
           </table>
+          {payments.length === 0 && (
+            <p className="text-center text-sm text-muted-foreground mt-4">
+              Nenhum pagamento encontrado.
+            </p>
+          )}
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
## Summary
- show empty state message when there are no payments

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68925762d1b0832faefc7af0c29168ee