### PR TITLE
Handle duplicate signup errors

### DIFF
--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -43,10 +43,28 @@ export async function POST(req: Request) {
       emailRedirectTo: "http://localhost:3000/auth/callback",
     },
   });
+  if (error) {
+    console.error("Erro ao criar usuário:", error.message);
+    if (
+      error.message?.includes("User already registered") ||
+      error.status === 400
+    ) {
+      return NextResponse.json(
+        { error: "Email já cadastrado" },
+        { status: 409 }
+      );
+    }
+    return NextResponse.json(
+      { error: "Erro ao criar usuário" },
+      { status: 409 }
+    );
+  }
 
-  if (error || !data.user) {
-    console.error('Erro ao criar usuário:', error?.message);
-    return NextResponse.json({ error: 'Erro ao criar usuário' }, { status: 409 });
+  if (!data.user) {
+    return NextResponse.json(
+      { error: "Erro ao criar usuário" },
+      { status: 409 }
+    );
   }
 
   const userId = data.user.id;


### PR DESCRIPTION
## Summary
- return specific message when signup fails because email already exists
- keep generic message for other signup errors

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68929dacc184832f978561d6b365a61a