### PR TITLE
feat: add verify email page

### DIFF
--- a/src/app/verify-email/page.tsx
+++ b/src/app/verify-email/page.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
+import { supabasebrowser } from '@/lib/supabaseClient';
+import { Button } from '@/components/ui/button';
+import { toast } from 'sonner';
+
+export default function VerifyEmailPage() {
+  const searchParams = useSearchParams();
+  const email = searchParams.get('email') || '';
+  const [cooldown, setCooldown] = useState(0);
+
+  useEffect(() => {
+    if (cooldown <= 0) return;
+    const interval = setInterval(() => {
+      setCooldown((prev) => Math.max(prev - 1, 0));
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [cooldown]);
+
+  const handleResend = async () => {
+    if (!email) {
+      toast.error('Email inválido');
+      return;
+    }
+    const { error } = await supabasebrowser.auth.resend({ type: 'signup', email });
+    if (error) {
+      console.error('Erro ao reenviar email:', error.message);
+      toast.error('Erro ao reenviar email. Tente novamente mais tarde.');
+    } else {
+      toast.success('Email de verificação reenviado');
+      setCooldown(60);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-[#FAFAFA] p-4">
+      <div className="max-w-md w-full bg-white rounded-lg shadow p-6 space-y-4">
+        <h1 className="text-2xl font-semibold text-center">E-mail não verificado</h1>
+        {email && (
+          <p className="text-center text-sm">{email}</p>
+        )}
+        <Button onClick={handleResend} className="w-full" disabled={cooldown > 0}>
+          {cooldown > 0 ? `Reenviar em ${cooldown}s` : 'Reenviar e-mail de verificação'}
+        </Button>
+        <p className="text-center text-sm">
+          <Link href="/login" className="text-teal-600 hover:underline">
+            Voltar ao login
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add verify email page that reads email from query string
- enable resend verification email with cooldown and login link

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68929dc43fc0832f9e0314fa1ef6cad4