### PR TITLE
feat: add agent onboarding settings

### DIFF
--- a/migration.sql
+++ b/migration.sql
@@ -92,3 +92,16 @@ create table public.agent_behavior (
   constraint agent_behavior_agent_id_fkey foreign key (agent_id) references agents (id)
 ) TABLESPACE pg_default;
 
+
+-- Tabela de onboarding dos agentes
+create table public.agent_onboarding (
+  id uuid not null default gen_random_uuid (),
+  created_at timestamp with time zone not null default now(),
+  agent_id uuid not null,
+  welcome_message text not null default ''::text,
+  collection jsonb not null default '[]'::jsonb,
+  constraint agent_onboarding_pkey primary key (id),
+  constraint agent_onboarding_agent_id_key unique (agent_id),
+  constraint agent_onboarding_agent_id_fkey foreign key (agent_id) references agents (id)
+) TABLESPACE pg_default;
+

--- a/src/app/dashboard/agents/[id]/onboarding/page.tsx
+++ b/src/app/dashboard/agents/[id]/onboarding/page.tsx
@@ -1,0 +1,286 @@
+"use client";
+
+import Link from "next/link";
+import { Fragment, useEffect, useState } from "react";
+import { useParams, usePathname } from "next/navigation";
+import { supabasebrowser } from "@/lib/supabaseClient";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Smile,
+  Settings,
+  BookOpen,
+  Database,
+  ClipboardList,
+} from "lucide-react";
+import { toast } from "sonner";
+
+type Agent = {
+  id: string;
+  name: string;
+  type: string;
+  is_active: boolean;
+};
+
+type CollectionItem = {
+  question: string;
+  variable: string;
+};
+
+export default function AgentOnboardingPage() {
+  const params = useParams();
+  const id = params?.id as string;
+  const pathname = usePathname();
+  const [agent, setAgent] = useState<Agent | null>(null);
+  const [welcomeMessage, setWelcomeMessage] = useState("");
+  const [collection, setCollection] = useState<CollectionItem[]>([
+    { question: "", variable: "" },
+  ]);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!id) return;
+    supabasebrowser
+      .from("agents")
+      .select("id,name,type,is_active")
+      .eq("id", id)
+      .single()
+      .then(({ data }) => {
+        setAgent(data);
+      });
+
+    supabasebrowser
+      .from("agent_onboarding")
+      .select("welcome_message, collection")
+      .eq("agent_id", id)
+      .single()
+      .then(({ data }) => {
+        if (data) {
+          setWelcomeMessage(data.welcome_message);
+          if (Array.isArray(data.collection) && data.collection.length > 0) {
+            setCollection(data.collection);
+          }
+        }
+      });
+  }, [id]);
+
+  if (!agent) return <div>Carregando...</div>;
+
+  const welcomeMessageValid = welcomeMessage.trim().length <= 500;
+  const collectionValid = collection.every(
+    (item) =>
+      item.question.trim().length <= 500 &&
+      item.variable.trim().length >= 10 &&
+      item.variable.trim().length <= 200
+  );
+  const hasAtLeastOneItem = collection.some(
+    (item) => item.question.trim() && item.variable.trim()
+  );
+  const isFormValid = welcomeMessageValid && collectionValid && hasAtLeastOneItem;
+
+  const handleQuestionChange = (index: number, value: string) => {
+    const newCollection = [...collection];
+    newCollection[index].question = value;
+    setCollection(newCollection);
+  };
+
+  const handleVariableChange = (index: number, value: string) => {
+    const newCollection = [...collection];
+    newCollection[index].variable = value;
+    setCollection(newCollection);
+  };
+
+  const addItem = () => {
+    if (collection.length >= 5) return;
+    setCollection([...collection, { question: "", variable: "" }]);
+  };
+
+  const removeItem = (index: number) => {
+    if (collection.length === 1) return;
+    const newCollection = collection.filter((_, i) => i !== index);
+    setCollection(newCollection);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!isFormValid || isSubmitting) return;
+    setIsSubmitting(true);
+    const filtered = collection.filter(
+      (item) => item.question.trim() && item.variable.trim()
+    );
+    const { error } = await supabasebrowser
+      .from("agent_onboarding")
+      .upsert(
+        {
+          agent_id: id,
+          welcome_message: welcomeMessage,
+          collection: filtered,
+        },
+        { onConflict: "agent_id" }
+      );
+
+    if (error) {
+      toast.error("Erro ao salvar onboarding.");
+    } else {
+      toast.success("Onboarding salvo com sucesso.");
+    }
+    setIsSubmitting(false);
+  };
+
+  const menuItems = [
+    { label: "Personalidade", icon: Smile, href: `/dashboard/agents/${id}` },
+    {
+      label: "Comportamento",
+      icon: Settings,
+      href: `/dashboard/agents/${id}/comportamento`,
+    },
+    { label: "Onboarding", icon: BookOpen, href: `/dashboard/agents/${id}/onboarding` },
+    {
+      label: "Base de conhecimento",
+      icon: Database,
+      href: `/dashboard/agents/${id}/base-conhecimento`,
+    },
+    {
+      label: "Instruções Específicas",
+      icon: ClipboardList,
+      href: `/dashboard/agents/${id}/instrucoes-especificas`,
+    },
+  ];
+
+  return (
+    <div className="space-y-6">
+      <div className="flex justify-center">
+        <Card className="w-4/5 p-6">
+          <nav className="flex items-center justify-around">
+            {menuItems.map(({ label, icon: Icon, href }, index) => (
+              <Fragment key={label}>
+                <Button
+                  asChild
+                  variant={pathname === href ? "secondary" : "ghost"}
+                  className="flex h-auto flex-col items-center gap-1 text-sm"
+                >
+                  <Link href={href} className="flex flex-col items-center">
+                    <Icon className="h-5 w-5" />
+                    <span>{label}</span>
+                  </Link>
+                </Button>
+                {index < menuItems.length - 1 && <div className="h-8 border-l" />}
+              </Fragment>
+            ))}
+          </nav>
+        </Card>
+      </div>
+      <div className="flex justify-center">
+        <Card className="w-4/5 p-6">
+          <form onSubmit={handleSubmit} className="space-y-6">
+            <div className="space-y-2">
+              <label htmlFor="welcome" className="text-sm font-medium">
+                Mensagem de boas-vindas
+              </label>
+              <Textarea
+                id="welcome"
+                value={welcomeMessage}
+                onChange={(e) => setWelcomeMessage(e.target.value)}
+                className="resize-y max-h-50 overflow-auto"
+                maxLength={500}
+              />
+              <div className="flex justify-between text-xs text-gray-500">
+                <p>Oii! Sou a IA da Evoluke.</p>
+                <p className="text-gray-400">0 a 500 caracteres</p>
+              </div>
+              {welcomeMessage && !welcomeMessageValid && (
+                <p className="text-xs text-red-500">
+                  A mensagem deve ter no máximo 500 caracteres
+                </p>
+              )}
+            </div>
+
+            {collection.map((item, index) => (
+              <div key={index} className="flex items-start gap-4">
+                <div className="flex-1 space-y-2">
+                  <label
+                    htmlFor={`question-${index}`}
+                    className="text-sm font-medium"
+                  >
+                    Pergunta de coleta
+                  </label>
+                  <Textarea
+                    id={`question-${index}`}
+                    value={item.question}
+                    onChange={(e) => handleQuestionChange(index, e.target.value)}
+                    className="resize-y max-h-50 overflow-auto"
+                    maxLength={500}
+                  />
+                  <div className="flex justify-between text-xs text-gray-500">
+                    <p>Nome, telefone, preferência de horário.</p>
+                    <p className="text-gray-400">0 a 500 caracteres</p>
+                  </div>
+                  {item.question && item.question.trim().length > 500 && (
+                    <p className="text-xs text-red-500">
+                      A pergunta deve ter no máximo 500 caracteres
+                    </p>
+                  )}
+                </div>
+                <div className="flex-1 space-y-2">
+                  <label
+                    htmlFor={`variable-${index}`}
+                    className="text-sm font-medium"
+                  >
+                    Variável de coleta
+                  </label>
+                  <Input
+                    id={`variable-${index}`}
+                    value={item.variable}
+                    onChange={(e) => handleVariableChange(index, e.target.value)}
+                    minLength={10}
+                    maxLength={200}
+                  />
+                  <div className="flex justify-end text-xs text-gray-500">
+                    <p className="text-gray-400">10 a 200 caracteres</p>
+                  </div>
+                  {item.variable &&
+                    (item.variable.trim().length < 10 ||
+                      item.variable.trim().length > 200) && (
+                      <p className="text-xs text-red-500">
+                        A variável deve ter entre 10 e 200 caracteres
+                      </p>
+                    )}
+                </div>
+                {collection.length > 1 && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    onClick={() => removeItem(index)}
+                  >
+                    Remover
+                  </Button>
+                )}
+              </div>
+            ))}
+
+            <Button
+              type="button"
+              variant="outline"
+              onClick={addItem}
+              disabled={collection.length >= 5}
+            >
+              Adicionar pergunta/variável
+            </Button>
+            {collection.length >= 5 && (
+              <p className="text-xs text-gray-500">
+                Máximo de 5 perguntas/variáveis
+              </p>
+            )}
+
+            <Button type="submit" disabled={!isFormValid || isSubmitting}>
+              Salvar
+            </Button>
+          </form>
+        </Card>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add onboarding settings page with welcome message and data collection pairs
- store onboarding configuration in new agent_onboarding table

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893ba0ad960832f89cdcbf48a21f836