### PR TITLE
feat: close agents submenu on outside click

### DIFF
--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -3,7 +3,7 @@
 'use client';
 
 import { supabasebrowser } from '@/lib/supabaseClient';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import {
@@ -47,6 +47,7 @@ export function Sidebar() {
   const router = useRouter();
   const [agents, setAgents] = useState<Agent[]>([]);
   const [open, setOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     supabasebrowser.auth.getUser().then(async ({ data }) => {
@@ -76,6 +77,17 @@ export function Sidebar() {
     router.replace('/login');
   };
 
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
   return (
     <aside className="w-16 bg-white border-r h-full flex flex-col items-center py-4 space-y-4">
       <div className="w-10 h-10 bg-gray-100 rounded-xl border border-gray-300 flex items-center justify-center p-1">
@@ -97,7 +109,7 @@ export function Sidebar() {
           </TooltipContent>
         </Tooltip>
 
-        <div className="relative">
+        <div ref={menuRef} className="relative">
           <Tooltip disableHoverableContent>
             <TooltipTrigger asChild>
               <button


### PR DESCRIPTION
## Summary
- close Agents IA submenu when clicking outside

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6893cda2eea0832fb7e9d82a220e57ed