### PR TITLE
fix: set payment due date one month later

### DIFF
--- a/src/app/api/agents/update/route.ts
+++ b/src/app/api/agents/update/route.ts
@@ -57,6 +57,7 @@ export async function POST(request: Request) {
 
   if (!existing || existing.length === 0) {
     const dueDate = new Date();
+    dueDate.setMonth(dueDate.getMonth() + 1);
     const { error: insertError } = await supabaseadmin
       .from('payments')
       .insert({


### PR DESCRIPTION
## Summary
- set newly created payment's due date one month later

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b910d75b4832f9cedc112b3f3da83