### PR TITLE
Refresh sidebar after personality save

### DIFF
--- a/src/app/dashboard/agents/[id]/page.tsx
+++ b/src/app/dashboard/agents/[id]/page.tsx
@@ -100,6 +100,7 @@ export default function AgentDetailPage() {
       toast.error("Erro ao salvar personalidade.");
     } else {
       toast.success("Personalidade salva com sucesso.");
+      window.dispatchEvent(new Event("agentsUpdated"));
     }
     setIsSubmitting(false);
   };


### PR DESCRIPTION
## Summary
- Dispatch global event after saving agent personality
- Sidebar listens for agentsUpdated event to reload agents list

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b91630274832fa5cd8eff32d05675