### PR TITLE
Add agent status panel with deactivate modal

### DIFF
--- a/components/agents/AgentMenu.tsx
+++ b/components/agents/AgentMenu.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import Link from "next/link";
+import { Fragment, useEffect, useState } from "react";
+import { usePathname } from "next/navigation";
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { supabasebrowser } from "@/lib/supabaseClient";
+import DeactivateAgentButton from "@/components/agents/DeactivateAgentButton";
+import {
+  Smile,
+  Settings,
+  BookOpen,
+  Database,
+  ClipboardList,
+} from "lucide-react";
+
+type Agent = {
+  id: string;
+  name: string;
+  type: string;
+  is_active: boolean;
+};
+
+export default function AgentMenu({ agent }: { agent: Agent }) {
+  const pathname = usePathname();
+  const [isActive, setIsActive] = useState(agent.is_active);
+  const [lastPayment, setLastPayment] = useState<string | null>(null);
+
+  useEffect(() => {
+    supabasebrowser
+      .from("payments")
+      .select("due_date")
+      .eq("agent_id", agent.id)
+      .order("due_date", { ascending: false })
+      .limit(1)
+      .single()
+      .then(({ data }) => {
+        setLastPayment(data?.due_date ?? null);
+      });
+  }, [agent.id]);
+
+  const menuItems = [
+    { label: "Personalidade", icon: Smile, href: `/dashboard/agents/${agent.id}` },
+    { label: "Comportamento", icon: Settings, href: `/dashboard/agents/${agent.id}/comportamento` },
+    { label: "Onboarding", icon: BookOpen, href: `/dashboard/agents/${agent.id}/onboarding` },
+    { label: "Base de conhecimento", icon: Database, href: `/dashboard/agents/${agent.id}/base-conhecimento` },
+    { label: "Instruções Específicas", icon: ClipboardList, href: `/dashboard/agents/${agent.id}/instrucoes-especificas` },
+  ];
+
+  return (
+    <div className="flex justify-center">
+      <div className="w-4/5 flex gap-4">
+        <Card className="w-64 p-4 flex flex-col gap-2 text-sm">
+          <p>Agente {isActive ? "ativo" : "inativo"}</p>
+          <p>
+            Vencimento último pagamento: {" "}
+            {lastPayment ? new Date(lastPayment).toLocaleDateString("pt-BR") : "Não existe"}
+          </p>
+          {isActive && (
+            <DeactivateAgentButton
+              agentId={agent.id}
+              onDeactivated={() => setIsActive(false)}
+            />
+          )}
+        </Card>
+        <Card className="flex-1 p-6">
+          <nav className="flex items-center justify-around">
+            {menuItems.map(({ label, icon: Icon, href }, index) => (
+              <Fragment key={label}>
+                <Button
+                  asChild
+                  variant={pathname === href ? "secondary" : "ghost"}
+                  className="flex h-auto flex-col items-center gap-1 text-sm"
+                >
+                  <Link href={href} className="flex flex-col items-center">
+                    <Icon className="h-5 w-5" />
+                    <span>{label}</span>
+                  </Link>
+                </Button>
+                {index < menuItems.length - 1 && <div className="h-8 border-l" />}
+              </Fragment>
+            ))}
+          </nav>
+        </Card>
+      </div>
+    </div>
+  );
+}
+

--- a/components/agents/DeactivateAgentButton.tsx
+++ b/components/agents/DeactivateAgentButton.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useState } from "react";
+import * as Dialog from "@radix-ui/react-dialog";
+import { Button } from "@/components/ui/button";
+import { supabasebrowser } from "@/lib/supabaseClient";
+import { toast } from "sonner";
+
+interface Props {
+  agentId: string;
+  onDeactivated: () => void;
+}
+
+export default function DeactivateAgentButton({ agentId, onDeactivated }: Props) {
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const handleDeactivate = async () => {
+    setLoading(true);
+    const { error } = await supabasebrowser
+      .from("agents")
+      .update({ is_active: false })
+      .eq("id", agentId);
+    setLoading(false);
+    if (error) {
+      toast.error("Erro ao desativar agente.");
+    } else {
+      toast.success("Agente desativado.");
+      setOpen(false);
+      onDeactivated();
+    }
+  };
+
+  return (
+    <Dialog.Root open={open} onOpenChange={setOpen}>
+      <Dialog.Trigger asChild>
+        <Button variant="destructive">Desativar Agente</Button>
+      </Dialog.Trigger>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/50" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 w-full max-w-sm -translate-x-1/2 -translate-y-1/2 rounded-md bg-white p-6 shadow">
+          <Dialog.Title className="mb-4 text-lg font-semibold">
+            Desativar Agente
+          </Dialog.Title>
+          <Dialog.Description className="mb-4 text-sm text-gray-600">
+            Tem certeza que deseja desativar este agente?
+          </Dialog.Description>
+          <div className="flex justify-end gap-2">
+            <Button variant="outline" onClick={() => setOpen(false)} disabled={loading}>
+              Cancelar
+            </Button>
+            <Button variant="destructive" onClick={handleDeactivate} disabled={loading}>
+              {loading ? "Desativando..." : "Desativar"}
+            </Button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+

--- a/src/app/dashboard/agents/[id]/base-conhecimento/page.tsx
+++ b/src/app/dashboard/agents/[id]/base-conhecimento/page.tsx
@@ -1,18 +1,12 @@
 "use client";
 
-import Link from "next/link";
-import { Fragment, useEffect, useRef, useState } from "react";
-import { useParams, usePathname } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
+import { useParams } from "next/navigation";
 import { supabasebrowser } from "@/lib/supabaseClient";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import {
-  Smile,
-  Settings,
-  BookOpen,
-  Database,
-  ClipboardList,
   Globe,
   FileText,
   HelpCircle,
@@ -26,6 +20,7 @@ import {
   ALLOWED_KNOWLEDGE_MIME_TYPES,
   MAX_KNOWLEDGE_FILE_SIZE,
 } from "@/lib/constants";
+import AgentMenu from "@/components/agents/AgentMenu";
 
 interface Agent {
   id: string;
@@ -45,7 +40,6 @@ interface KnowledgeFile {
 export default function AgentKnowledgeBasePage() {
   const params = useParams();
   const id = params?.id as string;
-  const pathname = usePathname();
   const [agent, setAgent] = useState<Agent | null>(null);
   const [activeSection, setActiveSection] = useState("Arquivos");
   const [search, setSearch] = useState("");
@@ -72,26 +66,6 @@ export default function AgentKnowledgeBasePage() {
   }, [id]);
 
   if (!agent) return <div>Carregando...</div>;
-
-  const menuItems = [
-    { label: "Personalidade", icon: Smile, href: `/dashboard/agents/${id}` },
-    {
-      label: "Comportamento",
-      icon: Settings,
-      href: `/dashboard/agents/${id}/comportamento`,
-    },
-    { label: "Onboarding", icon: BookOpen, href: `/dashboard/agents/${id}/onboarding` },
-    {
-      label: "Base de conhecimento",
-      icon: Database,
-      href: `/dashboard/agents/${id}/base-conhecimento`,
-    },
-    {
-      label: "Instruções Específicas",
-      icon: ClipboardList,
-      href: `/dashboard/agents/${id}/instrucoes-especificas`,
-    },
-  ];
 
   const sidebarItems = [
     { label: "Websites", icon: Globe },
@@ -188,29 +162,7 @@ export default function AgentKnowledgeBasePage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex justify-center">
-        <Card className="w-4/5 p-6">
-          <nav className="flex items-center justify-around">
-            {menuItems.map(({ label, icon: Icon, href }, index) => (
-              <Fragment key={label}>
-                <Button
-                  asChild
-                  variant={pathname === href ? "secondary" : "ghost"}
-                  className="flex h-auto flex-col items-center gap-1 text-sm"
-                >
-                  <Link href={href} className="flex flex-col items-center">
-                    <Icon className="h-5 w-5" />
-                    <span>{label}</span>
-                  </Link>
-                </Button>
-                {index < menuItems.length - 1 && (
-                  <div className="h-8 border-l" />
-                )}
-              </Fragment>
-            ))}
-          </nav>
-        </Card>
-      </div>
+      <AgentMenu agent={agent} />
 
       <div className="flex justify-center">
         <Card className="w-4/5 p-6">

--- a/src/app/dashboard/agents/[id]/comportamento/page.tsx
+++ b/src/app/dashboard/agents/[id]/comportamento/page.tsx
@@ -1,22 +1,15 @@
 "use client";
 
-import Link from "next/link";
-import { Fragment, useEffect, useState } from "react";
-import { useParams, usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
 import { supabasebrowser } from "@/lib/supabaseClient";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import {
-  Smile,
-  Settings,
-  BookOpen,
-  Database,
-  ClipboardList,
-} from "lucide-react";
 import { toast } from "sonner";
 import UpdateAgentButton from "@/components/agents/UpdateAgentButton";
+import AgentMenu from "@/components/agents/AgentMenu";
 
 type Agent = {
   id: string;
@@ -28,7 +21,6 @@ type Agent = {
 export default function AgentBehaviorPage() {
   const params = useParams();
   const id = params?.id as string;
-  const pathname = usePathname();
   const [agent, setAgent] = useState<Agent | null>(null);
   const [limitations, setLimitations] = useState("");
   const [forbiddenWords, setForbiddenWords] = useState("");
@@ -92,51 +84,9 @@ export default function AgentBehaviorPage() {
     setIsSubmitting(false);
   };
 
-  const menuItems = [
-    { label: "Personalidade", icon: Smile, href: `/dashboard/agents/${id}` },
-    {
-      label: "Comportamento",
-      icon: Settings,
-      href: `/dashboard/agents/${id}/comportamento`,
-    },
-    { label: "Onboarding", icon: BookOpen, href: `/dashboard/agents/${id}/onboarding` },
-    {
-      label: "Base de conhecimento",
-      icon: Database,
-      href: `/dashboard/agents/${id}/base-conhecimento`,
-    },
-    {
-      label: "Instruções Específicas",
-      icon: ClipboardList,
-      href: `/dashboard/agents/${id}/instrucoes-especificas`,
-    },
-  ];
-
   return (
     <div className="space-y-6">
-      <div className="flex justify-center">
-        <Card className="w-4/5 p-6">
-          <nav className="flex items-center justify-around">
-            {menuItems.map(({ label, icon: Icon, href }, index) => (
-              <Fragment key={label}>
-                <Button
-                  asChild
-                  variant={pathname === href ? "secondary" : "ghost"}
-                  className="flex h-auto flex-col items-center gap-1 text-sm"
-                >
-                  <Link href={href} className="flex flex-col items-center">
-                    <Icon className="h-5 w-5" />
-                    <span>{label}</span>
-                  </Link>
-                </Button>
-                {index < menuItems.length - 1 && (
-                  <div className="h-8 border-l" />
-                )}
-              </Fragment>
-            ))}
-          </nav>
-        </Card>
-      </div>
+      <AgentMenu agent={agent} />
       <div className="flex justify-center">
         <Card className="w-4/5 p-6">
           <form onSubmit={handleSubmit} className="space-y-6">

--- a/src/app/dashboard/agents/[id]/instrucoes-especificas/page.tsx
+++ b/src/app/dashboard/agents/[id]/instrucoes-especificas/page.tsx
@@ -1,24 +1,16 @@
 "use client";
 
-import Link from "next/link";
-import { Fragment, useEffect, useState } from "react";
-import { useParams, usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
 import { supabasebrowser } from "@/lib/supabaseClient";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import {
-  Smile,
-  Settings,
-  BookOpen,
-  Database,
-  ClipboardList,
-  Plus,
-  Trash2,
-} from "lucide-react";
+import { Plus, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import UpdateAgentButton from "@/components/agents/UpdateAgentButton";
+import AgentMenu from "@/components/agents/AgentMenu";
 
 interface Agent {
   id: string;
@@ -36,7 +28,6 @@ interface FaqItem {
 export default function AgentSpecificInstructionsPage() {
   const params = useParams();
   const id = params?.id as string;
-  const pathname = usePathname();
   const [agent, setAgent] = useState<Agent | null>(null);
   const [faqs, setFaqs] = useState<FaqItem[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -140,51 +131,9 @@ export default function AgentSpecificInstructionsPage() {
     setIsSubmitting(false);
   };
 
-  const menuItems = [
-    { label: "Personalidade", icon: Smile, href: `/dashboard/agents/${id}` },
-    {
-      label: "Comportamento",
-      icon: Settings,
-      href: `/dashboard/agents/${id}/comportamento`,
-    },
-    { label: "Onboarding", icon: BookOpen, href: `/dashboard/agents/${id}/onboarding` },
-    {
-      label: "Base de conhecimento",
-      icon: Database,
-      href: `/dashboard/agents/${id}/base-conhecimento`,
-    },
-    {
-      label: "Instruções Específicas",
-      icon: ClipboardList,
-      href: `/dashboard/agents/${id}/instrucoes-especificas`,
-    },
-  ];
-
   return (
     <div className="space-y-6">
-      <div className="flex justify-center">
-        <Card className="w-4/5 p-6">
-          <nav className="flex items-center justify-around">
-            {menuItems.map(({ label, icon: Icon, href }, index) => (
-              <Fragment key={label}>
-                <Button
-                  asChild
-                  variant={pathname === href ? "secondary" : "ghost"}
-                  className="flex h-auto flex-col items-center gap-1 text-sm"
-                >
-                  <Link href={href} className="flex flex-col items-center">
-                    <Icon className="h-5 w-5" />
-                    <span>{label}</span>
-                  </Link>
-                </Button>
-                {index < menuItems.length - 1 && (
-                  <div className="h-8 border-l" />
-                )}
-              </Fragment>
-            ))}
-          </nav>
-        </Card>
-      </div>
+      <AgentMenu agent={agent} />
       <div className="flex justify-center">
         <Card className="w-4/5 p-6">
           <form onSubmit={handleSubmit} className="space-y-6">

--- a/src/app/dashboard/agents/[id]/onboarding/page.tsx
+++ b/src/app/dashboard/agents/[id]/onboarding/page.tsx
@@ -1,22 +1,15 @@
 "use client";
 
-import Link from "next/link";
-import { Fragment, useEffect, useState } from "react";
-import { useParams, usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
 import { supabasebrowser } from "@/lib/supabaseClient";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import {
-  Smile,
-  Settings,
-  BookOpen,
-  Database,
-  ClipboardList,
-} from "lucide-react";
 import { toast } from "sonner";
 import UpdateAgentButton from "@/components/agents/UpdateAgentButton";
+import AgentMenu from "@/components/agents/AgentMenu";
 
 type Agent = {
   id: string;
@@ -33,7 +26,6 @@ type CollectionItem = {
 export default function AgentOnboardingPage() {
   const params = useParams();
   const id = params?.id as string;
-  const pathname = usePathname();
   const [agent, setAgent] = useState<Agent | null>(null);
   const [welcomeMessage, setWelcomeMessage] = useState("");
   const [collection, setCollection] = useState<CollectionItem[]>([
@@ -147,51 +139,9 @@ export default function AgentOnboardingPage() {
     setIsSubmitting(false);
   };
 
-  const menuItems = [
-    { label: "Personalidade", icon: Smile, href: `/dashboard/agents/${id}` },
-    {
-      label: "Comportamento",
-      icon: Settings,
-      href: `/dashboard/agents/${id}/comportamento`,
-    },
-    { label: "Onboarding", icon: BookOpen, href: `/dashboard/agents/${id}/onboarding` },
-    {
-      label: "Base de conhecimento",
-      icon: Database,
-      href: `/dashboard/agents/${id}/base-conhecimento`,
-    },
-    {
-      label: "Instruções Específicas",
-      icon: ClipboardList,
-      href: `/dashboard/agents/${id}/instrucoes-especificas`,
-    },
-  ];
-
   return (
     <div className="space-y-6">
-      <div className="flex justify-center">
-        <Card className="w-4/5 p-6">
-          <nav className="flex items-center justify-around">
-            {menuItems.map(({ label, icon: Icon, href }, index) => (
-              <Fragment key={label}>
-                <Button
-                  asChild
-                  variant={pathname === href ? "secondary" : "ghost"}
-                  className="flex h-auto flex-col items-center gap-1 text-sm"
-                >
-                  <Link href={href} className="flex flex-col items-center">
-                    <Icon className="h-5 w-5" />
-                    <span>{label}</span>
-                  </Link>
-                </Button>
-                {index < menuItems.length - 1 && (
-                  <div className="h-8 border-l" />
-                )}
-              </Fragment>
-            ))}
-          </nav>
-        </Card>
-      </div>
+      <AgentMenu agent={agent} />
       <div className="flex justify-center">
         <Card className="w-4/5 p-6">
           <form onSubmit={handleSubmit} className="space-y-6">

--- a/src/app/dashboard/agents/[id]/page.tsx
+++ b/src/app/dashboard/agents/[id]/page.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import Link from "next/link";
-import { Fragment, useEffect, useState } from "react";
-import { useParams, usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
 import { supabasebrowser } from "@/lib/supabaseClient";
 import { isValidAgentName } from "@/lib/validators";
 import { Button } from "@/components/ui/button";
@@ -16,15 +15,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import {
-  Smile,
-  Settings,
-  BookOpen,
-  Database,
-  ClipboardList,
-} from "lucide-react";
 import { toast } from "sonner";
 import UpdateAgentButton from "@/components/agents/UpdateAgentButton";
+import AgentMenu from "@/components/agents/AgentMenu";
 
 type Agent = {
   id: string;
@@ -36,7 +29,6 @@ type Agent = {
 export default function AgentDetailPage() {
   const params = useParams();
   const id = params?.id as string;
-  const pathname = usePathname();
   const [agent, setAgent] = useState<Agent | null>(null);
   const [name, setName] = useState("");
   const [tone, setTone] = useState("");
@@ -105,51 +97,9 @@ export default function AgentDetailPage() {
     setIsSubmitting(false);
   };
 
-  const menuItems = [
-    { label: "Personalidade", icon: Smile, href: `/dashboard/agents/${id}` },
-    {
-      label: "Comportamento",
-      icon: Settings,
-      href: `/dashboard/agents/${id}/comportamento`,
-    },
-    { label: "Onboarding", icon: BookOpen, href: `/dashboard/agents/${id}/onboarding` },
-    {
-      label: "Base de conhecimento",
-      icon: Database,
-      href: `/dashboard/agents/${id}/base-conhecimento`,
-    },
-    {
-      label: "Instruções Específicas",
-      icon: ClipboardList,
-      href: `/dashboard/agents/${id}/instrucoes-especificas`,
-    },
-  ];
-
   return (
     <div className="space-y-6">
-      <div className="flex justify-center">
-        <Card className="w-4/5 p-6">
-          <nav className="flex items-center justify-around">
-            {menuItems.map(({ label, icon: Icon, href }, index) => (
-              <Fragment key={label}>
-                <Button
-                  asChild
-                  variant={pathname === href ? "secondary" : "ghost"}
-                  className="flex h-auto flex-col items-center gap-1 text-sm"
-                >
-                  <Link href={href} className="flex flex-col items-center">
-                    <Icon className="h-5 w-5" />
-                    <span>{label}</span>
-                  </Link>
-                </Button>
-                {index < menuItems.length - 1 && (
-                  <div className="h-8 border-l" />
-                )}
-              </Fragment>
-            ))}
-          </nav>
-        </Card>
-      </div>
+      <AgentMenu agent={agent} />
       <div className="flex justify-center">
         <Card className="w-4/5 p-6">
           <form onSubmit={handleSubmit} className="space-y-6">


### PR DESCRIPTION
## Summary
- show agent status and last payment in edit screens
- allow disabling active agents via confirmation dialog

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b96035dd0832fa4847c5283312578