### PR TITLE
Show pending payment due date in AgentMenu

### DIFF
--- a/components/agents/AgentMenu.tsx
+++ b/components/agents/AgentMenu.tsx
@@ -30,9 +30,10 @@ export default function AgentMenu({ agent }: { agent: Agent }) {
       .from("payments")
       .select("due_date")
       .eq("agent_id", agent.id)
+      .eq("status", "pendente")
       .order("due_date", { ascending: false })
       .limit(1)
-      .single()
+      .maybeSingle()
       .then(({ data }) => {
         setLastPayment(data?.due_date ?? null);
       });


### PR DESCRIPTION
## Summary
- fetch latest pending payment for agent in menu

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ba01be034832fbe64a0ad9a654069