### PR TITLE
feat: reduce agent status block width

### DIFF
--- a/components/agents/AgentMenu.tsx
+++ b/components/agents/AgentMenu.tsx
@@ -50,7 +50,7 @@ export default function AgentMenu({ agent }: { agent: Agent }) {
   return (
     <div className="flex justify-center">
       <div className="w-4/5 flex gap-4">
-        <Card className="w-64 p-4 flex flex-col items-center justify-center gap-3 text-sm text-center">
+        <Card className="w-52 p-4 flex flex-col items-center justify-center gap-3 text-sm text-center">
           <div>
             <p className="text-xs text-gray-500">Status do agente</p>
             <p className={`text-base font-semibold ${agent.is_active ? "text-green-600" : "text-red-600"}`}>


### PR DESCRIPTION
## Summary
- shrink agent status card width by ~20%

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bf2f0af7c832f9aa32b33147d2741