### PR TITLE
Disable agendamento model on new agent form

### DIFF
--- a/components/agents/AgentTypeCard.tsx
+++ b/components/agents/AgentTypeCard.tsx
@@ -6,6 +6,7 @@ interface AgentTypeCardProps {
   title: string;
   description: string;
   selected: boolean;
+  disabled?: boolean;
   onSelect: (value: string) => void;
 }
 
@@ -14,17 +15,30 @@ export function AgentTypeCard({
   title,
   description,
   selected,
+  disabled,
   onSelect,
 }: AgentTypeCardProps) {
   return (
     <Card
-      onClick={() => onSelect(value)}
+      onClick={() => !disabled && onSelect(value)}
       className={cn(
-        "cursor-pointer", 
-        selected ? "border-2 border-primary" : "hover:border-primary"
+        "relative cursor-pointer",
+        disabled
+          ? "cursor-not-allowed"
+          : selected
+          ? "border-2 border-primary"
+          : "hover:border-primary"
       )}
     >
-      <CardHeader className="px-3 py-2">
+      {disabled && (
+        <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+          <span className="bg-blue-100 text-blue-800 text-xs font-semibold px-2 py-1 rounded">
+            Em breve
+          </span>
+        </div>
+      )}
+      <CardHeader className={cn("px-3 py-2", disabled && "opacity-50 select-none")}
+      >
         <CardTitle className="text-sm font-medium">{title}</CardTitle>
         <CardDescription className="text-xs text-gray-600">
           {description}

--- a/src/app/dashboard/agents/new/page.tsx
+++ b/src/app/dashboard/agents/new/page.tsx
@@ -31,6 +31,7 @@ export default function NewAgentPage() {
       value: "agendamento",
       title: "Agendamento",
       description: "Gerencia horários e calendários",
+      disabled: true,
     },
     {
       value: "sdr",
@@ -115,7 +116,7 @@ export default function NewAgentPage() {
 
             <CardContent className="space-y-6">
               <div className="space-y-2">
-                <label className="text-sm font-medium">Função do Agente</label>
+                <label className="text-sm font-medium">Modelo do Agente</label>
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
                   {agentTypes.map((option) => (
                     <AgentTypeCard
@@ -123,6 +124,7 @@ export default function NewAgentPage() {
                       value={option.value}
                       title={option.title}
                       description={option.description}
+                      disabled={option.disabled}
                       selected={type === option.value}
                       onSelect={setType}
                     />


### PR DESCRIPTION
## Summary
- rename agent function label to "Modelo do Agente"
- disable agendamento model and display "Em breve" badge

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bf49e51cc832fb5a368372cf012b1