### PR TITLE
chore: add metadata to home page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,33 @@ import Testimonials from "@/components/landing/Testimonials";
 import FAQ from "@/components/landing/FAQ";
 import FinalCTA from "@/components/landing/FinalCTA";
 import Footer from "@/components/landing/Footer";
+import type { Metadata } from "next";
+
+const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+
+export const metadata: Metadata = {
+  metadataBase: new URL(baseUrl),
+  alternates: {
+    canonical: "/",
+  },
+  title: "Agent Plug and Play",
+  description:
+    "Centralize conversas, gerencie clientes e otimize processos com ferramentas inteligentes.",
+  openGraph: {
+    title: "Agent Plug and Play",
+    description:
+      "Centralize conversas, gerencie clientes e otimize processos com ferramentas inteligentes.",
+    url: baseUrl,
+    siteName: "Agent Plug and Play",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Agent Plug and Play",
+    description:
+      "Centralize conversas, gerencie clientes e otimize processos com ferramentas inteligentes.",
+  },
+};
 
 export default function HomePage() {
   return (


### PR DESCRIPTION
## Summary
- add SEO metadata for home page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c7c956adc832fbb9250ba19ba8443