### PR TITLE
Redirect to payment page after agent update billing creation

### DIFF
--- a/components/agents/UpdateAgentButton.tsx
+++ b/components/agents/UpdateAgentButton.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
 import { supabasebrowser } from "@/lib/supabaseClient";
+import { useRouter } from "next/navigation";
 
 interface UpdateAgentButtonProps {
   agentId: string;
@@ -16,6 +17,7 @@ export default function UpdateAgentButton({ agentId }: UpdateAgentButtonProps) {
   const [remaining, setRemaining] = useState(0);
   const [isProcessing, setIsProcessing] = useState(false);
   const processingRef = useRef(false);
+  const router = useRouter();
 
   useEffect(() => {
     const last = localStorage.getItem(`agent-update-${agentId}`);
@@ -66,11 +68,15 @@ export default function UpdateAgentButton({ agentId }: UpdateAgentButtonProps) {
         body: JSON.stringify({ agentId }),
       });
       if (!res.ok) throw new Error();
+      const data = await res.json();
 
       toast.success("Agente atualizado com sucesso.");
       localStorage.setItem(`agent-update-${agentId}`, Date.now().toString());
       setIsCooldown(true);
       setRemaining(COOLDOWN_MS / 1000);
+      if (data.paymentId) {
+        router.push(`/dashboard/payments/${data.paymentId}`);
+      }
     } catch {
       toast.error("Erro ao atualizar agente.");
     } finally {

--- a/src/app/api/agents/update/route.ts
+++ b/src/app/api/agents/update/route.ts
@@ -58,7 +58,7 @@ export async function POST(request: Request) {
   if (!existing || existing.length === 0) {
     const dueDate = new Date();
     dueDate.setMonth(dueDate.getMonth() + 1);
-    const { error: insertError } = await supabaseadmin
+    const { data: inserted, error: insertError } = await supabaseadmin
       .from('payments')
       .insert({
         company_id: company.id,
@@ -66,10 +66,13 @@ export async function POST(request: Request) {
         amount: AGENT_UPDATE_FEE,
         due_date: dueDate.toISOString(),
         reference: `Mensalidade ${agent.name}`,
-      });
-    if (insertError) {
+      })
+      .select('id')
+      .single();
+    if (insertError || !inserted) {
       return NextResponse.json({ error: 'Failed to create payment' }, { status: 500 });
     }
+    return NextResponse.json({ success: true, paymentId: inserted.id });
   }
 
   return NextResponse.json({ success: true });


### PR DESCRIPTION
## Summary
- Redirect user to new payment when agent update triggers billing
- Return created payment ID from agent update API

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c91e9a4fc832f9c6d1ba5faaa97ed