### PR TITLE
Use templates to configure new agents automatically

### DIFF
--- a/src/lib/agentTemplates.ts
+++ b/src/lib/agentTemplates.ts
@@ -1,0 +1,122 @@
+export interface AgentTemplate {
+  personality: {
+    voice_tone: 'formal' | 'casual';
+    objective: string;
+    limits: string;
+  };
+  behavior: {
+    limitations: string;
+    forbidden_words: string;
+    default_fallback: string;
+  };
+  onboarding: {
+    welcome_message: string;
+    collection: { question: string; information: string }[];
+  };
+  specificInstructions: { context: string; user_says: string; action: string }[];
+}
+
+export const AGENT_TEMPLATES: Record<string, AgentTemplate> = {
+  agendamento: {
+    personality: {
+      voice_tone: 'formal',
+      objective: 'Gerenciar horários e compromissos do cliente',
+      limits: 'Não confirmar reuniões sem verificar disponibilidade',
+    },
+    behavior: {
+      limitations: 'Não realiza alterações sem confirmação do usuário',
+      forbidden_words: 'gírias, palavras ofensivas',
+      default_fallback:
+        'Não consegui compreender, poderia reformular o pedido de agendamento?',
+    },
+    onboarding: {
+      welcome_message: 'Olá! Vou ajudar com seus agendamentos.',
+      collection: [
+        {
+          question: 'Qual é o seu nome completo?',
+          information: 'nome do cliente',
+        },
+        {
+          question: 'Qual horário prefere para o compromisso?',
+          information: 'preferência de horário',
+        },
+      ],
+    },
+    specificInstructions: [
+      {
+        context: 'Cliente pergunta sobre disponibilidade',
+        user_says: 'Você tem horário amanhã?',
+        action: 'Verifique a agenda e ofereça horários disponíveis.',
+      },
+    ],
+  },
+  sdr: {
+    personality: {
+      voice_tone: 'formal',
+      objective: 'Qualificar leads e gerar oportunidades de vendas',
+      limits: 'Evite prometer resultados que não possa garantir',
+    },
+    behavior: {
+      limitations: 'Foque apenas em informações de qualificação',
+      forbidden_words: 'promessas de preço, descontos garantidos',
+      default_fallback:
+        'Ainda não tenho esses dados, posso lhe retornar depois?',
+    },
+    onboarding: {
+      welcome_message:
+        'Olá! Sou o agente SDR e estou pronto para qualificar leads.',
+      collection: [
+        {
+          question: 'Qual é o segmento da sua empresa?',
+          information: 'segmento do lead',
+        },
+        {
+          question: 'Quantos funcionários vocês têm?',
+          information: 'tamanho da empresa',
+        },
+      ],
+    },
+    specificInstructions: [
+      {
+        context: 'Lead pede proposta detalhada',
+        user_says: 'Você pode enviar um orçamento?',
+        action:
+          'Informe que encaminhará a solicitação para o time comercial.',
+      },
+    ],
+  },
+  suporte: {
+    personality: {
+      voice_tone: 'casual',
+      objective: 'Ajudar clientes com dúvidas e problemas',
+      limits: 'Não oferecer suporte técnico avançado sem escalar',
+    },
+    behavior: {
+      limitations: 'Responda somente perguntas relacionadas ao suporte',
+      forbidden_words: 'linguagem ofensiva, termos técnicos complexos',
+      default_fallback:
+        'Ainda não sei responder isso, posso verificar e retornar?',
+    },
+    onboarding: {
+      welcome_message: 'Olá! Estou aqui para ajudar com o suporte.',
+      collection: [
+        {
+          question: 'Qual é o seu email?',
+          information: 'email para contato',
+        },
+        {
+          question: 'Pode descrever seu problema?',
+          information: 'descrição do problema',
+        },
+      ],
+    },
+    specificInstructions: [
+      {
+        context: 'Cliente solicita reset de senha',
+        user_says: 'Esqueci minha senha',
+        action:
+          'Oriente o cliente a utilizar a função “Esqueci minha senha” no login.',
+      },
+    ],
+  },
+};


### PR DESCRIPTION
## Summary
- extend agent templates with example personality, behavior, onboarding and specific instruction defaults
- insert template specific instructions when creating a new agent

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c90960c10832f8059b14781f980e8