### PR TITLE
Add estorno status for payments

### DIFF
--- a/migration.sql
+++ b/migration.sql
@@ -31,6 +31,9 @@ create table public.company (
   constraint company_profile_id_fkey foreign KEY (company_profile_id) references company_profile (id)
 ) TABLESPACE pg_default;
 
+-- Enum para status de pagamento
+create type public.status_payment as enum ('pendente', 'pago', 'estorno');
+
 -- Cria tabela de pagamentos
 create table public.payments (
   id uuid not null default gen_random_uuid (),

--- a/src/app/api/agents/update/route.ts
+++ b/src/app/api/agents/update/route.ts
@@ -48,7 +48,7 @@ export async function POST(request: Request) {
     .from('payments')
     .select('id')
     .eq('agent_id', agentId)
-    .neq('status', 'pago')
+    .eq('status', 'pendente')
     .limit(1);
 
   if (paymentError) {

--- a/src/app/dashboard/payments/[id]/page.tsx
+++ b/src/app/dashboard/payments/[id]/page.tsx
@@ -17,7 +17,7 @@ interface Payment {
     amount: number;
     usage: number;
     created_at: string;
-    status: "pendente" | "pago";
+    status: "pendente" | "pago" | "estorno";
     payment_link: string | null;
 }
 
@@ -131,6 +131,18 @@ export default function PaymentPage() {
                 </CardHeader>
                 <CardContent>
                     O pagamento de <strong>{payment.reference}</strong> já foi processado.
+                </CardContent>
+            </Card>
+        );
+    }
+      if (payment.status === "estorno") {
+          return (
+            <Card className="max-w-md mx-auto mt-10">
+                <CardHeader>
+                    <CardTitle>Pagamento estornado</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    O pagamento de <strong>{payment.reference}</strong> foi estornado.
                 </CardContent>
             </Card>
         );

--- a/src/app/dashboard/payments/page.tsx
+++ b/src/app/dashboard/payments/page.tsx
@@ -10,7 +10,7 @@ import { toast } from "sonner";
 type Payment = {
   id: string;
   amount: number;
-  status: 'pendente' | 'pago';
+  status: 'pendente' | 'pago' | 'estorno';
   created_at: string;
   due_date: string;
   reference: string;
@@ -104,6 +104,10 @@ export default function PaymentsPage() {
                     {p.status === "pago" ? (
                       <span className="px-2 py-1 text-xs font-semibold rounded-full bg-green-100 text-green-800">
                         Quitado
+                      </span>
+                    ) : p.status === "estorno" ? (
+                      <span className="px-2 py-1 text-xs font-semibold rounded-full bg-red-100 text-red-800">
+                        Estornado
                       </span>
                     ) : (
                       <button


### PR DESCRIPTION
## Summary
- add `estorno` to `status_payment` enum in migration
- update payment pages to display `estorno` status
- check only pending payments when creating agent charges

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d092037d8832fb6abb39ea7c534a7