### PR TITLE
feat: add agent activation button

### DIFF
--- a/components/agents/ActivateAgentButton.tsx
+++ b/components/agents/ActivateAgentButton.tsx
@@ -38,7 +38,12 @@ export default function ActivateAgentButton({ agentId, onActivated }: Props) {
       return;
     }
 
-    if (new Date(payment.due_date) < new Date()) {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const dueDate = new Date(payment.due_date);
+    dueDate.setHours(0, 0, 0, 0);
+
+    if (dueDate < today) {
       toast.error(
         "Pagamento pendente vencido. Não é possível ativar o agente."
       );

--- a/components/agents/ActivateAgentButton.tsx
+++ b/components/agents/ActivateAgentButton.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { supabasebrowser } from "@/lib/supabaseClient";
+import { toast } from "sonner";
+
+interface Props {
+  agentId: string;
+  onActivated: () => void;
+}
+
+export default function ActivateAgentButton({ agentId, onActivated }: Props) {
+  const [loading, setLoading] = useState(false);
+
+  const handleActivate = async () => {
+    setLoading(true);
+    const { data: payment, error: paymentError } = await supabasebrowser
+      .from("payments")
+      .select("due_date")
+      .eq("agent_id", agentId)
+      .eq("status", "pendente")
+      .order("due_date", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (paymentError) {
+      toast.error("Erro ao verificar pagamentos.");
+      setLoading(false);
+      return;
+    }
+
+    if (!payment) {
+      toast.error(
+        "Primeiramente é necessário atualizar o agente de IA."
+      );
+      setLoading(false);
+      return;
+    }
+
+    if (new Date(payment.due_date) < new Date()) {
+      toast.error(
+        "Pagamento pendente vencido. Não é possível ativar o agente."
+      );
+      setLoading(false);
+      return;
+    }
+
+    const { error } = await supabasebrowser
+      .from("agents")
+      .update({ is_active: true })
+      .eq("id", agentId);
+    setLoading(false);
+    if (error) {
+      toast.error("Erro ao ativar agente.");
+    } else {
+      toast.success("Agente ativado.");
+      onActivated();
+    }
+  };
+
+  return (
+    <Button variant="outline" onClick={handleActivate} disabled={loading}>
+      {loading ? "Ativando..." : "Ativar Agente"}
+    </Button>
+  );
+}
+

--- a/src/app/dashboard/agents/[id]/base-conhecimento/page.tsx
+++ b/src/app/dashboard/agents/[id]/base-conhecimento/page.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/lib/constants";
 import AgentMenu from "@/components/agents/AgentMenu";
 import DeactivateAgentButton from "@/components/agents/DeactivateAgentButton";
+import ActivateAgentButton from "@/components/agents/ActivateAgentButton";
 
 interface Agent {
   id: string;
@@ -253,11 +254,18 @@ export default function AgentKnowledgeBasePage() {
       </div>
       <div className="flex justify-center">
         <div className="w-4/5 flex justify-end gap-2">
-          {agent.is_active && (
+          {agent.is_active ? (
             <DeactivateAgentButton
               agentId={id}
               onDeactivated={() =>
                 setAgent((a) => (a ? { ...a, is_active: false } : a))
+              }
+            />
+          ) : (
+            <ActivateAgentButton
+              agentId={id}
+              onActivated={() =>
+                setAgent((a) => (a ? { ...a, is_active: true } : a))
               }
             />
           )}

--- a/src/app/dashboard/agents/[id]/comportamento/page.tsx
+++ b/src/app/dashboard/agents/[id]/comportamento/page.tsx
@@ -11,6 +11,7 @@ import { toast } from "sonner";
 import UpdateAgentButton from "@/components/agents/UpdateAgentButton";
 import AgentMenu from "@/components/agents/AgentMenu";
 import DeactivateAgentButton from "@/components/agents/DeactivateAgentButton";
+import ActivateAgentButton from "@/components/agents/ActivateAgentButton";
 
 type Agent = {
   id: string;
@@ -167,11 +168,18 @@ export default function AgentBehaviorPage() {
       </div>
       <div className="flex justify-center">
         <div className="w-4/5 flex justify-end gap-2">
-          {agent.is_active && (
+          {agent.is_active ? (
             <DeactivateAgentButton
               agentId={id}
               onDeactivated={() =>
                 setAgent((a) => (a ? { ...a, is_active: false } : a))
+              }
+            />
+          ) : (
+            <ActivateAgentButton
+              agentId={id}
+              onActivated={() =>
+                setAgent((a) => (a ? { ...a, is_active: true } : a))
               }
             />
           )}

--- a/src/app/dashboard/agents/[id]/instrucoes-especificas/page.tsx
+++ b/src/app/dashboard/agents/[id]/instrucoes-especificas/page.tsx
@@ -12,6 +12,7 @@ import { toast } from "sonner";
 import UpdateAgentButton from "@/components/agents/UpdateAgentButton";
 import AgentMenu from "@/components/agents/AgentMenu";
 import DeactivateAgentButton from "@/components/agents/DeactivateAgentButton";
+import ActivateAgentButton from "@/components/agents/ActivateAgentButton";
 
 interface Agent {
   id: string;
@@ -274,11 +275,18 @@ export default function AgentSpecificInstructionsPage() {
       </div>
       <div className="flex justify-center">
         <div className="w-4/5 flex justify-end gap-2">
-          {agent.is_active && (
+          {agent.is_active ? (
             <DeactivateAgentButton
               agentId={id}
               onDeactivated={() =>
                 setAgent((a) => (a ? { ...a, is_active: false } : a))
+              }
+            />
+          ) : (
+            <ActivateAgentButton
+              agentId={id}
+              onActivated={() =>
+                setAgent((a) => (a ? { ...a, is_active: true } : a))
               }
             />
           )}

--- a/src/app/dashboard/agents/[id]/onboarding/page.tsx
+++ b/src/app/dashboard/agents/[id]/onboarding/page.tsx
@@ -11,6 +11,7 @@ import { toast } from "sonner";
 import UpdateAgentButton from "@/components/agents/UpdateAgentButton";
 import AgentMenu from "@/components/agents/AgentMenu";
 import DeactivateAgentButton from "@/components/agents/DeactivateAgentButton";
+import ActivateAgentButton from "@/components/agents/ActivateAgentButton";
 
 type Agent = {
   id: string;
@@ -233,11 +234,18 @@ export default function AgentOnboardingPage() {
       </div>
       <div className="flex justify-center">
         <div className="w-4/5 flex justify-end gap-2">
-          {agent.is_active && (
+          {agent.is_active ? (
             <DeactivateAgentButton
               agentId={id}
               onDeactivated={() =>
                 setAgent((a) => (a ? { ...a, is_active: false } : a))
+              }
+            />
+          ) : (
+            <ActivateAgentButton
+              agentId={id}
+              onActivated={() =>
+                setAgent((a) => (a ? { ...a, is_active: true } : a))
               }
             />
           )}

--- a/src/app/dashboard/agents/[id]/page.tsx
+++ b/src/app/dashboard/agents/[id]/page.tsx
@@ -19,6 +19,7 @@ import { toast } from "sonner";
 import UpdateAgentButton from "@/components/agents/UpdateAgentButton";
 import AgentMenu from "@/components/agents/AgentMenu";
 import DeactivateAgentButton from "@/components/agents/DeactivateAgentButton";
+import ActivateAgentButton from "@/components/agents/ActivateAgentButton";
 
 type Agent = {
   id: string;
@@ -188,11 +189,18 @@ export default function AgentDetailPage() {
       </div>
       <div className="flex justify-center">
         <div className="w-4/5 flex justify-end gap-2">
-          {agent.is_active && (
+          {agent.is_active ? (
             <DeactivateAgentButton
               agentId={id}
               onDeactivated={() =>
                 setAgent((a) => (a ? { ...a, is_active: false } : a))
+              }
+            />
+          ) : (
+            <ActivateAgentButton
+              agentId={id}
+              onActivated={() =>
+                setAgent((a) => (a ? { ...a, is_active: true } : a))
               }
             />
           )}


### PR DESCRIPTION
## Summary
- add activation button for agents with pending payment validation
- show activate button when agent is inactive in all edit screens

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d40e24e9c832f8906197b6987ce76