### PR TITLE
feat: add password input component

### DIFF
--- a/components/ui/password-input.tsx
+++ b/components/ui/password-input.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Eye, EyeOff } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+type PasswordInputProps = React.ComponentProps<typeof Input>;
+
+function PasswordInput({ className, ...props }: PasswordInputProps) {
+  const [visible, setVisible] = useState(false);
+
+  return (
+    <div className="relative">
+      <Input
+        type={visible ? "text" : "password"}
+        className={cn("pr-10", className)}
+        {...props}
+      />
+      <button
+        type="button"
+        onClick={() => setVisible((v) => !v)}
+        aria-label={visible ? "Esconder senha" : "Mostrar senha"}
+        className="absolute inset-y-0 right-0 flex items-center pr-3 text-muted-foreground"
+      >
+        {visible ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+      </button>
+    </div>
+  );
+}
+
+export { PasswordInput };

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { Input } from "@/components/ui/input";
+import { PasswordInput } from "@/components/ui/password-input";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
 import { supabasebrowser } from '@/lib/supabaseClient'
@@ -79,9 +80,8 @@ export default function LoginPage() {
 
         <div>
           <label htmlFor="password" className="block text-sm font-medium">Senha</label>
-          <Input
+          <PasswordInput
             id="password"
-            type="password"
             value={password}
             onChange={e => setPassword(e.target.value)}
             required

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Input } from "@/components/ui/input";
+import { PasswordInput } from "@/components/ui/password-input";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
 import {
@@ -108,9 +109,8 @@ export default function SignupPage() {
           <label htmlFor="password" className="block text-sm font-medium">
             Senha
           </label>
-          <Input
+          <PasswordInput
             id="password"
-            type="password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             required
@@ -121,9 +121,8 @@ export default function SignupPage() {
           <label htmlFor="confirm" className="block text-sm font-medium">
             Confirme a senha
           </label>
-          <Input
+          <PasswordInput
             id="confirm"
-            type="password"
             value={confirm}
             onChange={(e) => setConfirm(e.target.value)}
             required

--- a/src/app/update-password/update-password-form.tsx
+++ b/src/app/update-password/update-password-form.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { Input } from '@/components/ui/input';
+import { PasswordInput } from '@/components/ui/password-input';
 import { Button } from '@/components/ui/button';
 import { supabasebrowser } from '@/lib/supabaseClient';
 import { toast } from 'sonner';
@@ -68,9 +68,8 @@ export default function UpdatePasswordForm() {
 
         <div>
           <label htmlFor="password" className="block text-sm font-medium">Senha</label>
-          <Input
+          <PasswordInput
             id="password"
-            type="password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             required
@@ -80,9 +79,8 @@ export default function UpdatePasswordForm() {
 
         <div>
           <label htmlFor="confirm" className="block text-sm font-medium">Confirmar senha</label>
-          <Input
+          <PasswordInput
             id="confirm"
-            type="password"
             value={confirm}
             onChange={(e) => setConfirm(e.target.value)}
             required


### PR DESCRIPTION
## Summary
- add PasswordInput component with visibility toggle
- replace password fields in auth forms

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689d484435d4832f9563e49070681263