### PR TITLE
destacar modelos na landing com preço único

### DIFF
--- a/components/landing/Header.tsx
+++ b/components/landing/Header.tsx
@@ -28,8 +28,8 @@ export default function Header() {
               </Link>
             </li>
             <li>
-              <Link href="#planos" className="hover:text-primary">
-                Planos
+              <Link href="#modelos" className="hover:text-primary">
+                Modelos
               </Link>
             </li>
             <li>
@@ -78,8 +78,8 @@ export default function Header() {
             <Link href="#solucoes" onClick={() => setOpen(false)}>
               Soluções
             </Link>
-            <Link href="#planos" onClick={() => setOpen(false)}>
-              Planos
+            <Link href="#modelos" onClick={() => setOpen(false)}>
+              Modelos
             </Link>
             <Link href="#contato" onClick={() => setOpen(false)}>
               Contato

--- a/components/landing/Models.tsx
+++ b/components/landing/Models.tsx
@@ -10,45 +10,35 @@ import {
   CardFooter,
 } from "@/components/ui/card";
 
-const plans = [
+const monthlyPrice = "R$ 599/mês";
+
+const models = [
   {
     name: "Suporte Atendimento",
-    price: "R$ 599,00/mês",
-    features: ["Consulta base de conhecimento", "Responde seus clientes 24/7"],
+    description:
+      "Consulta base de conhecimento e responde seus clientes 24/7.",
   },
   {
     name: "Representante de vendas (SDR)",
-    price: "R$ 599,00/mês",
-    features: ["Todos os recursos do Básico", "CRM completo", "Kanban"],
-  },
-  {
-    name: "Enterprise",
-    price: "Sob consulta",
-    features: ["Todos do Pro", "Suporte dedicado", "Recursos avançados"],
+    description:
+      "Qualifica leads, registra interações e organiza o pipeline de vendas.",
   },
 ];
 
-export default function Pricing() {
+export default function Models() {
   return (
-    <section id="planos" className="bg-[#FAFAFA] py-24">
+    <section id="modelos" className="bg-[#FAFAFA] py-24">
       <div className="container mx-auto max-w-6xl px-4">
         <h2 className="mb-12 text-center text-3xl font-bold">Modelos prontos para uso</h2>
         <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-          {plans.map(({ name, price, features }) => (
+          {models.map(({ name, description }) => (
             <Card key={name} className="flex flex-col">
               <CardHeader>
                 <CardTitle className="text-2xl">{name}</CardTitle>
               </CardHeader>
               <CardContent className="flex-grow">
-                <p className="mb-4 text-3xl font-bold">{price}</p>
-                <ul className="space-y-2 text-sm">
-                  {features.map((feature) => (
-                    <li key={feature} className="flex items-start gap-2">
-                      <span>•</span>
-                      <span>{feature}</span>
-                    </li>
-                  ))}
-                </ul>
+                <p className="mb-4 text-sm">{description}</p>
+                <p className="text-3xl font-bold">{monthlyPrice}</p>
               </CardContent>
               <CardFooter>
                 <Link href="/signup" className="w-full">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,7 @@ import Testimonials from "@/components/landing/Testimonials";
 import FAQ from "@/components/landing/FAQ";
 import FinalCTA from "@/components/landing/FinalCTA";
 import Footer from "@/components/landing/Footer";
-import Pricing from "@/components/landing/Pricing";
+import Models from "@/components/landing/Models";
 import type { Metadata } from "next";
 
 const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
@@ -72,7 +72,7 @@ export default function HomePage() {
           reverse
           primary
         />
-        <Pricing />
+        <Models />
         <Testimonials />
         <FAQ />
         <FinalCTA />

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,10 +1,10 @@
-import Pricing from "@/components/landing/Pricing";
+import Models from "@/components/landing/Models";
 import Footer from "@/components/landing/Footer";
 
-export default function PricingPage() {
+export default function ModelsPage() {
   return (
     <main className="flex flex-col">
-      <Pricing />
+      <Models />
       <Footer />
     </main>
   );


### PR DESCRIPTION
## Summary
- replace pricing with model descriptions and R$ 599 mensal price
- update header links and pages to use Models component

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3b9b739fc832f94def6792e39690a