### PR TITLE
feat: showcase models with uniform pricing

### DIFF
--- a/components/landing/Header.tsx
+++ b/components/landing/Header.tsx
@@ -28,8 +28,8 @@ export default function Header() {
               </Link>
             </li>
             <li>
-              <Link href="#planos" className="hover:text-primary">
-                Planos
+              <Link href="#modelos" className="hover:text-primary">
+                Modelos
               </Link>
             </li>
             <li>
@@ -78,8 +78,8 @@ export default function Header() {
             <Link href="#solucoes" onClick={() => setOpen(false)}>
               Soluções
             </Link>
-            <Link href="#planos" onClick={() => setOpen(false)}>
-              Planos
+            <Link href="#modelos" onClick={() => setOpen(false)}>
+              Modelos
             </Link>
             <Link href="#contato" onClick={() => setOpen(false)}>
               Contato

--- a/components/landing/Pricing.tsx
+++ b/components/landing/Pricing.tsx
@@ -10,45 +10,40 @@ import {
   CardFooter,
 } from "@/components/ui/card";
 
-const plans = [
+const models = [
   {
     name: "Suporte Atendimento",
-    price: "R$ 599,00/mês",
-    features: ["Consulta base de conhecimento", "Responde seus clientes 24/7"],
+    description:
+      "Consulta sua base de conhecimento e responde clientes 24/7.",
   },
   {
     name: "Representante de vendas (SDR)",
-    price: "R$ 599,00/mês",
-    features: ["Todos os recursos do Básico", "CRM completo", "Kanban"],
-  },
-  {
-    name: "Enterprise",
-    price: "Sob consulta",
-    features: ["Todos do Pro", "Suporte dedicado", "Recursos avançados"],
+    description:
+      "Qualifica leads, integra-se ao CRM e organiza oportunidades no kanban.",
   },
 ];
 
+const monthlyPrice = "R$ 599/mês";
+
 export default function Pricing() {
   return (
-    <section id="planos" className="bg-[#FAFAFA] py-24">
+    <section id="modelos" className="bg-[#FAFAFA] py-24">
       <div className="container mx-auto max-w-6xl px-4">
-        <h2 className="mb-12 text-center text-3xl font-bold">Modelos prontos para uso</h2>
-        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-          {plans.map(({ name, price, features }) => (
+        <h2 className="mb-4 text-center text-3xl font-bold">
+          Modelos prontos para uso
+        </h2>
+        <p className="mb-12 text-center text-muted-foreground">
+          Cada modelo por {monthlyPrice}
+        </p>
+        <div className="grid gap-6 sm:grid-cols-2">
+          {models.map(({ name, description }) => (
             <Card key={name} className="flex flex-col">
               <CardHeader>
                 <CardTitle className="text-2xl">{name}</CardTitle>
               </CardHeader>
               <CardContent className="flex-grow">
-                <p className="mb-4 text-3xl font-bold">{price}</p>
-                <ul className="space-y-2 text-sm">
-                  {features.map((feature) => (
-                    <li key={feature} className="flex items-start gap-2">
-                      <span>•</span>
-                      <span>{feature}</span>
-                    </li>
-                  ))}
-                </ul>
+                <p className="mb-4 text-2xl font-bold">{monthlyPrice}</p>
+                <p className="text-sm text-muted-foreground">{description}</p>
               </CardContent>
               <CardFooter>
                 <Link href="/signup" className="w-full">


### PR DESCRIPTION
## Summary
- replace tiered pricing with model descriptions and unified price
- update navigation anchor to "Modelos"

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3b9b739fc832f94def6792e39690a