### PR TITLE
Display agent models with unified monthly pricing

### DIFF
--- a/components/landing/Pricing.tsx
+++ b/components/landing/Pricing.tsx
@@ -10,21 +10,16 @@ import {
   CardFooter,
 } from "@/components/ui/card";
 
-const plans = [
+const models = [
   {
     name: "Suporte Atendimento",
-    price: "R$ 599,00/mês",
-    features: ["Consulta base de conhecimento", "Responde seus clientes 24/7"],
+    description:
+      "Consulta sua base de conhecimento e responde seus clientes 24/7.",
   },
   {
     name: "Representante de vendas (SDR)",
-    price: "R$ 599,00/mês",
-    features: ["Todos os recursos do Básico", "CRM completo", "Kanban"],
-  },
-  {
-    name: "Enterprise",
-    price: "Sob consulta",
-    features: ["Todos do Pro", "Suporte dedicado", "Recursos avançados"],
+    description:
+      "Capta e qualifica leads com CRM integrado e funil em Kanban.",
   },
 ];
 
@@ -32,23 +27,18 @@ export default function Pricing() {
   return (
     <section id="planos" className="bg-[#FAFAFA] py-24">
       <div className="container mx-auto max-w-6xl px-4">
-        <h2 className="mb-12 text-center text-3xl font-bold">Modelos prontos para uso</h2>
+        <h2 className="mb-2 text-center text-3xl font-bold">Modelos prontos para uso</h2>
+        <p className="mb-12 text-center text-lg text-gray-600">
+          Todos os modelos por <span className="font-semibold">R$ 599/mês</span>
+        </p>
         <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-          {plans.map(({ name, price, features }) => (
+          {models.map(({ name, description }) => (
             <Card key={name} className="flex flex-col">
               <CardHeader>
                 <CardTitle className="text-2xl">{name}</CardTitle>
               </CardHeader>
               <CardContent className="flex-grow">
-                <p className="mb-4 text-3xl font-bold">{price}</p>
-                <ul className="space-y-2 text-sm">
-                  {features.map((feature) => (
-                    <li key={feature} className="flex items-start gap-2">
-                      <span>•</span>
-                      <span>{feature}</span>
-                    </li>
-                  ))}
-                </ul>
+                <p className="text-sm">{description}</p>
               </CardContent>
               <CardFooter>
                 <Link href="/signup" className="w-full">


### PR DESCRIPTION
## Summary
- replace pricing plans with agent model cards and descriptions
- show single monthly price of R$ 599 for all models

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3b9b739fc832f94def6792e39690a