### PR TITLE
feat: add contact page

### DIFF
--- a/components/landing/Footer.tsx
+++ b/components/landing/Footer.tsx
@@ -33,7 +33,7 @@ export default function Footer() {
                 </Link>
               </li>
               <li>
-                <Link href="#" className="hover:text-primary">
+                <Link href="/contact" className="hover:text-primary">
                   Contato
                 </Link>
               </li>
@@ -93,7 +93,7 @@ export default function Footer() {
                 </Link>
               </li>
               <li>
-                <Link href="#" className="hover:text-primary">
+                <Link href="/contact" className="hover:text-primary">
                   Contato
                 </Link>
               </li>

--- a/components/landing/Header.tsx
+++ b/components/landing/Header.tsx
@@ -33,7 +33,7 @@ export default function Header() {
               </Link>
             </li>
             <li>
-              <Link href="#contato" className="hover:text-primary">
+              <Link href="/contact" className="hover:text-primary">
                 Contato
               </Link>
             </li>
@@ -81,7 +81,7 @@ export default function Header() {
             <Link href="#modelos" onClick={() => setOpen(false)}>
               Modelos
             </Link>
-            <Link href="#contato" onClick={() => setOpen(false)}>
+            <Link href="/contact" onClick={() => setOpen(false)}>
               Contato
             </Link>
           </nav>

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -2,6 +2,13 @@ import Header from "@/components/landing/Header";
 import Footer from "@/components/landing/Footer";
 import Link from "next/link";
 import type { Metadata } from "next";
+import {
+  Building2,
+  Instagram,
+  Linkedin,
+  Mail,
+  Phone,
+} from "lucide-react";
 
 export const metadata: Metadata = {
   title: "Contato - Evoluke",
@@ -12,35 +19,76 @@ export default function ContactPage() {
   return (
     <>
       <Header />
-      <main className="flex flex-col items-center">
-        <section className="w-full max-w-[1140px] px-3 md:px-4 lg:px-6 py-12">
-          <h1 className="mb-6 text-center text-3xl font-bold">Contato</h1>
-          <ul className="space-y-4 text-center">
-            <li>CNPJ: 12.345.678/0001-90</li>
-            <li>Telefone: (11) 1234-5678</li>
-            <li>
-              Instagram: {" "}
-              <Link
-                href="https://instagram.com/evoluke"
-                className="text-primary hover:underline"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                @evoluke
-              </Link>
-            </li>
-            <li>
-              LinkedIn: {" "}
-              <Link
-                href="https://www.linkedin.com/company/evoluke"
-                className="text-primary hover:underline"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Evoluke
-              </Link>
-            </li>
-          </ul>
+      <main>
+        <section className="mx-auto w-full max-w-[1140px] px-3 py-12 md:px-4 lg:px-6">
+          <h1 className="mb-8 text-center text-3xl font-bold">Contato</h1>
+          <address className="mx-auto max-w-md space-y-6 not-italic">
+            <div className="flex items-center gap-4">
+              <Building2
+                className="h-5 w-5 text-primary"
+                aria-hidden="true"
+              />
+              <div>
+                <p className="font-semibold">CNPJ</p>
+                <p>12.345.678/0001-90</p>
+              </div>
+            </div>
+            <div className="flex items-center gap-4">
+              <Phone className="h-5 w-5 text-primary" aria-hidden="true" />
+              <div>
+                <p className="font-semibold">Telefone</p>
+                <a href="tel:+551112345678" className="hover:underline">
+                  (11) 1234-5678
+                </a>
+              </div>
+            </div>
+            <div className="flex items-center gap-4">
+              <Mail className="h-5 w-5 text-primary" aria-hidden="true" />
+              <div>
+                <p className="font-semibold">E-mail</p>
+                <Link
+                  href="mailto:contato@evoluke.com"
+                  className="text-primary hover:underline"
+                >
+                  contato@evoluke.com
+                </Link>
+              </div>
+            </div>
+            <div className="flex items-center gap-4">
+              <Instagram
+                className="h-5 w-5 text-primary"
+                aria-hidden="true"
+              />
+              <div>
+                <p className="font-semibold">Instagram</p>
+                <Link
+                  href="https://instagram.com/evoluke"
+                  className="text-primary hover:underline"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  @evoluke
+                </Link>
+              </div>
+            </div>
+            <div className="flex items-center gap-4">
+              <Linkedin
+                className="h-5 w-5 text-primary"
+                aria-hidden="true"
+              />
+              <div>
+                <p className="font-semibold">LinkedIn</p>
+                <Link
+                  href="https://www.linkedin.com/company/evoluke"
+                  className="text-primary hover:underline"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Evoluke
+                </Link>
+              </div>
+            </div>
+          </address>
         </section>
       </main>
       <Footer />

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,49 @@
+import Header from "@/components/landing/Header";
+import Footer from "@/components/landing/Footer";
+import Link from "next/link";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Contato - Evoluke",
+  description: "Informações de contato da Evoluke",
+};
+
+export default function ContactPage() {
+  return (
+    <>
+      <Header />
+      <main className="flex flex-col items-center">
+        <section className="w-full max-w-[1140px] px-3 md:px-4 lg:px-6 py-12">
+          <h1 className="mb-6 text-center text-3xl font-bold">Contato</h1>
+          <ul className="space-y-4 text-center">
+            <li>CNPJ: 12.345.678/0001-90</li>
+            <li>Telefone: (11) 1234-5678</li>
+            <li>
+              Instagram: {" "}
+              <Link
+                href="https://instagram.com/evoluke"
+                className="text-primary hover:underline"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                @evoluke
+              </Link>
+            </li>
+            <li>
+              LinkedIn: {" "}
+              <Link
+                href="https://www.linkedin.com/company/evoluke"
+                className="text-primary hover:underline"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Evoluke
+              </Link>
+            </li>
+          </ul>
+        </section>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -21,71 +21,66 @@ export default function ContactPage() {
       <Header />
       <main>
         <section className="mx-auto w-full max-w-[1140px] px-3 py-12 md:px-4 lg:px-6">
-          <h1 className="mb-8 text-center text-3xl font-bold">Contato</h1>
-          <address className="mx-auto max-w-md space-y-6 not-italic">
-            <div className="flex items-center gap-4">
-              <Building2
-                className="h-5 w-5 text-primary"
-                aria-hidden="true"
-              />
-              <div>
-                <p className="font-semibold">CNPJ</p>
-                <p>12.345.678/0001-90</p>
+          <h1 className="mb-8 text-3xl font-bold">Contato</h1>
+          <address className="grid gap-6 not-italic md:grid-cols-2">
+            <div className="space-y-6">
+              <div className="flex items-center gap-4">
+                <Building2 className="h-5 w-5 text-primary" aria-hidden="true" />
+                <div>
+                  <p className="font-semibold">CNPJ</p>
+                  <p>12.345.678/0001-90</p>
+                </div>
+              </div>
+              <div className="flex items-center gap-4">
+                <Phone className="h-5 w-5 text-primary" aria-hidden="true" />
+                <div>
+                  <p className="font-semibold">Telefone</p>
+                  <a href="tel:+551112345678" className="hover:underline">
+                    (11) 1234-5678
+                  </a>
+                </div>
+              </div>
+              <div className="flex items-center gap-4">
+                <Mail className="h-5 w-5 text-primary" aria-hidden="true" />
+                <div>
+                  <p className="font-semibold">E-mail</p>
+                  <Link
+                    href="mailto:contato@evoluke.com"
+                    className="text-primary hover:underline"
+                  >
+                    contato@evoluke.com
+                  </Link>
+                </div>
               </div>
             </div>
-            <div className="flex items-center gap-4">
-              <Phone className="h-5 w-5 text-primary" aria-hidden="true" />
-              <div>
-                <p className="font-semibold">Telefone</p>
-                <a href="tel:+551112345678" className="hover:underline">
-                  (11) 1234-5678
-                </a>
+            <div className="space-y-6">
+              <div className="flex items-center gap-4">
+                <Instagram className="h-5 w-5 text-primary" aria-hidden="true" />
+                <div>
+                  <p className="font-semibold">Instagram</p>
+                  <Link
+                    href="https://instagram.com/evoluke"
+                    className="text-primary hover:underline"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    @evoluke
+                  </Link>
+                </div>
               </div>
-            </div>
-            <div className="flex items-center gap-4">
-              <Mail className="h-5 w-5 text-primary" aria-hidden="true" />
-              <div>
-                <p className="font-semibold">E-mail</p>
-                <Link
-                  href="mailto:contato@evoluke.com"
-                  className="text-primary hover:underline"
-                >
-                  contato@evoluke.com
-                </Link>
-              </div>
-            </div>
-            <div className="flex items-center gap-4">
-              <Instagram
-                className="h-5 w-5 text-primary"
-                aria-hidden="true"
-              />
-              <div>
-                <p className="font-semibold">Instagram</p>
-                <Link
-                  href="https://instagram.com/evoluke"
-                  className="text-primary hover:underline"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  @evoluke
-                </Link>
-              </div>
-            </div>
-            <div className="flex items-center gap-4">
-              <Linkedin
-                className="h-5 w-5 text-primary"
-                aria-hidden="true"
-              />
-              <div>
-                <p className="font-semibold">LinkedIn</p>
-                <Link
-                  href="https://www.linkedin.com/company/evoluke"
-                  className="text-primary hover:underline"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Evoluke
-                </Link>
+              <div className="flex items-center gap-4">
+                <Linkedin className="h-5 w-5 text-primary" aria-hidden="true" />
+                <div>
+                  <p className="font-semibold">LinkedIn</p>
+                  <Link
+                    href="https://www.linkedin.com/company/evoluke"
+                    className="text-primary hover:underline"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Evoluke
+                  </Link>
+                </div>
               </div>
             </div>
           </address>


### PR DESCRIPTION
## Summary
- add simple contact page with company info
- link header and footer navigation to new contact page

## Testing
- `npm run lint`
- `npm run build` (fails: Failed to collect page data for /api/profile/complete)


------
https://chatgpt.com/codex/tasks/task_e_68a47f3d6aa4832f81655fcaf1856add