### PR TITLE
feat: add about page

### DIFF
--- a/components/landing/Footer.tsx
+++ b/components/landing/Footer.tsx
@@ -13,7 +13,7 @@ export default function Footer() {
             <Image src="/logo.svg" alt="Logo" width={120} height={32} />
             <ul className="space-y-2">
               <li>
-                <Link href="#" className="hover:text-primary">
+                <Link href="/sobre-nos" className="hover:text-primary">
                   Sobre nós
                 </Link>
               </li>

--- a/src/app/sobre-nos/page.tsx
+++ b/src/app/sobre-nos/page.tsx
@@ -1,0 +1,30 @@
+import Header from "@/components/landing/Header";
+import Footer from "@/components/landing/Footer";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Sobre Nós - Evoluke",
+  description:
+    "Saiba mais sobre a Evoluke e nossa missão de transformar o atendimento com tecnologia.",
+};
+
+export default function AboutPage() {
+  return (
+    <>
+      <Header />
+      <main className="mx-auto max-w-2xl px-4 py-16">
+        <h1 className="mb-4 text-3xl font-bold">Sobre Nós</h1>
+        <p className="mb-4">
+          A Evoluke oferece soluções de CRM integradas com inteligência
+          artificial para personalizar atendimentos e automatizar processos.
+        </p>
+        <p>
+          Nosso objetivo é ajudar empresas a construir relacionamentos mais
+          eficientes e humanizados por meio de tecnologia acessível.
+        </p>
+      </main>
+      <Footer />
+    </>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add "Sobre Nós" page with company overview
- link footer navigation to the new page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a47f5c1798832fafd3e31d06fed5a2