### PR TITLE
feat: add LGPD privacy policy page

### DIFF
--- a/components/landing/Footer.tsx
+++ b/components/landing/Footer.tsx
@@ -88,7 +88,7 @@ export default function Footer() {
                 </Link>
               </li>
               <li>
-                <Link href="#" className="hover:text-primary">
+                <Link href="/privacy" className="hover:text-primary">
                   Privacidade
                 </Link>
               </li>
@@ -112,7 +112,7 @@ export default function Footer() {
         <div className="mx-auto flex max-w-[1140px] flex-col items-center gap-2 px-3 md:flex-row md:justify-between md:px-4 lg:px-6 py-4 text-muted-foreground">
           <p>© {year} Evoluke. Todos os direitos reservados.</p>
           <div className="flex gap-4">
-            <Link href="#" className="hover:text-primary">
+            <Link href="/privacy" className="hover:text-primary">
               Privacidade
             </Link>
             <Link href="#" className="hover:text-primary">

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,70 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Política de Privacidade",
+  description:
+    "Entenda como tratamos seus dados pessoais de acordo com a Lei Geral de Proteção de Dados (LGPD).",
+  alternates: {
+    canonical: "/privacy",
+  },
+};
+
+export default function PrivacyPage() {
+  return (
+    <main className="mx-auto max-w-3xl px-4 py-16 space-y-8">
+      <h1 className="text-3xl font-bold">Política de Privacidade</h1>
+      <p>
+        Esta Política de Privacidade explica como a Evoluke trata dados pessoais em
+        conformidade com a Lei Geral de Proteção de Dados (Lei nº 13.709/2018 - LGPD).
+      </p>
+      <h2 className="text-2xl font-semibold">Informações que coletamos</h2>
+      <p>
+        Coletamos informações que você nos fornece voluntariamente, como nome,
+        e-mail e dados de contato. Também registramos automaticamente dados de
+        navegação, como endereço IP e ações realizadas na plataforma.
+      </p>
+      <h2 className="text-2xl font-semibold">Uso das informações</h2>
+      <p>
+        Utilizamos os dados coletados para fornecer e melhorar nossos serviços,
+        personalizar a sua experiência e cumprir obrigações legais ou
+        regulatórias.
+      </p>
+      <h2 className="text-2xl font-semibold">Compartilhamento de dados</h2>
+      <p>
+        Podemos compartilhar dados com parceiros que nos auxiliam na operação da
+        plataforma, sempre sujeitos a obrigações de confidencialidade e
+        segurança. Não comercializamos dados pessoais.
+      </p>
+      <h2 className="text-2xl font-semibold">Seus direitos</h2>
+      <p>
+        Você tem direito a confirmar a existência de tratamento, acessar,
+        corrigir, anonimizar, portar ou eliminar seus dados pessoais, além de
+        revogar consentimentos. Para exercer seus direitos, contate
+        <a href="mailto:privacidade@evoluke.com" className="text-teal-600 hover:underline">
+          privacidade@evoluke.com
+        </a>
+        .
+      </p>
+      <h2 className="text-2xl font-semibold">Segurança</h2>
+      <p>
+        Adotamos medidas técnicas e administrativas para proteger os dados
+        pessoais contra acessos não autorizados e incidentes de segurança.
+      </p>
+      <h2 className="text-2xl font-semibold">Atualizações</h2>
+      <p>
+        Esta política pode ser atualizada periodicamente. Mudanças relevantes
+        serão comunicadas por nossos canais oficiais.
+      </p>
+      <h2 className="text-2xl font-semibold">Contato</h2>
+      <p>
+        Se tiver dúvidas ou solicitações sobre esta Política de Privacidade,
+        envie um e-mail para
+        <a href="mailto:privacidade@evoluke.com" className="text-teal-600 hover:underline">
+          privacidade@evoluke.com
+        </a>
+        .
+      </p>
+    </main>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add LGPD-compliant privacy policy page
- link footer to privacy policy

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build` (fails: supabaseUrl is required)

------
https://chatgpt.com/codex/tasks/task_e_68a47f90b1dc832f986df81e58ee0d8c