### PR TITLE
feat: enhance final CTA

### DIFF
--- a/components/landing/FinalCTA.tsx
+++ b/components/landing/FinalCTA.tsx
@@ -6,12 +6,28 @@ export default function FinalCTA() {
     <section className="bg-primary/10 py-12 md:py-16 lg:py-20">
       <div className="mx-auto max-w-[1140px] px-3 md:px-4 lg:px-6 text-center">
         <h2 className="text-3xl font-bold">Pronto para transformar seu atendimento?</h2>
+        <p className="mt-2 text-lg font-medium text-primary">
+          Ative hoje e veja resultados em minutos.
+        </p>
         <p className="mb-6 text-muted-foreground">
           Experimente gratuitamente e descubra como a Evoluke pode ajudar sua empresa.
         </p>
-        <Link href="/signup">
-          <Button size="lg">Criar conta</Button>
-        </Link>
+        <div className="flex flex-col justify-center gap-4 sm:flex-row">
+          <Link href="/signup">
+            <Button
+              size="lg"
+              className="bg-gradient-to-r from-primary to-primary/80"
+            >
+              Criar conta
+            </Button>
+          </Link>
+          <Link href="/contact">
+            <Button variant="outline" size="lg">
+              Falar com especialista
+            </Button>
+          </Link>
+        </div>
+        <p className="mt-4 text-sm text-muted-foreground">Sem cartão de crédito</p>
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- add immediate-benefit subtitle and trust text
- include gradient primary button and specialist contact option

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a49ad52a48832f9aa9dabdd775eb9b