### PR TITLE
style: improve pricing visuals

### DIFF
--- a/components/landing/Pricing.tsx
+++ b/components/landing/Pricing.tsx
@@ -31,30 +31,37 @@ export default function Pricing() {
         <h2 className="mb-4 text-center text-3xl font-bold">
           Modelos prontos para uso
         </h2>
-        <p className="mb-12 text-center text-muted-foreground">
+        <p className="mb-2 text-center text-muted-foreground">
           Cada modelo por {price}
         </p>
-        <div className="grid gap-6 sm:grid-cols-2">
+        <p className="mb-12 text-center text-sm text-muted-foreground">
+          São pontos de partida prontos, mas você pode personalizar cada
+          detalhe conforme a necessidade da sua empresa.
+        </p>
+        <ul className="grid gap-6 sm:grid-cols-2" role="list">
           {models.map(({ name, description }) => (
-            <Card
-              key={name}
-              className="flex flex-col transition-shadow transition-transform hover:-translate-y-1 hover:shadow-lg"
-            >
-              <CardHeader>
-                <CardTitle className="text-2xl">{name}</CardTitle>
-              </CardHeader>
-              <CardContent className="flex-grow">
-                <p className="mb-4 text-2xl font-bold">{price}</p>
-                <p className="text-sm text-muted-foreground">{description}</p>
-              </CardContent>
-              <CardFooter>
-                <Link href="/signup" className="w-full">
-                  <Button className="w-full">Assinar</Button>
-                </Link>
-              </CardFooter>
-            </Card>
+            <li key={name} role="listitem">
+              <Card className="flex flex-col transition-transform transition-shadow hover:-translate-y-1 hover:shadow-lg">
+                <CardHeader>
+                  <CardTitle className="text-2xl">{name}</CardTitle>
+                </CardHeader>
+                <CardContent className="flex-grow">
+                  <p className="mb-4 text-2xl font-bold">{price}</p>
+                  <p className="text-sm text-muted-foreground">{description}</p>
+                </CardContent>
+                <CardFooter>
+                  <Link
+                    href="/signup"
+                    className="w-full"
+                    aria-label={`Assinar o modelo ${name}`}
+                  >
+                    <Button className="w-full">Assinar</Button>
+                  </Link>
+                </CardFooter>
+              </Card>
+            </li>
           ))}
-        </div>
+        </ul>
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- simplify pricing page to show static monthly price
- add hover lift and shadow for pricing cards

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4a53500fc832f8769033370282cc6