### PR TITLE
feat: add theme toggle

### DIFF
--- a/components/landing/Header.tsx
+++ b/components/landing/Header.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useState } from "react";
 import { Menu, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { ThemeToggle } from "@/components/ui/theme-toggle";
 
 export default function Header() {
   const [open, setOpen] = useState(false);
@@ -35,6 +36,7 @@ export default function Header() {
           </ul>
         </nav>
         <div className="hidden items-center gap-2 md:flex">
+          <ThemeToggle />
           <Link href="/login">
             <Button variant="outline" size="sm">
               Login
@@ -44,15 +46,17 @@ export default function Header() {
             <Button size="sm">Criar conta</Button>
           </Link>
         </div>
-        <Button
-          variant="outline"
-          size="icon"
-          className="md:hidden"
-          onClick={() => setOpen(true)}
-          aria-label="Abrir menu"
-        >
-          <Menu className="h-5 w-5" />
-        </Button>
+        <div className="flex items-center gap-2 md:hidden">
+          <ThemeToggle />
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={() => setOpen(true)}
+            aria-label="Abrir menu"
+          >
+            <Menu className="h-5 w-5" />
+          </Button>
+        </div>
       </div>
       {open && (
         <div className="fixed inset-0 z-50 bg-background/95 p-6 md:hidden">

--- a/components/ui/theme-toggle.tsx
+++ b/components/ui/theme-toggle.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Moon, Sun } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export function ThemeToggle() {
+  const [theme, setTheme] = useState<"light" | "dark">("light");
+
+  useEffect(() => {
+    const stored = window.localStorage.getItem("theme");
+    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+    const initial = stored ? (stored === "dark" ? "dark" : "light") : prefersDark ? "dark" : "light";
+    setTheme(initial);
+    document.documentElement.classList.toggle("dark", initial === "dark");
+  }, []);
+
+  const toggleTheme = () => {
+    const next = theme === "dark" ? "light" : "dark";
+    setTheme(next);
+    document.documentElement.classList.toggle("dark", next === "dark");
+    window.localStorage.setItem("theme", next);
+  };
+
+  return (
+    <Button variant="ghost" size="icon" onClick={toggleTheme} aria-label="Alternar tema">
+      {theme === "dark" ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
+    </Button>
+  );
+}
+

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -39,8 +39,23 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="pt-BR" className={`${inter.variable} ${geistMono.variable}`}>
+    <html
+      lang="pt-BR"
+      className={`${inter.variable} ${geistMono.variable}`}
+      suppressHydrationWarning
+    >
       <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(() => {
+  const stored = window.localStorage.getItem('theme');
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  if (stored === 'dark' || (!stored && prefersDark)) {
+    document.documentElement.classList.add('dark');
+  }
+})();`,
+          }}
+        />
         <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
       </head>
       <body className="font-sans antialiased h-full">


### PR DESCRIPTION
## Summary
- add ThemeToggle component with localStorage and system preference
- inject initial theme script into layout
- integrate theme toggle into landing header

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to collect page data for /api/profile/complete)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b242ecf8832fb7a8c94965d4e043