### PR TITLE
Add Evoluke logo to auth pages

### DIFF
--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -6,6 +6,7 @@ import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { supabasebrowser } from '@/lib/supabaseClient';
 import { toast } from 'sonner';
+import Image from 'next/image';
 
 export default function ForgotPasswordPage() {
   const [email, setEmail] = useState('');
@@ -32,6 +33,11 @@ export default function ForgotPasswordPage() {
         onSubmit={handleSubmit}
         className="max-w-md w-full bg-white rounded-lg shadow p-6 space-y-4"
       >
+        <div className="flex justify-center mb-2">
+          <Link href="/">
+            <Image src="/logo.svg" alt="Evoluke" width={120} height={32} />
+          </Link>
+        </div>
         <h1 className="text-2xl font-semibold text-center">Recuperar senha</h1>
 
         <div>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -5,6 +5,7 @@ import { Input } from "@/components/ui/input";
 import { PasswordInput } from "@/components/ui/password-input";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
+import Image from "next/image";
 import { supabasebrowser } from '@/lib/supabaseClient'
 import { useRouter } from 'next/navigation'
 import { toast } from "sonner";
@@ -71,6 +72,11 @@ export default function LoginPage() {
         onSubmit={handleSubmit}
         className="max-w-md w-full bg-white rounded-lg shadow p-6 space-y-6"
       >
+        <div className="flex justify-center mb-2">
+          <Link href="/">
+            <Image src="/logo.svg" alt="Evoluke" width={120} height={32} />
+          </Link>
+        </div>
         <h1 className="text-2xl font-semibold text-center">Login</h1>
 
         <div>

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
+import Image from "next/image";
 import { Input } from "@/components/ui/input";
 import { PasswordInput } from "@/components/ui/password-input";
 import { Button } from "@/components/ui/button";
@@ -73,6 +74,11 @@ export default function SignupPage() {
         onSubmit={handleSubmit}
         className="max-w-md w-full bg-white rounded-lg shadow p-6 space-y-4"
       >
+        <div className="flex justify-center mb-2">
+          <Link href="/">
+            <Image src="/logo.svg" alt="Evoluke" width={120} height={32} />
+          </Link>
+        </div>
         <h1 className="text-2xl font-semibold text-center">Cadastro</h1>
 
         {error && (

--- a/src/app/verify-email/page.tsx
+++ b/src/app/verify-email/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
+import Image from 'next/image';
 import { useSearchParams } from 'next/navigation';
 import { supabasebrowser } from '@/lib/supabaseClient';
 import { Button } from '@/components/ui/button';
@@ -39,6 +40,11 @@ function VerifyEmailContent() {
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-[#FAFAFA] p-4">
       <div className="max-w-md w-full bg-white rounded-lg shadow p-6 space-y-4">
+        <div className="flex justify-center mb-2">
+          <Link href="/">
+            <Image src="/logo.svg" alt="Evoluke" width={120} height={32} />
+          </Link>
+        </div>
         <h1 className="text-2xl font-semibold text-center">E-mail não verificado</h1>
         {email && (
           <p className="text-center text-sm">{email}</p>


### PR DESCRIPTION
## Summary
- show Evoluke logo above login form
- brand signup, forgot password and verify email screens with Evoluke logo

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4b75de784832fa5822b22068f4b6a