### PR TITLE
feat: add Evoluke logo to auth pages

### DIFF
--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
+import Image from 'next/image';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { supabasebrowser } from '@/lib/supabaseClient';
@@ -27,7 +28,14 @@ export default function ForgotPasswordPage() {
   };
 
   return (
-    <div className="fixed inset-0 flex items-center justify-center bg-[#FAFAFA] p-4">
+    <div className="fixed inset-0 flex flex-col items-center justify-center bg-[#FAFAFA] p-4">
+      <Image
+        src="/logo.svg"
+        alt="Evoluke logo"
+        width={200}
+        height={60}
+        className="mb-8"
+      />
       <form
         onSubmit={handleSubmit}
         className="max-w-md w-full bg-white rounded-lg shadow p-6 space-y-4"

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -5,6 +5,7 @@ import { Input } from "@/components/ui/input";
 import { PasswordInput } from "@/components/ui/password-input";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
+import Image from "next/image";
 import { supabasebrowser } from '@/lib/supabaseClient'
 import { useRouter } from 'next/navigation'
 import { toast } from "sonner";
@@ -66,7 +67,14 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="fixed inset-0 flex items-center justify-center bg-[#FAFAFA]">
+    <div className="fixed inset-0 flex flex-col items-center justify-center bg-[#FAFAFA]">
+      <Image
+        src="/logo.svg"
+        alt="Evoluke logo"
+        width={200}
+        height={60}
+        className="mb-8"
+      />
       <form
         onSubmit={handleSubmit}
         className="max-w-md w-full bg-white rounded-lg shadow p-6 space-y-6"

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
+import Image from "next/image";
 import { Input } from "@/components/ui/input";
 import { PasswordInput } from "@/components/ui/password-input";
 import { Button } from "@/components/ui/button";
@@ -68,7 +69,14 @@ export default function SignupPage() {
   };
 
   return (
-    <div className="fixed inset-0 flex items-center justify-center bg-[#FAFAFA] p-4">
+    <div className="fixed inset-0 flex flex-col items-center justify-center bg-[#FAFAFA] p-4">
+      <Image
+        src="/logo.svg"
+        alt="Evoluke logo"
+        width={200}
+        height={60}
+        className="mb-8"
+      />
       <form
         onSubmit={handleSubmit}
         className="max-w-md w-full bg-white rounded-lg shadow p-6 space-y-4"

--- a/src/app/verify-email/page.tsx
+++ b/src/app/verify-email/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
+import Image from 'next/image';
 import { useSearchParams } from 'next/navigation';
 import { supabasebrowser } from '@/lib/supabaseClient';
 import { Button } from '@/components/ui/button';
@@ -37,7 +38,14 @@ function VerifyEmailContent() {
   };
 
   return (
-    <div className="fixed inset-0 flex items-center justify-center bg-[#FAFAFA] p-4">
+    <div className="fixed inset-0 flex flex-col items-center justify-center bg-[#FAFAFA] p-4">
+      <Image
+        src="/logo.svg"
+        alt="Evoluke logo"
+        width={200}
+        height={60}
+        className="mb-8"
+      />
       <div className="max-w-md w-full bg-white rounded-lg shadow p-6 space-y-4">
         <h1 className="text-2xl font-semibold text-center">E-mail não verificado</h1>
         {email && (


### PR DESCRIPTION
## Summary
- display Evoluke logo above login form
- show Evoluke logo on signup form
- add Evoluke logo to password reset and email verification screens

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4bdf29174832fa883ee12b126c857