### PR TITLE
feat: improve mobile responsiveness for dashboard chart

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -162,53 +162,55 @@ export default function DashboardPage() {
 
       <div className="space-y-2">
         <h3 className="text-lg font-semibold">Mensagens por dia</h3>
-        <div className="h-80">
+        <div className="h-64 sm:h-80 w-full overflow-x-auto">
           {dailyMessages.length ? (
-            <ResponsiveContainer width="100%" height="100%">
-              <AreaChart
-                data={dailyMessages}
-                margin={{ top: 10, right: 30, left: 0, bottom: 0 }}
-              >
-                <defs>
-                  <linearGradient id="colorCount" x1="0" y1="0" x2="0" y2="1">
-                    <stop offset="5%" stopColor="#3b82f6" stopOpacity={0.3} />
-                    <stop offset="95%" stopColor="#3b82f6" stopOpacity={0} />
-                  </linearGradient>
-                </defs>
-                <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
-                <XAxis
-                  dataKey="date"
-                  tick={{ fontSize: 12 }}
-                  tickFormatter={(value) =>
-                    new Date(value).toLocaleDateString('pt-BR', {
-                      day: '2-digit',
-                      month: '2-digit',
-                    })
-                  }
-                />
-                <YAxis
-                  tick={{ fontSize: 12 }}
-                  allowDecimals={false} />
-                <Tooltip
-                  labelFormatter={(value) =>
-                    new Date(value as string).toLocaleDateString('pt-BR')
-                  }
-                  formatter={(value: number) => [`${value} mensagens`, '']}
-                  contentStyle={{ borderRadius: '0.375rem', borderColor: '#e2e8f0' }}
-                />
-                <Area
-                  type="monotone"
-                  dataKey="count"
-                  stroke="#3b82f6"
-                  strokeWidth={2}
-                  fill="url(#colorCount)"
-                  dot={{ r: 3 }}
-                  activeDot={{ r: 5 }}
-                />
-              </AreaChart>
-            </ResponsiveContainer>
+            <div className="min-w-[600px] h-full">
+              <ResponsiveContainer width="100%" height="100%">
+                <AreaChart
+                  data={dailyMessages}
+                  margin={{ top: 10, right: 30, left: 0, bottom: 0 }}
+                >
+                  <defs>
+                    <linearGradient id="colorCount" x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="5%" stopColor="#3b82f6" stopOpacity={0.3} />
+                      <stop offset="95%" stopColor="#3b82f6" stopOpacity={0} />
+                    </linearGradient>
+                  </defs>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
+                  <XAxis
+                    dataKey="date"
+                    tick={{ fontSize: 12 }}
+                    tickFormatter={(value) =>
+                      new Date(value).toLocaleDateString('pt-BR', {
+                        day: '2-digit',
+                        month: '2-digit',
+                      })
+                    }
+                  />
+                  <YAxis
+                    tick={{ fontSize: 12 }}
+                    allowDecimals={false} />
+                  <Tooltip
+                    labelFormatter={(value) =>
+                      new Date(value as string).toLocaleDateString('pt-BR')
+                    }
+                    formatter={(value: number) => [`${value} mensagens`, '']}
+                    contentStyle={{ borderRadius: '0.375rem', borderColor: '#e2e8f0' }}
+                  />
+                  <Area
+                    type="monotone"
+                    dataKey="count"
+                    stroke="#3b82f6"
+                    strokeWidth={2}
+                    fill="url(#colorCount)"
+                    dot={{ r: 3 }}
+                    activeDot={{ r: 5 }}
+                  />
+                </AreaChart>
+              </ResponsiveContainer>
+            </div>
           ) : (
-            <div className="flex items-center justify-center h-full text-sm text-gray-500">
+            <div className="flex items-center justify-center h-full w-full text-sm text-gray-500">
               Nenhuma mensagem registrada
             </div>
           )}


### PR DESCRIPTION
## Summary
- add horizontal scrolling and adaptive height for dashboard message chart

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a77502d1b4832f8fa2946d1c813bde