### PR TITLE
feat: improve mobile layout for agent pages

### DIFF
--- a/components/agents/AgentMenu.tsx
+++ b/components/agents/AgentMenu.tsx
@@ -49,8 +49,8 @@ export default function AgentMenu({ agent }: { agent: Agent }) {
 
   return (
     <div className="flex justify-center">
-      <div className="w-4/5 flex gap-4">
-        <Card className="w-52 p-4 flex flex-col items-center justify-center gap-3 text-sm text-center">
+      <div className="w-full md:w-4/5 flex flex-col md:flex-row gap-4">
+        <Card className="w-full md:w-52 p-4 flex flex-col items-center justify-center gap-3 text-sm text-center">
           <div>
             <p className="text-xs text-gray-500">Status do agente</p>
             <p className={`text-base font-semibold ${agent.is_active ? "text-green-600" : "text-red-600"}`}>
@@ -64,8 +64,8 @@ export default function AgentMenu({ agent }: { agent: Agent }) {
             </p>
           </div>
         </Card>
-        <Card className="flex-1 p-6">
-          <nav className="flex items-center justify-around">
+        <Card className="w-full md:flex-1 p-4 md:p-6">
+          <nav className="flex flex-wrap justify-center gap-2 md:flex-nowrap md:items-center md:justify-around md:gap-0">
             {menuItems.map(({ label, icon: Icon, href }, index) => (
               <Fragment key={label}>
                 <Button
@@ -78,7 +78,7 @@ export default function AgentMenu({ agent }: { agent: Agent }) {
                     <span>{label}</span>
                   </Link>
                 </Button>
-                {index < menuItems.length - 1 && <div className="h-8 border-l" />}
+                {index < menuItems.length - 1 && <div className="hidden md:block h-8 border-l" />}
               </Fragment>
             ))}
           </nav>

--- a/src/app/dashboard/agents/[id]/base-conhecimento/page.tsx
+++ b/src/app/dashboard/agents/[id]/base-conhecimento/page.tsx
@@ -169,7 +169,7 @@ export default function AgentKnowledgeBasePage() {
       <AgentGuide />
 
       <div className="flex justify-center">
-        <Card className="w-4/5 p-6">
+        <Card className="w-full md:w-4/5 p-6">
           <div className="flex flex-col gap-6">
             <h2 className="text-xl font-semibold">Cérebro</h2>
             <div className="flex flex-col gap-6 md:flex-row">
@@ -190,7 +190,7 @@ export default function AgentKnowledgeBasePage() {
                 })}
               </aside>
               <main className="flex-1 space-y-6">
-                <div className="flex items-center justify-between">
+                <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
                   <Input
                     placeholder="Pesquisar"
                     className="max-w-xs"
@@ -257,7 +257,7 @@ export default function AgentKnowledgeBasePage() {
         </Card>
       </div>
       <div className="flex justify-center">
-        <div className="w-4/5 flex justify-end gap-2">
+        <div className="w-full md:w-4/5 flex justify-end gap-2">
           {agent.is_active ? (
             <DeactivateAgentButton
               agentId={id}

--- a/src/app/dashboard/agents/[id]/comportamento/page.tsx
+++ b/src/app/dashboard/agents/[id]/comportamento/page.tsx
@@ -92,7 +92,7 @@ export default function AgentBehaviorPage() {
       <AgentMenu agent={agent} />
       <AgentGuide />
       <div className="flex justify-center">
-        <Card className="w-4/5 p-6">
+        <Card className="w-full md:w-4/5 p-6">
           <form onSubmit={handleSubmit} className="space-y-6">
             <div className="space-y-2">
               <label htmlFor="limitations" className="text-sm font-medium">
@@ -169,7 +169,7 @@ export default function AgentBehaviorPage() {
         </Card>
       </div>
       <div className="flex justify-center">
-        <div className="w-4/5 flex justify-end gap-2">
+        <div className="w-full md:w-4/5 flex justify-end gap-2">
           {agent.is_active ? (
             <DeactivateAgentButton
               agentId={id}

--- a/src/app/dashboard/agents/[id]/instrucoes-especificas/page.tsx
+++ b/src/app/dashboard/agents/[id]/instrucoes-especificas/page.tsx
@@ -139,7 +139,7 @@ export default function AgentSpecificInstructionsPage() {
       <AgentMenu agent={agent} />
       <AgentGuide />
       <div className="flex justify-center">
-        <Card className="w-4/5 p-6">
+        <Card className="w-full md:w-4/5 p-6">
           <form onSubmit={handleSubmit} className="space-y-6">
             {faqs.map((faq, index) => (
               <div
@@ -276,7 +276,7 @@ export default function AgentSpecificInstructionsPage() {
         </Card>
       </div>
       <div className="flex justify-center">
-        <div className="w-4/5 flex justify-end gap-2">
+        <div className="w-full md:w-4/5 flex justify-end gap-2">
           {agent.is_active ? (
             <DeactivateAgentButton
               agentId={id}

--- a/src/app/dashboard/agents/[id]/onboarding/page.tsx
+++ b/src/app/dashboard/agents/[id]/onboarding/page.tsx
@@ -129,7 +129,7 @@ export default function AgentOnboardingPage() {
       <AgentMenu agent={agent} />
       <AgentGuide />
       <div className="flex justify-center">
-        <Card className="w-4/5 p-6">
+        <Card className="w-full md:w-4/5 p-6">
           <form onSubmit={handleSubmit} className="space-y-6">
             <div className="space-y-2">
               <label htmlFor="welcome" className="text-sm font-medium">
@@ -154,7 +154,7 @@ export default function AgentOnboardingPage() {
             </div>
 
             {collection.map((item, index) => (
-              <div key={index} className="flex items-start gap-4">
+              <div key={index} className="flex flex-col gap-4 md:flex-row">
                 <div className="flex-1 space-y-2">
                   <label
                     htmlFor={`question-${index}`}
@@ -208,6 +208,7 @@ export default function AgentOnboardingPage() {
                   type="button"
                   variant="ghost"
                   onClick={() => removeItem(index)}
+                  className="self-start md:self-auto"
                 >
                   Remover
                 </Button>
@@ -235,7 +236,7 @@ export default function AgentOnboardingPage() {
         </Card>
       </div>
       <div className="flex justify-center">
-        <div className="w-4/5 flex justify-end gap-2">
+        <div className="w-full md:w-4/5 flex justify-end gap-2">
           {agent.is_active ? (
             <DeactivateAgentButton
               agentId={id}

--- a/src/app/dashboard/agents/[id]/page.tsx
+++ b/src/app/dashboard/agents/[id]/page.tsx
@@ -106,9 +106,9 @@ export default function AgentDetailPage() {
       <AgentMenu agent={agent} />
       <AgentGuide />
       <div className="flex justify-center">
-        <Card className="w-4/5 p-6">
+        <Card className="w-full md:w-4/5 p-6">
           <form onSubmit={handleSubmit} className="space-y-6">
-            <div className="flex gap-4">
+            <div className="flex flex-col gap-4 md:flex-row">
               <div className="flex-1 space-y-2">
                 <label htmlFor="name" className="text-sm font-medium">
                   Nome interno
@@ -191,7 +191,7 @@ export default function AgentDetailPage() {
         </Card>
       </div>
       <div className="flex justify-center">
-        <div className="w-4/5 flex justify-end gap-2">
+        <div className="w-full md:w-4/5 flex justify-end gap-2">
           {agent.is_active ? (
             <DeactivateAgentButton
               agentId={id}


### PR DESCRIPTION
## Summary
- Make agent detail and configuration pages responsive on mobile
- Stack form fields vertically on small screens and keep desktop layout

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a77b690cb8832fb3069362fed8ca5a