### PR TITLE
feat: add dashboard alerts banner

### DIFF
--- a/components/ui/dashboard-alerts.tsx
+++ b/components/ui/dashboard-alerts.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { supabasebrowser } from '@/lib/supabaseClient'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+
+interface Alert {
+  id: string
+  message: string
+  start_date: string
+  end_date: string
+}
+
+export default function DashboardAlerts() {
+  const [alerts, setAlerts] = useState<Alert[]>([])
+  const [index, setIndex] = useState(0)
+
+  useEffect(() => {
+    const today = new Date().toISOString().split('T')[0]
+    supabasebrowser
+      .from('dashboard_alerts')
+      .select('id, message, start_date, end_date')
+      .lte('start_date', today)
+      .gte('end_date', today)
+      .order('start_date')
+      .then(({ data, error }) => {
+        if (!error && data) {
+          setAlerts(data)
+        }
+      })
+  }, [])
+
+  if (alerts.length === 0) return null
+
+  const prev = () => setIndex((index - 1 + alerts.length) % alerts.length)
+  const next = () => setIndex((index + 1) % alerts.length)
+
+  const current = alerts[index]
+
+  return (
+    <div className="mb-4">
+      <div className="relative flex items-center justify-center bg-yellow-100 border-l-4 border-yellow-500 p-3 rounded">
+        <p className="text-xs sm:text-sm text-yellow-800 text-center">{current.message}</p>
+      </div>
+      {alerts.length > 1 && (
+        <div className="flex justify-end gap-2 mt-1">
+          <button
+            onClick={prev}
+            aria-label="Alerta anterior"
+            className="p-1 text-yellow-700 hover:text-yellow-900"
+          >
+            <ChevronLeft className="w-4 h-4" />
+          </button>
+          <button
+            onClick={next}
+            aria-label="Próximo alerta"
+            className="p-1 text-yellow-700 hover:text-yellow-900"
+          >
+            <ChevronRight className="w-4 h-4" />
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/migration.sql
+++ b/migration.sql
@@ -146,3 +146,13 @@ create table public.messages (
   constraint messages_pkey primary key (id),
   constraint messages_company_id_fkey foreign key (company_id) references company (id)
 ) TABLESPACE pg_default;
+
+-- Tabela de alertas do dashboard
+create table public.dashboard_alerts (
+  id uuid not null default gen_random_uuid(),
+  created_at timestamp with time zone not null default now(),
+  message text not null,
+  start_date date not null,
+  end_date date not null,
+  constraint dashboard_alerts_pkey primary key (id)
+) TABLESPACE pg_default;

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -2,6 +2,7 @@
 'use client'
 import React, { ReactNode, useEffect, useState } from 'react'
 import { Sidebar, MobileSidebar } from '@/components/ui/sidebar'
+import DashboardAlerts from '@/components/ui/dashboard-alerts'
 import { supabasebrowser } from '@/lib/supabaseClient'
 import { useRouter } from 'next/navigation'
 
@@ -37,6 +38,7 @@ export default function DashboardClientLayout({ children }: Props) {
       <Sidebar className="hidden sm:flex" />
       <main className="flex-1 bg-[#FAFAFA] p-6 h-full overflow-auto">
         <MobileSidebar />
+        <DashboardAlerts />
         {children}
       </main>
     </div>


### PR DESCRIPTION
## Summary
- show dashboard alerts from Supabase at top of all dashboard pages
- create `dashboard_alerts` table for storing messages and validity dates

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7c35381c0832f9285e1b8368dd845