### PR TITLE
Add dashboard alerts banner

### DIFF
--- a/components/dashboard/alert-banner.tsx
+++ b/components/dashboard/alert-banner.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { supabasebrowser } from '@/lib/supabaseClient'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+
+interface Alert {
+  id: string
+  message: string
+}
+
+export default function AlertBanner() {
+  const [alerts, setAlerts] = useState<Alert[]>([])
+  const [index, setIndex] = useState(0)
+
+  useEffect(() => {
+    const fetchAlerts = async () => {
+      const now = new Date().toISOString()
+      const { data } = await supabasebrowser
+        .from('alerts')
+        .select('id,message,start_date,end_date')
+        .lte('start_date', now)
+        .gte('end_date', now)
+        .order('start_date', { ascending: false })
+      setAlerts(data || [])
+    }
+    fetchAlerts()
+  }, [])
+
+  if (!alerts.length) return null
+
+  const handlePrev = () =>
+    setIndex((i) => (i === 0 ? alerts.length - 1 : i - 1))
+  const handleNext = () =>
+    setIndex((i) => (i === alerts.length - 1 ? 0 : i + 1))
+
+  return (
+    <div className="mb-4 rounded-md bg-yellow-100 p-3 text-yellow-800">
+      <div className="flex flex-col sm:flex-row items-center justify-between gap-2">
+        <span className="text-sm text-center sm:text-left w-full break-words">
+          {alerts[index].message}
+        </span>
+        {alerts.length > 1 && (
+          <div className="flex items-center gap-2">
+            <button
+              onClick={handlePrev}
+              aria-label="Alerta anterior"
+              className="p-1 text-yellow-800 hover:text-yellow-900"
+            >
+              <ChevronLeft className="w-4 h-4" />
+            </button>
+            <span className="text-xs">
+              {index + 1}/{alerts.length}
+            </span>
+            <button
+              onClick={handleNext}
+              aria-label="Próximo alerta"
+              className="p-1 text-yellow-800 hover:text-yellow-900"
+            >
+              <ChevronRight className="w-4 h-4" />
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+

--- a/migration.sql
+++ b/migration.sql
@@ -146,3 +146,13 @@ create table public.messages (
   constraint messages_pkey primary key (id),
   constraint messages_company_id_fkey foreign key (company_id) references company (id)
 ) TABLESPACE pg_default;
+
+-- Tabela de alertas do dashboard
+create table public.alerts (
+  id uuid not null default gen_random_uuid(),
+  created_at timestamp with time zone not null default now(),
+  message text not null,
+  start_date timestamp with time zone not null,
+  end_date timestamp with time zone not null,
+  constraint alerts_pkey primary key (id)
+) TABLESPACE pg_default;

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -4,6 +4,7 @@ import React, { ReactNode, useEffect, useState } from 'react'
 import { Sidebar, MobileSidebar } from '@/components/ui/sidebar'
 import { supabasebrowser } from '@/lib/supabaseClient'
 import { useRouter } from 'next/navigation'
+import AlertBanner from '@/components/dashboard/alert-banner'
 
 interface Props { children: ReactNode }
 
@@ -37,6 +38,7 @@ export default function DashboardClientLayout({ children }: Props) {
       <Sidebar className="hidden sm:flex" />
       <main className="flex-1 bg-[#FAFAFA] p-6 h-full overflow-auto">
         <MobileSidebar />
+        <AlertBanner />
         {children}
       </main>
     </div>


### PR DESCRIPTION
## Summary
- fetch and display time-bound alerts in dashboard with mobile-friendly pagination
- integrate alert banner across dashboard layout
- create database table for storing dashboard alerts

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7c35381c0832f9285e1b8368dd845