### PR TITLE
Remove document rows when deleting knowledge base files

### DIFF
--- a/src/app/dashboard/agents/[id]/base-conhecimento/page.tsx
+++ b/src/app/dashboard/agents/[id]/base-conhecimento/page.tsx
@@ -175,11 +175,9 @@ export default function AgentKnowledgeBasePage() {
     const { error: docError } = await supabasebrowser
       .from("documents")
       .delete()
-      .contains("metadata", {
-        company_id: agent.company_id.toString(),
-        agent_id: id,
-        path_id: file.id,
-      });
+      .eq("metadata->>company_id", agent.company_id.toString())
+      .eq("metadata->>agent_id", id)
+      .eq("metadata->>path_id", file.id);
 
     if (docError) {
       await supabasebrowser.from("agent_knowledge_files").insert({


### PR DESCRIPTION
## Summary
- delete document embeddings associated with removed knowledge files
- rollback file removal and show an error if document deletion fails
- include company and agent IDs in n8n upload endpoint and rename id to path_id

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa20251f48832f8c83b33d139947ad