### PR TITLE
remove csv from allowed file types

### DIFF
--- a/src/app/dashboard/agents/[id]/base-conhecimento/page.tsx
+++ b/src/app/dashboard/agents/[id]/base-conhecimento/page.tsx
@@ -55,7 +55,6 @@ export default function AgentKnowledgeBasePage() {
   const mimeToExt: Record<string, string> = {
     "application/pdf": "PDF",
     "text/plain": "TXT",
-    "text/csv": "CSV",
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document": "DOCX",
     "application/msword": "DOC",
   };

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -3,7 +3,6 @@ export const MAX_AGENTS_PER_COMPANY = 5;
 export const ALLOWED_KNOWLEDGE_MIME_TYPES = [
   "application/pdf",
   "text/plain",
-  "text/csv",
   "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
   "application/msword",
 ];


### PR DESCRIPTION
## Summary
- remove CSV from allowed knowledge MIME types
- update file upload mapping to reflect new file types

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab97eef1e4832fb4ade9ed867393a8