### PR TITLE
Validate agent type on creation

### DIFF
--- a/src/app/dashboard/agents/new/page.tsx
+++ b/src/app/dashboard/agents/new/page.tsx
@@ -16,7 +16,7 @@ import {
 import AgentTypeCard from "@/components/agents/AgentTypeCard";
 import { isValidAgentName } from "@/lib/validators";
 import { toast } from "sonner";
-import { MAX_AGENTS_PER_COMPANY } from "@/lib/constants";
+import { MAX_AGENTS_PER_COMPANY, ALLOWED_AGENT_TYPES } from "@/lib/constants";
 import { AGENT_TEMPLATES } from "@/lib/agentTemplates";
 
 export default function NewAgentPage() {
@@ -69,6 +69,11 @@ export default function NewAgentPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!isFormValid || !companyId || isSubmitting) return;
+
+    if (!ALLOWED_AGENT_TYPES.includes(type)) {
+      toast.error("Tipo de agente inválido.");
+      return;
+    }
 
     setIsSubmitting(true);
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,5 +1,11 @@
 export const MAX_AGENTS_PER_COMPANY = 5;
 
+export const ALLOWED_AGENT_TYPES = [
+  "agendamento",
+  "sdr",
+  "suporte",
+];
+
 export const ALLOWED_KNOWLEDGE_MIME_TYPES = [
   "application/pdf",
   "text/plain",


### PR DESCRIPTION
## Summary
- add constant for allowed agent types
- ensure new agent creation checks type against allowed values

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ab9c1fbd20832f997b997e2064d319