### PR TITLE
feat: add qualification transfer rule to agent behavior

### DIFF
--- a/migration.sql
+++ b/migration.sql
@@ -86,6 +86,9 @@ create table public.agent_personality (
   constraint agent_personality_agent_id_fkey foreign key (agent_id) references agents (id)
 ) TABLESPACE pg_default;
 
+-- Enum para regra de transferência após qualificação
+create type public.qualification_transfer_rule as enum ('never', 'user_request', 'lead_interested');
+
 -- Tabela de comportamento dos agentes
 create table public.agent_behavior (
   id uuid not null default gen_random_uuid (),
@@ -94,7 +97,7 @@ create table public.agent_behavior (
   limitations text not null default ''::text,
   forbidden_words text not null default ''::text,
   default_fallback text not null,
-  qualification_transfer_rule text not null default ''::text,
+  qualification_transfer_rule public.qualification_transfer_rule not null default 'never'::qualification_transfer_rule,
   constraint agent_behavior_pkey primary key (id),
   constraint agent_behavior_agent_id_key unique (agent_id),
   constraint agent_behavior_agent_id_fkey foreign key (agent_id) references agents (id)

--- a/migration.sql
+++ b/migration.sql
@@ -87,7 +87,7 @@ create table public.agent_personality (
 ) TABLESPACE pg_default;
 
 -- Enum para regra de transferência após qualificação
-create type public.qualification_transfer_rule as enum ('never', 'user_request', 'lead_interested');
+create type public.qualification_transfer_rule as enum ('never', 'filled_collection_questions', 'personalized');
 
 -- Tabela de comportamento dos agentes
 create table public.agent_behavior (
@@ -98,6 +98,7 @@ create table public.agent_behavior (
   forbidden_words text not null default ''::text,
   default_fallback text not null,
   qualification_transfer_rule public.qualification_transfer_rule not null default 'never'::qualification_transfer_rule,
+  qualification_transfer_conditions text not null default ''::text,
   constraint agent_behavior_pkey primary key (id),
   constraint agent_behavior_agent_id_key unique (agent_id),
   constraint agent_behavior_agent_id_fkey foreign key (agent_id) references agents (id)

--- a/migration.sql
+++ b/migration.sql
@@ -94,6 +94,7 @@ create table public.agent_behavior (
   limitations text not null default ''::text,
   forbidden_words text not null default ''::text,
   default_fallback text not null,
+  qualification_transfer_rule text not null default ''::text,
   constraint agent_behavior_pkey primary key (id),
   constraint agent_behavior_agent_id_key unique (agent_id),
   constraint agent_behavior_agent_id_fkey foreign key (agent_id) references agents (id)

--- a/src/app/api/agents/update/route.ts
+++ b/src/app/api/agents/update/route.ts
@@ -75,7 +75,7 @@ export async function POST(request: Request) {
       limitations: '',
       forbidden_words: '',
       default_fallback: '',
-      qualification_transfer_rule: '',
+      qualification_transfer_rule: 'never',
     },
     onboarding: onboarding ?? {
       welcome_message: '',

--- a/src/app/api/agents/update/route.ts
+++ b/src/app/api/agents/update/route.ts
@@ -52,7 +52,7 @@ export async function POST(request: Request) {
     .single();
   const { data: behavior } = await supabaseadmin
     .from('agent_behavior')
-    .select('limitations, forbidden_words, default_fallback')
+    .select('limitations, forbidden_words, default_fallback, qualification_transfer_rule')
     .eq('agent_id', agentId)
     .single();
   const { data: onboarding } = await supabaseadmin
@@ -75,6 +75,7 @@ export async function POST(request: Request) {
       limitations: '',
       forbidden_words: '',
       default_fallback: '',
+      qualification_transfer_rule: '',
     },
     onboarding: onboarding ?? {
       welcome_message: '',

--- a/src/app/api/agents/update/route.ts
+++ b/src/app/api/agents/update/route.ts
@@ -52,7 +52,9 @@ export async function POST(request: Request) {
     .single();
   const { data: behavior } = await supabaseadmin
     .from('agent_behavior')
-    .select('limitations, forbidden_words, default_fallback, qualification_transfer_rule')
+    .select(
+      'limitations, forbidden_words, default_fallback, qualification_transfer_rule, qualification_transfer_conditions'
+    )
     .eq('agent_id', agentId)
     .single();
   const { data: onboarding } = await supabaseadmin
@@ -76,6 +78,7 @@ export async function POST(request: Request) {
       forbidden_words: '',
       default_fallback: '',
       qualification_transfer_rule: 'never',
+      qualification_transfer_conditions: '',
     },
     onboarding: onboarding ?? {
       welcome_message: '',

--- a/src/app/dashboard/agents/[id]/comportamento/page.tsx
+++ b/src/app/dashboard/agents/[id]/comportamento/page.tsx
@@ -5,14 +5,25 @@ import { useParams } from "next/navigation";
 import { supabasebrowser } from "@/lib/supabaseClient";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { toast } from "sonner";
 import UpdateAgentButton from "@/components/agents/UpdateAgentButton";
 import AgentMenu from "@/components/agents/AgentMenu";
 import AgentGuide from "@/components/agents/AgentGuide";
 import DeactivateAgentButton from "@/components/agents/DeactivateAgentButton";
 import ActivateAgentButton from "@/components/agents/ActivateAgentButton";
+import {
+  QUALIFICATION_TRANSFER_RULES,
+  QualificationTransferRule,
+} from "@/lib/qualificationTransferRules";
 
 type Agent = {
   id: string;
@@ -28,7 +39,8 @@ export default function AgentBehaviorPage() {
   const [limitations, setLimitations] = useState("");
   const [forbiddenWords, setForbiddenWords] = useState("");
   const [fallback, setFallback] = useState("");
-  const [qualificationTransferRule, setQualificationTransferRule] = useState("");
+  const [qualificationTransferRule, setQualificationTransferRule] =
+    useState<QualificationTransferRule>("never");
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   useEffect(() => {
@@ -52,7 +64,9 @@ export default function AgentBehaviorPage() {
           setLimitations(data.limitations);
           setForbiddenWords(data.forbidden_words);
           setFallback(data.default_fallback);
-          setQualificationTransferRule(data.qualification_transfer_rule);
+          setQualificationTransferRule(
+            data.qualification_transfer_rule as QualificationTransferRule,
+          );
         }
       });
   }, [id]);
@@ -62,8 +76,9 @@ export default function AgentBehaviorPage() {
   const limitationsValid = limitations.trim().length <= 500;
   const forbiddenWordsValid = forbiddenWords.trim().length <= 500;
   const fallbackValid = fallback.trim().length >= 10 && fallback.trim().length <= 200;
-  const qualificationTransferRuleValid =
-    qualificationTransferRule.trim().length <= 200;
+  const qualificationTransferRuleValid = QUALIFICATION_TRANSFER_RULES.some(
+    (r) => r.value === qualificationTransferRule,
+  );
   const isFormValid =
     limitationsValid &&
     forbiddenWordsValid &&
@@ -172,27 +187,29 @@ export default function AgentBehaviorPage() {
             </div>
 
             <div className="space-y-2">
-              <label
-                htmlFor="qualificationTransferRule"
-                className="text-sm font-medium"
-              >
+              <label className="text-sm font-medium">
                 Quando transferir para humano após a qualificação
               </label>
-              <Input
-                id="qualificationTransferRule"
+              <Select
                 value={qualificationTransferRule}
-                onChange={(e) => setQualificationTransferRule(e.target.value)}
-                maxLength={200}
-              />
-              <div className="flex justify-between text-xs text-gray-500">
-                <p>Defina a regra para transferência após qualificar o lead.</p>
-                <p className="text-gray-400">0 a 200 caracteres</p>
-              </div>
-              {qualificationTransferRule && !qualificationTransferRuleValid && (
-                <p className="text-xs text-red-500">
-                  A regra deve ter no máximo 200 caracteres
-                </p>
-              )}
+                onValueChange={(v) =>
+                  setQualificationTransferRule(v as QualificationTransferRule)
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Selecione a regra" />
+                </SelectTrigger>
+                <SelectContent>
+                  {QUALIFICATION_TRANSFER_RULES.map((r) => (
+                    <SelectItem key={r.value} value={r.value}>
+                      {r.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-gray-500">
+                Defina a regra para transferência após qualificar o lead.
+              </p>
             </div>
 
             <Button type="submit" disabled={!isFormValid || isSubmitting}>

--- a/src/app/dashboard/agents/[id]/comportamento/page.tsx
+++ b/src/app/dashboard/agents/[id]/comportamento/page.tsx
@@ -28,6 +28,7 @@ export default function AgentBehaviorPage() {
   const [limitations, setLimitations] = useState("");
   const [forbiddenWords, setForbiddenWords] = useState("");
   const [fallback, setFallback] = useState("");
+  const [qualificationTransferRule, setQualificationTransferRule] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   useEffect(() => {
@@ -43,7 +44,7 @@ export default function AgentBehaviorPage() {
 
     supabasebrowser
       .from("agent_behavior")
-      .select("limitations, forbidden_words, default_fallback")
+      .select("limitations, forbidden_words, default_fallback, qualification_transfer_rule")
       .eq("agent_id", id)
       .single()
       .then(({ data }) => {
@@ -51,6 +52,7 @@ export default function AgentBehaviorPage() {
           setLimitations(data.limitations);
           setForbiddenWords(data.forbidden_words);
           setFallback(data.default_fallback);
+          setQualificationTransferRule(data.qualification_transfer_rule);
         }
       });
   }, [id]);
@@ -60,7 +62,13 @@ export default function AgentBehaviorPage() {
   const limitationsValid = limitations.trim().length <= 500;
   const forbiddenWordsValid = forbiddenWords.trim().length <= 500;
   const fallbackValid = fallback.trim().length >= 10 && fallback.trim().length <= 200;
-  const isFormValid = limitationsValid && forbiddenWordsValid && fallbackValid;
+  const qualificationTransferRuleValid =
+    qualificationTransferRule.trim().length <= 200;
+  const isFormValid =
+    limitationsValid &&
+    forbiddenWordsValid &&
+    fallbackValid &&
+    qualificationTransferRuleValid;
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -75,6 +83,7 @@ export default function AgentBehaviorPage() {
           limitations,
           forbidden_words: forbiddenWords,
           default_fallback: fallback,
+          qualification_transfer_rule: qualificationTransferRule,
         },
         { onConflict: "agent_id" }
       );
@@ -158,6 +167,30 @@ export default function AgentBehaviorPage() {
               {fallback && !fallbackValid && (
                 <p className="text-xs text-red-500">
                   O fallback deve ter entre 10 e 200 caracteres
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <label
+                htmlFor="qualificationTransferRule"
+                className="text-sm font-medium"
+              >
+                Quando transferir para humano após a qualificação
+              </label>
+              <Input
+                id="qualificationTransferRule"
+                value={qualificationTransferRule}
+                onChange={(e) => setQualificationTransferRule(e.target.value)}
+                maxLength={200}
+              />
+              <div className="flex justify-between text-xs text-gray-500">
+                <p>Defina a regra para transferência após qualificar o lead.</p>
+                <p className="text-gray-400">0 a 200 caracteres</p>
+              </div>
+              {qualificationTransferRule && !qualificationTransferRuleValid && (
+                <p className="text-xs text-red-500">
+                  A regra deve ter no máximo 200 caracteres
                 </p>
               )}
             </div>

--- a/src/app/dashboard/agents/new/page.tsx
+++ b/src/app/dashboard/agents/new/page.tsx
@@ -105,7 +105,7 @@ export default function NewAgentPage() {
         limitations: "",
         forbidden_words: "",
         default_fallback: "",
-        qualification_transfer_rule: "",
+        qualification_transfer_rule: "never",
       };
       const inserts = [];
       inserts.push(

--- a/src/app/dashboard/agents/new/page.tsx
+++ b/src/app/dashboard/agents/new/page.tsx
@@ -106,6 +106,7 @@ export default function NewAgentPage() {
         forbidden_words: "",
         default_fallback: "",
         qualification_transfer_rule: "never",
+        qualification_transfer_conditions: "",
       };
       const inserts = [];
       inserts.push(

--- a/src/app/dashboard/agents/new/page.tsx
+++ b/src/app/dashboard/agents/new/page.tsx
@@ -101,6 +101,12 @@ export default function NewAgentPage() {
 
     const template = AGENT_TEMPLATES[type];
     if (template) {
+      const behavior = template.behavior ?? {
+        limitations: "",
+        forbidden_words: "",
+        default_fallback: "",
+        qualification_transfer_rule: "",
+      };
       const inserts = [];
       inserts.push(
         supabasebrowser.from("agent_personality").insert({
@@ -111,7 +117,7 @@ export default function NewAgentPage() {
       inserts.push(
         supabasebrowser.from("agent_behavior").insert({
           agent_id: data.id,
-          ...template.behavior,
+          ...behavior,
         })
       );
       inserts.push(

--- a/src/lib/agentInstructions.ts
+++ b/src/lib/agentInstructions.ts
@@ -8,6 +8,7 @@ export interface AgentInstructionsData {
     limitations: string;
     forbidden_words: string;
     default_fallback: string;
+    qualification_transfer_rule: string;
   };
   onboarding: {
     welcome_message: string;
@@ -28,6 +29,9 @@ export function buildAgentInstructions(data: AgentInstructionsData): string {
   lines.push(`    <limitations>${data.behavior.limitations}</limitations>`);
   lines.push(`    <forbidden_words>${data.behavior.forbidden_words}</forbidden_words>`);
   lines.push(`    <default_fallback>${data.behavior.default_fallback}</default_fallback>`);
+  lines.push(
+    `    <qualification_transfer_rule>${data.behavior.qualification_transfer_rule}</qualification_transfer_rule>`,
+  );
   lines.push('  </behavior>');
   lines.push('  <onboarding>');
   lines.push(`    <welcome_message>${data.onboarding.welcome_message}</welcome_message>`);

--- a/src/lib/agentInstructions.ts
+++ b/src/lib/agentInstructions.ts
@@ -1,3 +1,8 @@
+import {
+  QualificationTransferRule,
+  QUALIFICATION_TRANSFER_RULE_TEXT,
+} from './qualificationTransferRules';
+
 export interface AgentInstructionsData {
   personality: {
     voice_tone: string;
@@ -8,7 +13,7 @@ export interface AgentInstructionsData {
     limitations: string;
     forbidden_words: string;
     default_fallback: string;
-    qualification_transfer_rule: string;
+    qualification_transfer_rule: QualificationTransferRule;
   };
   onboarding: {
     welcome_message: string;
@@ -30,7 +35,7 @@ export function buildAgentInstructions(data: AgentInstructionsData): string {
   lines.push(`    <forbidden_words>${data.behavior.forbidden_words}</forbidden_words>`);
   lines.push(`    <default_fallback>${data.behavior.default_fallback}</default_fallback>`);
   lines.push(
-    `    <qualification_transfer_rule>${data.behavior.qualification_transfer_rule}</qualification_transfer_rule>`,
+    `    <qualification_transfer_rule>${QUALIFICATION_TRANSFER_RULE_TEXT[data.behavior.qualification_transfer_rule]}</qualification_transfer_rule>`,
   );
   lines.push('  </behavior>');
   lines.push('  <onboarding>');

--- a/src/lib/agentInstructions.ts
+++ b/src/lib/agentInstructions.ts
@@ -14,6 +14,7 @@ export interface AgentInstructionsData {
     forbidden_words: string;
     default_fallback: string;
     qualification_transfer_rule: QualificationTransferRule;
+    qualification_transfer_conditions: string;
   };
   onboarding: {
     welcome_message: string;
@@ -37,6 +38,11 @@ export function buildAgentInstructions(data: AgentInstructionsData): string {
   lines.push(
     `    <qualification_transfer_rule>${QUALIFICATION_TRANSFER_RULE_TEXT[data.behavior.qualification_transfer_rule]}</qualification_transfer_rule>`,
   );
+  if (data.behavior.qualification_transfer_rule === 'personalized') {
+    lines.push(
+      `    <qualification_transfer_conditions>${data.behavior.qualification_transfer_conditions}</qualification_transfer_conditions>`,
+    );
+  }
   lines.push('  </behavior>');
   lines.push('  <onboarding>');
   lines.push(`    <welcome_message>${data.onboarding.welcome_message}</welcome_message>`);

--- a/src/lib/agentTemplates.ts
+++ b/src/lib/agentTemplates.ts
@@ -11,6 +11,7 @@ export interface AgentTemplate {
     forbidden_words: string;
     default_fallback: string;
     qualification_transfer_rule: QualificationTransferRule;
+    qualification_transfer_conditions: string;
   };
   onboarding: {
     welcome_message: string;
@@ -31,7 +32,9 @@ export const AGENT_TEMPLATES: Record<string, AgentTemplate> = {
       forbidden_words: 'gírias, palavras ofensivas',
       default_fallback:
         'Não consegui compreender, poderia reformular o pedido de agendamento?',
-      qualification_transfer_rule: 'user_request',
+      qualification_transfer_rule: 'personalized',
+      qualification_transfer_conditions:
+        'Quando o usuário solicitar atendimento humano.',
     },
     onboarding: {
       welcome_message: 'Olá! Vou ajudar com seus agendamentos.',
@@ -65,7 +68,8 @@ export const AGENT_TEMPLATES: Record<string, AgentTemplate> = {
       forbidden_words: 'promessas de preço, descontos garantidos, agendamento de reuniões/consultas',
       default_fallback:
         'Agora não consigo te ajudar, mas vou te direcionar para um de nossos atendentes que poderá atender você.',
-      qualification_transfer_rule: 'lead_interested',
+      qualification_transfer_rule: 'filled_collection_questions',
+      qualification_transfer_conditions: '',
     },
     onboarding: {
       welcome_message:
@@ -101,7 +105,9 @@ export const AGENT_TEMPLATES: Record<string, AgentTemplate> = {
       forbidden_words: 'termos técnicos complexos',
       default_fallback:
         'Ainda não sei responder isso, mas vou te direcionar para um de nossos atendentes que poderá atender você.',
-      qualification_transfer_rule: 'user_request',
+      qualification_transfer_rule: 'personalized',
+      qualification_transfer_conditions:
+        'Quando o usuário solicitar atendimento humano.',
     },
     onboarding: {
       welcome_message: 'Olá! Estou aqui para ajudar com o suporte.',

--- a/src/lib/agentTemplates.ts
+++ b/src/lib/agentTemplates.ts
@@ -8,6 +8,7 @@ export interface AgentTemplate {
     limitations: string;
     forbidden_words: string;
     default_fallback: string;
+    qualification_transfer_rule: string;
   };
   onboarding: {
     welcome_message: string;
@@ -28,6 +29,8 @@ export const AGENT_TEMPLATES: Record<string, AgentTemplate> = {
       forbidden_words: 'gírias, palavras ofensivas',
       default_fallback:
         'Não consegui compreender, poderia reformular o pedido de agendamento?',
+      qualification_transfer_rule:
+        'Transferir para humano se o usuário solicitar atendimento após o agendamento.',
     },
     onboarding: {
       welcome_message: 'Olá! Vou ajudar com seus agendamentos.',
@@ -61,6 +64,8 @@ export const AGENT_TEMPLATES: Record<string, AgentTemplate> = {
       forbidden_words: 'promessas de preço, descontos garantidos, agendamento de reuniões/consultas',
       default_fallback:
         'Agora não consigo te ajudar, mas vou te direcionar para um de nossos atendentes que poderá atender você.',
+      qualification_transfer_rule:
+        'Transferir para humano quando o lead demonstrar interesse claro em prosseguir.',
     },
     onboarding: {
       welcome_message:
@@ -96,6 +101,8 @@ export const AGENT_TEMPLATES: Record<string, AgentTemplate> = {
       forbidden_words: 'termos técnicos complexos',
       default_fallback:
         'Ainda não sei responder isso, mas vou te direcionar para um de nossos atendentes que poderá atender você.',
+      qualification_transfer_rule:
+        'Transferir para humano se o usuário solicitar atendimento direto.',
     },
     onboarding: {
       welcome_message: 'Olá! Estou aqui para ajudar com o suporte.',

--- a/src/lib/agentTemplates.ts
+++ b/src/lib/agentTemplates.ts
@@ -1,3 +1,5 @@
+import { QualificationTransferRule } from './qualificationTransferRules';
+
 export interface AgentTemplate {
   personality: {
     voice_tone: 'formal' | 'casual';
@@ -8,7 +10,7 @@ export interface AgentTemplate {
     limitations: string;
     forbidden_words: string;
     default_fallback: string;
-    qualification_transfer_rule: string;
+    qualification_transfer_rule: QualificationTransferRule;
   };
   onboarding: {
     welcome_message: string;
@@ -29,8 +31,7 @@ export const AGENT_TEMPLATES: Record<string, AgentTemplate> = {
       forbidden_words: 'gírias, palavras ofensivas',
       default_fallback:
         'Não consegui compreender, poderia reformular o pedido de agendamento?',
-      qualification_transfer_rule:
-        'Transferir para humano se o usuário solicitar atendimento após o agendamento.',
+      qualification_transfer_rule: 'user_request',
     },
     onboarding: {
       welcome_message: 'Olá! Vou ajudar com seus agendamentos.',
@@ -64,8 +65,7 @@ export const AGENT_TEMPLATES: Record<string, AgentTemplate> = {
       forbidden_words: 'promessas de preço, descontos garantidos, agendamento de reuniões/consultas',
       default_fallback:
         'Agora não consigo te ajudar, mas vou te direcionar para um de nossos atendentes que poderá atender você.',
-      qualification_transfer_rule:
-        'Transferir para humano quando o lead demonstrar interesse claro em prosseguir.',
+      qualification_transfer_rule: 'lead_interested',
     },
     onboarding: {
       welcome_message:
@@ -101,8 +101,7 @@ export const AGENT_TEMPLATES: Record<string, AgentTemplate> = {
       forbidden_words: 'termos técnicos complexos',
       default_fallback:
         'Ainda não sei responder isso, mas vou te direcionar para um de nossos atendentes que poderá atender você.',
-      qualification_transfer_rule:
-        'Transferir para humano se o usuário solicitar atendimento direto.',
+      qualification_transfer_rule: 'user_request',
     },
     onboarding: {
       welcome_message: 'Olá! Estou aqui para ajudar com o suporte.',

--- a/src/lib/qualificationTransferRules.ts
+++ b/src/lib/qualificationTransferRules.ts
@@ -1,13 +1,26 @@
-export type QualificationTransferRule = 'never' | 'user_request' | 'lead_interested';
+export type QualificationTransferRule =
+  | 'never'
+  | 'filled_collection_questions'
+  | 'personalized';
 
-export const QUALIFICATION_TRANSFER_RULES: { value: QualificationTransferRule; label: string }[] = [
+export const QUALIFICATION_TRANSFER_RULES: {
+  value: QualificationTransferRule;
+  label: string;
+}[] = [
   { value: 'never', label: 'Nunca transferir automaticamente' },
-  { value: 'user_request', label: 'Quando o usuário solicitar' },
-  { value: 'lead_interested', label: 'Quando o lead demonstrar interesse' },
+  {
+    value: 'filled_collection_questions',
+    label: 'Quando preencher as perguntas de coleta',
+  },
+  { value: 'personalized', label: 'Personalizado' },
 ];
 
-export const QUALIFICATION_TRANSFER_RULE_TEXT: Record<QualificationTransferRule, string> = {
+export const QUALIFICATION_TRANSFER_RULE_TEXT: Record<
+  QualificationTransferRule,
+  string
+> = {
   never: 'Nunca transferir automaticamente',
-  user_request: 'Transferir para humano se o usuário solicitar atendimento.',
-  lead_interested: 'Transferir para humano quando o lead demonstrar interesse claro em prosseguir.',
+  filled_collection_questions:
+    'Transferir para humano quando as perguntas de coleta estiverem preenchidas.',
+  personalized: 'Transferir para humano conforme condições personalizadas.',
 };

--- a/src/lib/qualificationTransferRules.ts
+++ b/src/lib/qualificationTransferRules.ts
@@ -1,0 +1,13 @@
+export type QualificationTransferRule = 'never' | 'user_request' | 'lead_interested';
+
+export const QUALIFICATION_TRANSFER_RULES: { value: QualificationTransferRule; label: string }[] = [
+  { value: 'never', label: 'Nunca transferir automaticamente' },
+  { value: 'user_request', label: 'Quando o usuário solicitar' },
+  { value: 'lead_interested', label: 'Quando o lead demonstrar interesse' },
+];
+
+export const QUALIFICATION_TRANSFER_RULE_TEXT: Record<QualificationTransferRule, string> = {
+  never: 'Nunca transferir automaticamente',
+  user_request: 'Transferir para humano se o usuário solicitar atendimento.',
+  lead_interested: 'Transferir para humano quando o lead demonstrar interesse claro em prosseguir.',
+};

--- a/supabase/migrations/20250214000000_add_qualification_transfer_rule.sql
+++ b/supabase/migrations/20250214000000_add_qualification_transfer_rule.sql
@@ -1,3 +1,5 @@
-create type public.qualification_transfer_rule as enum ('never', 'user_request', 'lead_interested');
+create type public.qualification_transfer_rule as enum ('never', 'filled_collection_questions', 'personalized');
 alter table public.agent_behavior
   add column qualification_transfer_rule public.qualification_transfer_rule not null default 'never'::qualification_transfer_rule;
+alter table public.agent_behavior
+  add column qualification_transfer_conditions text not null default '';

--- a/supabase/migrations/20250214000000_add_qualification_transfer_rule.sql
+++ b/supabase/migrations/20250214000000_add_qualification_transfer_rule.sql
@@ -1,0 +1,1 @@
+alter table public.agent_behavior add column qualification_transfer_rule text not null default '';

--- a/supabase/migrations/20250214000000_add_qualification_transfer_rule.sql
+++ b/supabase/migrations/20250214000000_add_qualification_transfer_rule.sql
@@ -1,1 +1,3 @@
-alter table public.agent_behavior add column qualification_transfer_rule text not null default '';
+create type public.qualification_transfer_rule as enum ('never', 'user_request', 'lead_interested');
+alter table public.agent_behavior
+  add column qualification_transfer_rule public.qualification_transfer_rule not null default 'never'::qualification_transfer_rule;


### PR DESCRIPTION
## Summary
- add qualification transfer rule column and migration
- wire rule into behavior configuration, API, templates and instructions
- ensure new agents save default transfer rules

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aba3bb1e40832fa9a2f69f7fec4ee4