### PR TITLE
Proxy N8N upload through internal API route

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,5 @@ AUTH_MAX_AGE=7200
 ASAAS_API_KEY=asaas_test_<seu_token_aqui>
 ASAAS_API_URL=https://api-sandbox.asaas.com/v3
 NEXT_PUBLIC_APP_URL=
+N8N_WEBHOOK_URL=
+N8N_WEBHOOK_TOKEN=

--- a/README.md
+++ b/README.md
@@ -33,8 +33,10 @@ Este repositório contém uma aplicação [Next.js](https://nextjs.org/) prepara
    ```
 
 2. Faça o deploy na [Vercel](https://vercel.com/) (via CLI ou integração com Git). O processo padrão consiste em:
-   - Configurar as variáveis de ambiente no painel da Vercel.
+   - Configurar as variáveis de ambiente no painel da Vercel (incluindo `N8N_WEBHOOK_URL` e `N8N_WEBHOOK_TOKEN`, usadas pelo endpoint interno `/api/knowledge-base/upload`).
    - Realizar o push para o branch principal para disparar o deploy automático **ou** utilizar o comando `vercel --prod`.
+
+> O fluxo do N8N deve validar o token enviado no header `Authorization` antes de aceitar o upload.
 
 ## 🔗 Links Úteis
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,5 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {
-  /* config options here */
-};
+const nextConfig: NextConfig = {};
 
 export default nextConfig;

--- a/src/app/api/knowledge-base/upload/route.ts
+++ b/src/app/api/knowledge-base/upload/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const path_id = searchParams.get("path_id");
+  const company_id = searchParams.get("company_id");
+  const agent_id = searchParams.get("agent_id");
+
+  if (!path_id || !company_id || !agent_id) {
+    return NextResponse.json({ error: "Missing parameters" }, { status: 400 });
+  }
+
+  const webhookUrl = process.env.N8N_WEBHOOK_URL;
+  const webhookToken = process.env.N8N_WEBHOOK_TOKEN;
+
+  if (!webhookUrl || !webhookToken) {
+    return NextResponse.json({ error: "Webhook not configured" }, { status: 500 });
+  }
+
+  const formData = await req.formData();
+  const file = formData.get("file");
+  if (!(file instanceof Blob)) {
+    return NextResponse.json({ error: "File not provided" }, { status: 400 });
+  }
+
+  const response = await fetch(
+    `${webhookUrl}?path_id=${path_id}&company_id=${company_id}&agent_id=${agent_id}`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": (file as File).type || "application/octet-stream",
+        Authorization: `Bearer ${webhookToken}`,
+      },
+      body: file,
+    }
+  );
+
+  if (!response.ok) {
+    return NextResponse.json(
+      { error: "Webhook upload failed" },
+      { status: response.status }
+    );
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/dashboard/agents/[id]/base-conhecimento/page.tsx
+++ b/src/app/dashboard/agents/[id]/base-conhecimento/page.tsx
@@ -156,14 +156,13 @@ export default function AgentKnowledgeBasePage() {
       return;
     }
     try {
+      const uploadData = new FormData();
+      uploadData.append("file", uploadFile);
       const response = await fetch(
-        `https://n8nwebhookplatform.tracelead.com.br/webhook/add-file-vector?path_id=${fileId}&company_id=${agent.company_id}&agent_id=${id}`,
+        `/api/knowledge-base/upload?path_id=${fileId}&company_id=${agent.company_id}&agent_id=${id}`,
         {
           method: "POST",
-          body: uploadFile,
-          headers: {
-            "Content-Type": file.type,
-          },
+          body: uploadData,
         }
       );
       if (!response.ok) {


### PR DESCRIPTION
## Summary
- route N8N knowledge base uploads through a protected `/api/knowledge-base/upload` endpoint
- remove client-side exposure of `N8N_WEBHOOK_URL` and `N8N_WEBHOOK_TOKEN`
- document new server-side webhook proxy in deployment instructions

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aba318e804832fa32e77c105329114