### PR TITLE
Remove doc-based file types from knowledge base

### DIFF
--- a/src/app/dashboard/agents/[id]/base-conhecimento/page.tsx
+++ b/src/app/dashboard/agents/[id]/base-conhecimento/page.tsx
@@ -55,8 +55,6 @@ export default function AgentKnowledgeBasePage() {
   const mimeToExt: Record<string, string> = {
     "application/pdf": "PDF",
     "text/plain": "TXT",
-    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": "DOCX",
-    "application/msword": "DOC",
   };
   const allowedFileTypes = ALLOWED_KNOWLEDGE_MIME_TYPES.map(
     (type) => mimeToExt[type] || type

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -9,8 +9,6 @@ export const ALLOWED_AGENT_TYPES = [
 export const ALLOWED_KNOWLEDGE_MIME_TYPES = [
   "application/pdf",
   "text/plain",
-  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-  "application/msword",
 ];
 
 export const MAX_KNOWLEDGE_FILE_SIZE = 10 * 1024 * 1024; // 10MB


### PR DESCRIPTION
## Summary
- stop accepting `.doc` and `.docx` documents in knowledge base

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acdbf08550832fa14bf431e9756523