### PR TITLE
feat: add inteligencia landing page and multi-landing layout

### DIFF
--- a/components/landings/inteligencia/CTA.tsx
+++ b/components/landings/inteligencia/CTA.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+export default function CTA() {
+  return (
+    <section className="bg-primary text-primary-foreground py-12 md:py-20">
+      <div className="mx-auto max-w-[1140px] px-3 md:px-4 lg:px-6 text-center space-y-6">
+        <h2 className="text-3xl font-bold">Pronto para oferecer atendimento inteligente?</h2>
+        <p>Crie sua conta gratuitamente e implemente IA no seu atendimento hoje mesmo.</p>
+        <Link href="/signup">
+          <Button size="lg" variant="secondary">
+            Criar conta
+          </Button>
+        </Link>
+      </div>
+    </section>
+  );
+}
+

--- a/components/landings/inteligencia/Features.tsx
+++ b/components/landings/inteligencia/Features.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Bot, MessageSquare, LineChart } from "lucide-react";
+
+const items = [
+  {
+    title: "Chatbots treinados",
+    description: "Configure assistentes virtuais que entendem o contexto das conversas.",
+    icon: Bot,
+  },
+  {
+    title: "Centralização de canais",
+    description: "Integre WhatsApp e outros canais em um único painel.",
+    icon: MessageSquare,
+  },
+  {
+    title: "Relatórios em tempo real",
+    description: "Acompanhe métricas de atendimento com dashboards intuitivos.",
+    icon: LineChart,
+  },
+];
+
+export default function Features() {
+  return (
+    <section className="py-12 md:py-20" id="features">
+      <div className="mx-auto max-w-[1140px] px-3 md:px-4 lg:px-6">
+        <h2 className="mb-8 text-center text-3xl font-bold">Recursos</h2>
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {items.map(({ title, description, icon: Icon }) => (
+            <Card key={title} className="h-full">
+              <CardHeader>
+                <Icon className="mb-2 h-6 w-6 text-primary" />
+                <CardTitle>{title}</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm text-muted-foreground">{description}</p>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+

--- a/components/landings/inteligencia/Hero.tsx
+++ b/components/landings/inteligencia/Hero.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+export default function Hero() {
+  return (
+    <section className="bg-[#FAFAFA] py-12 md:py-20">
+      <div className="mx-auto max-w-[1140px] px-3 md:px-4 lg:px-6 text-center space-y-6">
+        <h1 className="text-4xl font-bold sm:text-5xl">
+          Atendimento inteligente para seu negócio
+        </h1>
+        <p className="text-lg text-muted-foreground">
+          Utilize agentes com IA para responder seus clientes com rapidez e eficiência.
+        </p>
+        <div className="flex flex-col gap-4 sm:flex-row justify-center">
+          <Link href="/signup">
+            <Button size="lg">Começar agora</Button>
+          </Link>
+          <Link href="/contact">
+            <Button variant="outline" size="lg">
+              Fale conosco
+            </Button>
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}
+

--- a/src/app/landings/inteligencia/page.tsx
+++ b/src/app/landings/inteligencia/page.tsx
@@ -1,0 +1,20 @@
+import Hero from "@/components/landings/inteligencia/Hero";
+import Features from "@/components/landings/inteligencia/Features";
+import CTA from "@/components/landings/inteligencia/CTA";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Inteligência no Atendimento",
+  description: "Automatize e personalize o atendimento com IA.",
+};
+
+export default function InteligenciaPage() {
+  return (
+    <>
+      <Hero />
+      <Features />
+      <CTA />
+    </>
+  );
+}
+

--- a/src/app/landings/layout.tsx
+++ b/src/app/landings/layout.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from "react";
+import Header from "@/components/landing/Header";
+import Footer from "@/components/landing/Footer";
+
+export default function LandingLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <Header />
+      <main className="flex flex-col">{children}</main>
+      <Footer />
+    </>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add shared layout for future landing pages
- implement first landing page following Inteligencia Atendimento structure

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acdc35a500832fb1c0e266a1344d0e