### PR TITLE
feat: add new landing page skeleton

### DIFF
--- a/src/app/landing/components/CTASection.tsx
+++ b/src/app/landing/components/CTASection.tsx
@@ -1,0 +1,19 @@
+interface CTA {
+  title: string;
+  href: string;
+}
+
+export default function CTASection({ cta }: { cta: CTA }) {
+  return (
+    <section className="py-16 text-center">
+      <h2 className="mb-4 text-2xl font-bold">{cta.title}</h2>
+      <a
+        href={cta.href}
+        target="_blank"
+        className="inline-block rounded bg-green-600 px-6 py-3 text-white"
+      >
+        WhatsApp
+      </a>
+    </section>
+  );
+}

--- a/src/app/landing/components/Checklist.tsx
+++ b/src/app/landing/components/Checklist.tsx
@@ -1,0 +1,40 @@
+interface ChecklistItem {
+  item: string;
+  value: string;
+}
+
+export default function Checklist({
+  comparison,
+  benefits,
+}: {
+  comparison: ChecklistItem[];
+  benefits: string[];
+}) {
+  return (
+    <section id="planos" className="bg-gray-50 py-16">
+      <div className="mx-auto grid max-w-6xl gap-8 md:grid-cols-2">
+        <div>
+          <h2 className="mb-4 text-2xl font-bold">Comparativo</h2>
+          <ul className="space-y-2">
+            {comparison.map((c) => (
+              <li key={c.item} className="flex justify-between border-b pb-2 text-sm">
+                <span>{c.item}</span>
+                <span className="font-semibold">{c.value}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <h2 className="mb-4 text-2xl font-bold">Benefícios</h2>
+          <ul className="space-y-2">
+            {benefits.map((b) => (
+              <li key={b} className="text-sm">
+                {b}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/landing/components/FeatureCards.tsx
+++ b/src/app/landing/components/FeatureCards.tsx
@@ -1,0 +1,21 @@
+interface Agent {
+  name: string;
+  desc: string;
+  icon: string;
+}
+
+export default function FeatureCards({ agents }: { agents: Agent[] }) {
+  return (
+    <section className="bg-gray-50 py-16">
+      <div className="mx-auto grid max-w-6xl gap-6 md:grid-cols-3">
+        {agents.map((agent) => (
+          <div key={agent.name} className="rounded border bg-white p-6 text-center">
+            <img src={agent.icon} alt="" className="mx-auto h-12 w-12" />
+            <h3 className="mt-4 text-xl font-semibold">{agent.name}</h3>
+            <p className="mt-2 text-sm">{agent.desc}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/app/landing/components/Footer.tsx
+++ b/src/app/landing/components/Footer.tsx
@@ -1,0 +1,21 @@
+interface FooterLink {
+  label: string;
+  href: string;
+}
+
+export default function Footer({ links }: { links: FooterLink[] }) {
+  return (
+    <footer className="bg-gray-900 py-8 text-white">
+      <div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-4 px-4 md:flex-row">
+        <p className="text-sm">&copy; {new Date().getFullYear()}</p>
+        <div className="flex gap-4">
+          {links.map((link) => (
+            <a key={link.href} href={link.href} target="_blank" className="text-sm">
+              {link.label}
+            </a>
+          ))}
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/src/app/landing/components/Header.tsx
+++ b/src/app/landing/components/Header.tsx
@@ -1,0 +1,34 @@
+import Link from "next/link";
+
+interface NavItem {
+  label: string;
+  href: string;
+}
+
+interface CTA {
+  label: string;
+  href: string;
+}
+
+export default function Header({ nav, cta }: { nav: NavItem[]; cta: CTA }) {
+  return (
+    <header className="fixed top-0 left-0 right-0 bg-white shadow z-50">
+      <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3">
+        <nav className="flex space-x-4">
+          {nav.map((item) => (
+            <a key={item.href} href={item.href} className="text-sm font-medium">
+              {item.label}
+            </a>
+          ))}
+        </nav>
+        <Link
+          href={cta.href}
+          className="rounded bg-green-600 px-4 py-2 text-white"
+          target="_blank"
+        >
+          {cta.label}
+        </Link>
+      </div>
+    </header>
+  );
+}

--- a/src/app/landing/components/Hero.tsx
+++ b/src/app/landing/components/Hero.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+
+interface HeroData {
+  h1: string;
+  bullets: string[];
+  image: string;
+}
+
+interface CTA {
+  label: string;
+  href: string;
+}
+
+export default function Hero({ data, cta }: { data: HeroData; cta: CTA }) {
+  return (
+    <section className="container mx-auto flex flex-col items-center gap-8 py-24 md:flex-row">
+      <div className="flex-1 space-y-4">
+        <h1 className="text-4xl font-bold md:text-5xl">{data.h1}</h1>
+        <ul className="space-y-2">
+          {data.bullets.map((bullet) => (
+            <li key={bullet} className="text-lg">
+              {bullet}
+            </li>
+          ))}
+        </ul>
+        <Link
+          href={cta.href}
+          className="inline-block rounded bg-green-600 px-6 py-3 text-white"
+          target="_blank"
+        >
+          {cta.label}
+        </Link>
+      </div>
+      <div className="flex-1">
+        <img src={data.image} alt="banner" className="w-full" />
+      </div>
+    </section>
+  );
+}

--- a/src/app/landing/components/IndustryGrid.tsx
+++ b/src/app/landing/components/IndustryGrid.tsx
@@ -1,0 +1,22 @@
+interface Industry {
+  name: string;
+  desc: string;
+}
+
+export default function IndustryGrid({ industries }: { industries: Industry[] }) {
+  return (
+    <section className="py-16">
+      <div className="mx-auto max-w-6xl">
+        <h2 className="mb-8 text-center text-2xl font-bold">Setores atendidos</h2>
+        <div className="grid grid-cols-2 gap-6 md:grid-cols-3">
+          {industries.map((ind) => (
+            <div key={ind.name} className="rounded border p-4 text-center">
+              <h3 className="font-semibold">{ind.name}</h3>
+              <p className="text-sm">{ind.desc}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/landing/components/KPIList.tsx
+++ b/src/app/landing/components/KPIList.tsx
@@ -1,0 +1,19 @@
+interface KPI {
+  label: string;
+  value: string;
+}
+
+export default function KPIList({ kpis }: { kpis: KPI[] }) {
+  return (
+    <section className="bg-gray-50 py-12">
+      <div className="mx-auto grid max-w-6xl grid-cols-2 gap-6 text-center md:grid-cols-4">
+        {kpis.map((kpi) => (
+          <div key={kpi.label} className="space-y-2">
+            <p className="text-3xl font-bold">{kpi.value}</p>
+            <p className="text-sm">{kpi.label}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/app/landing/components/LogosMarquee.tsx
+++ b/src/app/landing/components/LogosMarquee.tsx
@@ -1,0 +1,14 @@
+export default function LogosMarquee({ logos }: { logos: string[] }) {
+  return (
+    <section className="py-16">
+      <div className="mx-auto max-w-4xl">
+        <h2 className="mb-8 text-center text-2xl font-bold">Clientes</h2>
+        <div className="flex flex-wrap items-center justify-center gap-8">
+          {logos.map((logo) => (
+            <img key={logo} src={logo} alt="logo" className="h-12" />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/landing/components/OnboardingSteps.tsx
+++ b/src/app/landing/components/OnboardingSteps.tsx
@@ -1,0 +1,19 @@
+interface Step { title: string }
+
+export default function OnboardingSteps({ steps }: { steps: Step[] }) {
+  return (
+    <section className="py-16">
+      <div className="mx-auto max-w-4xl">
+        <h2 className="mb-8 text-center text-2xl font-bold">Implementação em 4 passos</h2>
+        <ol className="grid gap-4 md:grid-cols-4">
+          {steps.map((step, index) => (
+            <li key={step.title} className="rounded border p-4 text-center">
+              <div className="mb-2 text-3xl font-bold">{index + 1}</div>
+              <p className="text-sm">{step.title}</p>
+            </li>
+          ))}
+        </ol>
+      </div>
+    </section>
+  );
+}

--- a/src/app/landing/components/ProcessSteps.tsx
+++ b/src/app/landing/components/ProcessSteps.tsx
@@ -1,0 +1,38 @@
+interface Step {
+  title: string;
+  desc: string;
+}
+
+interface HowItWorks {
+  intro: string;
+  steps: Step[];
+  ctaHref?: string;
+}
+
+export default function ProcessSteps({ data, ctaLabel }: { data: HowItWorks; ctaLabel: string }) {
+  return (
+    <section id="como-funciona" className="bg-gray-50 py-16">
+      <div className="mx-auto max-w-6xl">
+        <h2 className="mb-4 text-center text-2xl font-bold">Como funciona</h2>
+        <p className="mb-8 text-center text-sm">{data.intro}</p>
+        <div className="grid gap-6 md:grid-cols-3">
+          {data.steps.map((step) => (
+            <div key={step.title} className="rounded border bg-white p-4">
+              <h3 className="font-semibold">{step.title}</h3>
+              <p className="text-sm">{step.desc}</p>
+            </div>
+          ))}
+        </div>
+        <div className="mt-8 text-center">
+          <a
+            href={data.ctaHref}
+            target="_blank"
+            className="rounded bg-green-600 px-6 py-3 text-white"
+          >
+            {ctaLabel}
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/landing/components/StickyWhatsAppButton.tsx
+++ b/src/app/landing/components/StickyWhatsAppButton.tsx
@@ -1,0 +1,11 @@
+export default function StickyWhatsAppButton({ href }: { href: string }) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      className="fixed bottom-4 right-4 rounded-full bg-green-600 p-4 text-white shadow-lg"
+    >
+      WA
+    </a>
+  );
+}

--- a/src/app/landing/components/TestimonialsCarousel.tsx
+++ b/src/app/landing/components/TestimonialsCarousel.tsx
@@ -1,0 +1,22 @@
+interface Testimonial {
+  image: string;
+  text: string;
+}
+
+export default function TestimonialsCarousel({ testimonials }: { testimonials: Testimonial[] }) {
+  return (
+    <section id="depoimentos" className="py-16">
+      <div className="mx-auto max-w-3xl text-center">
+        <h2 className="mb-8 text-2xl font-bold">Depoimentos</h2>
+        <div className="flex snap-x gap-6 overflow-x-auto">
+          {testimonials.map((t, idx) => (
+            <div key={idx} className="snap-center min-w-full rounded border p-6">
+              <img src={t.image} alt="" className="mx-auto h-16 w-16 rounded-full" />
+              <p className="mt-4 text-sm">{t.text}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/landing/components/ValueProp.tsx
+++ b/src/app/landing/components/ValueProp.tsx
@@ -1,0 +1,13 @@
+interface ValuePropData {
+  title: string;
+  text: string;
+}
+
+export default function ValueProp({ data }: { data: ValuePropData }) {
+  return (
+    <section className="py-16 text-center">
+      <h2 className="text-2xl font-bold md:text-3xl">{data.title}</h2>
+      <p className="mx-auto mt-4 max-w-3xl text-lg">{data.text}</p>
+    </section>
+  );
+}

--- a/src/app/landing/data.ts
+++ b/src/app/landing/data.ts
@@ -1,0 +1,86 @@
+export const landingData = {
+  nav: [
+    { label: "Como funciona", href: "#como-funciona" },
+    { label: "Depoimentos", href: "#depoimentos" },
+    { label: "Planos", href: "#planos" }
+  ],
+  cta_primary: { label: "Fale com um consultor", href: "https://wa.me/..." },
+  hero: {
+    h1: "Automatize seu atendimento e venda mais!",
+    bullets: [
+      "Atendimento 24h",
+      "Reduza custos com equipe",
+      "Integração no seu WhatsApp"
+    ],
+    image: "/hero.png"
+  },
+  kpis: [
+    { label: "Redução de custo", value: "-72%" },
+    { label: "Conversão em vendas", value: "+56%" },
+    { label: "Segmentos", value: "34" },
+    { label: "Usuários", value: "4.785" }
+  ],
+  value_prop: {
+    title: "Tenha um funcionário de IA no seu atendimento",
+    text: "Se você usa o WhatsApp... temos a solução!"
+  },
+  agents: [
+    { name: "Suporte", desc: "Tira dúvidas, orienta, envia links", icon: "/file.svg" },
+    { name: "Atendente", desc: "Agenda, coleta info, agiliza humano", icon: "/file.svg" },
+    { name: "Vendedor", desc: "Qualifica, oferece, ajuda a decidir", icon: "/file.svg" }
+  ],
+  industries: [
+    { name: "Dentistas", desc: "Agende mais consultas" },
+    { name: "Médicos", desc: "Automatize agendamentos" },
+    { name: "Salão e Barbearia", desc: "Mais agendamentos" },
+    { name: "Advogados", desc: "Qualifique clientes" },
+    { name: "Pet Shops", desc: "Vendas e serviços" },
+    { name: "Info Produtores", desc: "Atendimento humanizado" }
+  ],
+  how_it_works: {
+    intro: "Integrado ao seu número",
+    steps: [
+      { title: "Início do atendimento", desc: "Mensagens iniciais e serviços" },
+      { title: "Coleta de informações", desc: "Perguntas definidas com o cliente" },
+      { title: "Agendamento no Google", desc: "Consulta/salva no Google Agenda" }
+    ]
+  },
+  onboarding_4steps: [
+    { title: "Coleta de informações" },
+    { title: "Teste (até 7 dias)" },
+    { title: "Integração" },
+    { title: "Contratação" }
+  ],
+  comparison_checklist: [
+    { item: "Contrato com fidelidade", value: "Não" },
+    { item: "Integração Google Agenda", value: "Sim" },
+    { item: "Integração Google Planilhas", value: "Sim" },
+    { item: "Sites de consulta de dados", value: "Sim" },
+    { item: "Suporte dúvidas", value: "Sim" },
+    { item: "Suporte alterações", value: "Sim" },
+    { item: "Acesso curso WhatsApp estratégico", value: "Sim" }
+  ],
+  benefits: [
+    "Investimento baixo",
+    "Acompanhamento",
+    "Mensal",
+    "Atendimento 24h",
+    "Respostas personalizadas",
+    "Qualificação de leads",
+    "Redução de espera",
+    "Integrado ao seu número"
+  ],
+  testimonials: [
+    { image: "/hero.png", text: "Depoimento 1" },
+    { image: "/hero.png", text: "Depoimento 2" }
+  ],
+  clients_logos: ["/logo.svg", "/logo-sidebar.svg", "/vercel.svg"],
+  cta_final: { title: "Solicite um teste gratuito!", href: "https://wa.me/..." },
+  footer: {
+    links: [
+      { label: "Política de Privacidade", href: "/politica-de-privacidade" },
+      { label: "Instagram", href: "https://instagram.com" },
+      { label: "Facebook", href: "https://facebook.com" }
+    ]
+  }
+};

--- a/src/app/landing/page.tsx
+++ b/src/app/landing/page.tsx
@@ -1,0 +1,39 @@
+import Header from "./components/Header";
+import Hero from "./components/Hero";
+import KPIList from "./components/KPIList";
+import ValueProp from "./components/ValueProp";
+import FeatureCards from "./components/FeatureCards";
+import IndustryGrid from "./components/IndustryGrid";
+import ProcessSteps from "./components/ProcessSteps";
+import OnboardingSteps from "./components/OnboardingSteps";
+import Checklist from "./components/Checklist";
+import TestimonialsCarousel from "./components/TestimonialsCarousel";
+import LogosMarquee from "./components/LogosMarquee";
+import CTASection from "./components/CTASection";
+import StickyWhatsAppButton from "./components/StickyWhatsAppButton";
+import Footer from "./components/Footer";
+import { landingData } from "./data";
+
+export default function LandingPage() {
+  const d = landingData;
+  return (
+    <>
+      <Header nav={d.nav} cta={d.cta_primary} />
+      <main className="pt-16">
+        <Hero data={d.hero} cta={d.cta_primary} />
+        <KPIList kpis={d.kpis} />
+        <ValueProp data={d.value_prop} />
+        <FeatureCards agents={d.agents} />
+        <IndustryGrid industries={d.industries} />
+        <ProcessSteps data={{ ...d.how_it_works, ctaHref: d.cta_primary.href }} ctaLabel={d.cta_primary.label} />
+        <OnboardingSteps steps={d.onboarding_4steps} />
+        <Checklist comparison={d.comparison_checklist} benefits={d.benefits} />
+        <TestimonialsCarousel testimonials={d.testimonials} />
+        <LogosMarquee logos={d.clients_logos} />
+        <CTASection cta={d.cta_final} />
+      </main>
+      <StickyWhatsAppButton href={d.cta_final.href} />
+      <Footer links={d.footer.links} />
+    </>
+  );
+}

--- a/src/app/politica-de-privacidade/page.tsx
+++ b/src/app/politica-de-privacidade/page.tsx
@@ -1,0 +1,25 @@
+import Header from "../landing/components/Header";
+import Footer from "../landing/components/Footer";
+import { landingData } from "../landing/data";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Política de Privacidade",
+};
+
+export default function PoliticaPage() {
+  const d = landingData;
+  return (
+    <>
+      <Header nav={d.nav} cta={d.cta_primary} />
+      <main className="mx-auto max-w-3xl space-y-4 py-24">
+        <h1 className="text-3xl font-bold">Política de Privacidade</h1>
+        <p>
+          Esta é uma página de exemplo de política de privacidade para a nova
+          landing page.
+        </p>
+      </main>
+      <Footer links={d.footer.links} />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add data-driven landing page route with sections and sticky WhatsApp CTA
- include static privacy policy page

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ace60653cc832f921c7463fd7fa4d3