### PR TITLE
Add video section to landing page

### DIFF
--- a/components/landing/Video.tsx
+++ b/components/landing/Video.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+export default function Video() {
+  return (
+    <section className="py-8 md:py-12 lg:py-16">
+      <div className="mx-auto max-w-[1140px] px-3 md:px-4 lg:px-6">
+        <h2 className="mb-8 text-center text-3xl font-bold">Veja em ação</h2>
+        <div className="relative mx-auto w-full overflow-hidden rounded-lg shadow-lg" style={{paddingTop: "56.25%"}}>
+          <iframe
+            className="absolute left-0 top-0 h-full w-full"
+            src="https://www.youtube.com/embed/dQw4w9WgXcQ?controls=0&rel=0&showinfo=0"
+            title="Demonstração"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowFullScreen
+          ></iframe>
+        </div>
+      </div>
+    </section>
+  );
+}
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import Header from "@/components/landing/Header";
 import Hero from "@/components/landing/Hero";
 import Features from "@/components/landing/Features";
+import Video from "@/components/landing/Video";
 import Stats from "@/components/landing/Stats";
 import Benefit from "@/components/landing/Benefit";
 import Testimonials from "@/components/landing/Testimonials";
@@ -43,6 +44,7 @@ export default function HomePage() {
       <main className="flex flex-col">
         <Hero />
         <Features />
+        <Video />
         <Stats />
         <Benefit
           tag="IA + CRM"


### PR DESCRIPTION
## Summary
- embed conversion-focused video section after the solutions block on the landing page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ace94da834832fa972874a908bee86