### PR TITLE
Add static video section to landing page

### DIFF
--- a/components/landing/Video.tsx
+++ b/components/landing/Video.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+export default function Video() {
+  return (
+    <section className="py-8 md:py-12 lg:py-16">
+      <div className="mx-auto max-w-[1140px] px-3 md:px-4 lg:px-6">
+        <h2 className="mb-8 text-center text-3xl font-bold">Veja em ação</h2>
+        <div className="mx-auto w-full lg:w-[70%] aspect-video overflow-hidden rounded-lg shadow-lg">
+          <video
+            className="h-full w-full object-cover"
+            src="/demo.mp4"
+            autoPlay
+            muted
+            loop
+            playsInline
+          />
+        </div>
+      </div>
+    </section>
+  );
+}
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import Header from "@/components/landing/Header";
 import Hero from "@/components/landing/Hero";
 import Features from "@/components/landing/Features";
+import Video from "@/components/landing/Video";
 import Stats from "@/components/landing/Stats";
 import Benefit from "@/components/landing/Benefit";
 import Testimonials from "@/components/landing/Testimonials";
@@ -43,6 +44,7 @@ export default function HomePage() {
       <main className="flex flex-col">
         <Hero />
         <Features />
+        <Video />
         <Stats />
         <Benefit
           tag="IA + CRM"


### PR DESCRIPTION
## Summary
- replace YouTube embed with a locally hosted video
- scale video to 70% width on desktops for a smaller footprint
- remove placeholder `demo.mp4` asset so users can supply their own video

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ace94da834832fa972874a908bee86