### PR TITLE
feat: add dark landing page variant

### DIFF
--- a/src/app/dark/layout.tsx
+++ b/src/app/dark/layout.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { useEffect, type ReactNode } from "react";
+
+export default function DarkLayout({ children }: { children: ReactNode }) {
+  useEffect(() => {
+    document.documentElement.classList.add("dark");
+    return () => {
+      document.documentElement.classList.remove("dark");
+    };
+  }, []);
+
+  return <>{children}</>;
+}

--- a/src/app/dark/page.tsx
+++ b/src/app/dark/page.tsx
@@ -1,0 +1,5 @@
+import HomePage from "../page";
+
+export default function DarkHomePage() {
+  return <HomePage />;
+}


### PR DESCRIPTION
## Summary
- add dark landing page variant under /dark
- toggle dark theme via layout side effect

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ae5ce41158832f92baa3139e8d8f8b