### PR TITLE
feat: add descriptions to agent menus

### DIFF
--- a/src/app/dashboard/agents/[id]/base-conhecimento/page.tsx
+++ b/src/app/dashboard/agents/[id]/base-conhecimento/page.tsx
@@ -235,6 +235,9 @@ export default function AgentKnowledgeBasePage() {
 
       <div className="flex justify-center">
         <Card className="w-full md:w-4/5 p-6">
+          <p className="text-xs italic text-gray-500 mb-4">
+            Adicione arquivos para compor a base de conhecimento do agente.
+          </p>
           <div className="flex flex-col gap-6">
             <h2 className="text-xl font-semibold">Cérebro</h2>
             <div className="flex flex-col gap-6 md:flex-row">

--- a/src/app/dashboard/agents/[id]/comportamento/page.tsx
+++ b/src/app/dashboard/agents/[id]/comportamento/page.tsx
@@ -130,6 +130,9 @@ export default function AgentBehaviorPage() {
       <AgentGuide />
       <div className="flex justify-center">
         <Card className="w-full md:w-4/5 p-6">
+          <p className="text-xs italic text-gray-500 mb-4">
+            Configure como o agente deve se comportar durante as interações.
+          </p>
           <form onSubmit={handleSubmit} className="space-y-6">
             <div className="space-y-2">
               <label htmlFor="limitations" className="text-sm font-medium">

--- a/src/app/dashboard/agents/[id]/instrucoes-especificas/page.tsx
+++ b/src/app/dashboard/agents/[id]/instrucoes-especificas/page.tsx
@@ -140,6 +140,9 @@ export default function AgentSpecificInstructionsPage() {
       <AgentGuide />
       <div className="flex justify-center">
         <Card className="w-full md:w-4/5 p-6">
+          <p className="text-xs italic text-gray-500 mb-4">
+            Crie respostas específicas para situações ou perguntas frequentes.
+          </p>
           <form onSubmit={handleSubmit} className="space-y-6">
             {faqs.map((faq, index) => (
               <div

--- a/src/app/dashboard/agents/[id]/onboarding/page.tsx
+++ b/src/app/dashboard/agents/[id]/onboarding/page.tsx
@@ -130,6 +130,9 @@ export default function AgentOnboardingPage() {
       <AgentGuide />
       <div className="flex justify-center">
         <Card className="w-full md:w-4/5 p-6">
+          <p className="text-xs italic text-gray-500 mb-4">
+            Personalize a mensagem inicial e colete dados essenciais dos usuários.
+          </p>
           <form onSubmit={handleSubmit} className="space-y-6">
             <div className="space-y-2">
               <label htmlFor="welcome" className="text-sm font-medium">

--- a/src/app/dashboard/agents/[id]/page.tsx
+++ b/src/app/dashboard/agents/[id]/page.tsx
@@ -107,6 +107,9 @@ export default function AgentDetailPage() {
       <AgentGuide />
       <div className="flex justify-center">
         <Card className="w-full md:w-4/5 p-6">
+          <p className="text-xs italic text-gray-500 mb-4">
+            Defina a personalidade e os objetivos do agente.
+          </p>
           <form onSubmit={handleSubmit} className="space-y-6">
             <div className="flex flex-col gap-4 md:flex-row">
               <div className="flex-1 space-y-2">


### PR DESCRIPTION
## Summary
- add introductory descriptions to agent personality, behavior, knowledge base, onboarding, and specific instructions menus

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae625caa18832f8d38339d5a1622bc