### PR TITLE
feat: add mascot overlay to hero

### DIFF
--- a/components/landing/Hero.tsx
+++ b/components/landing/Hero.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
+import Mascot from "@/components/landing/Mascot";
 import { Button } from "@/components/ui/button";
 
 export default function Hero() {
@@ -28,7 +29,7 @@ export default function Hero() {
             </Link>
           </div>
         </div>
-        <div className="flex justify-center lg:col-span-6">
+        <div className="relative flex justify-center lg:col-span-6">
           <Image
             src="/hero.png"
             alt="Ilustração"
@@ -36,6 +37,7 @@ export default function Hero() {
             height={600}
             className="h-auto w-full max-w-[600px] rounded-md"
           />
+          <Mascot className="absolute -right-4 -bottom-4 w-24 h-24" />
         </div>
       </div>
     </section>

--- a/components/landing/Mascot.tsx
+++ b/components/landing/Mascot.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import Image from "next/image";
+import { cn } from "@/lib/utils";
+
+interface MascotProps {
+  className?: string;
+}
+
+export default function Mascot({ className }: MascotProps) {
+  return (
+    <Image
+      src="/mascot.png"
+      alt="Mascote"
+      width={160}
+      height={160}
+      className={cn("animate-float", className)}
+      priority={false}
+    />
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -145,3 +145,21 @@ body,
   }
 }
 
+@layer utilities {
+  @keyframes float {
+    0% {
+      transform: translateY(0);
+    }
+    50% {
+      transform: translateY(-10px);
+    }
+    100% {
+      transform: translateY(0);
+    }
+  }
+
+  .animate-float {
+    animation: float 3s ease-in-out infinite;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add animated mascot component
- overlay mascot on landing hero image
- introduce floating animation utility

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ae6a633a90832f897c9fc4e1e0fd34