### PR TITLE
Add pulse animation to hero mascot

### DIFF
--- a/components/landing/Hero.tsx
+++ b/components/landing/Hero.tsx
@@ -34,7 +34,7 @@ export default function Hero() {
             alt="Ilustração"
             width={600}
             height={600}
-            className="h-auto w-full max-w-[600px] rounded-md"
+            className="h-auto w-full max-w-[600px] rounded-md animate-pulse-scale"
           />
         </div>
       </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -161,5 +161,18 @@ body,
   .animate-float {
     animation: float 3s ease-in-out infinite;
   }
+
+  @keyframes pulse {
+    0%, 100% {
+      transform: scale(1);
+    }
+    50% {
+      transform: scale(1.05);
+    }
+  }
+
+  .animate-pulse-scale {
+    animation: pulse 2s ease-in-out infinite;
+  }
 }
 


### PR DESCRIPTION
## Summary
- add pulse keyframes and utility class
- animate mascot image in hero

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae711c6a44832fa842e013510e89a6