### PR TITLE
feat: centralize AgentType union for agents

### DIFF
--- a/components/agents/AgentMenu.tsx
+++ b/components/agents/AgentMenu.tsx
@@ -13,11 +13,12 @@ import {
   Database,
   ClipboardList,
 } from "lucide-react";
+import { AgentType } from "@/lib/types";
 
 type Agent = {
   id: string;
   name: string;
-  type: string;
+  type: AgentType;
   is_active: boolean;
 };
 

--- a/components/agents/AgentTypeCard.tsx
+++ b/components/agents/AgentTypeCard.tsx
@@ -1,13 +1,14 @@
 import { Card, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { cn } from "@/components/ui/utils";
+import { AgentType } from "@/lib/types";
 
 interface AgentTypeCardProps {
-  value: string;
+  value: AgentType;
   title: string;
   description: string;
   selected: boolean;
   disabled?: boolean;
-  onSelect: (value: string) => void;
+  onSelect: (value: AgentType) => void;
 }
 
 export function AgentTypeCard({

--- a/src/app/dashboard/agents/[id]/base-conhecimento/page.tsx
+++ b/src/app/dashboard/agents/[id]/base-conhecimento/page.tsx
@@ -23,11 +23,12 @@ import AgentMenu from "@/components/agents/AgentMenu";
 import AgentGuide from "@/components/agents/AgentGuide";
 import DeactivateAgentButton from "@/components/agents/DeactivateAgentButton";
 import ActivateAgentButton from "@/components/agents/ActivateAgentButton";
+import { AgentType } from "@/lib/types";
 
 interface Agent {
   id: string;
   name: string;
-  type: string;
+  type: AgentType;
   is_active: boolean;
   company_id: number;
 }

--- a/src/app/dashboard/agents/[id]/comportamento/page.tsx
+++ b/src/app/dashboard/agents/[id]/comportamento/page.tsx
@@ -24,11 +24,12 @@ import {
   QUALIFICATION_TRANSFER_RULES,
   QualificationTransferRule,
 } from "@/lib/qualificationTransferRules";
+import { AgentType } from "@/lib/types";
 
 type Agent = {
   id: string;
   name: string;
-  type: string;
+  type: AgentType;
   is_active: boolean;
 };
 

--- a/src/app/dashboard/agents/[id]/instrucoes-especificas/page.tsx
+++ b/src/app/dashboard/agents/[id]/instrucoes-especificas/page.tsx
@@ -14,11 +14,12 @@ import AgentMenu from "@/components/agents/AgentMenu";
 import AgentGuide from "@/components/agents/AgentGuide";
 import DeactivateAgentButton from "@/components/agents/DeactivateAgentButton";
 import ActivateAgentButton from "@/components/agents/ActivateAgentButton";
+import { AgentType } from "@/lib/types";
 
 interface Agent {
   id: string;
   name: string;
-  type: string;
+  type: AgentType;
   is_active: boolean;
 }
 

--- a/src/app/dashboard/agents/[id]/onboarding/page.tsx
+++ b/src/app/dashboard/agents/[id]/onboarding/page.tsx
@@ -13,11 +13,12 @@ import AgentMenu from "@/components/agents/AgentMenu";
 import AgentGuide from "@/components/agents/AgentGuide";
 import DeactivateAgentButton from "@/components/agents/DeactivateAgentButton";
 import ActivateAgentButton from "@/components/agents/ActivateAgentButton";
+import { AgentType } from "@/lib/types";
 
 type Agent = {
   id: string;
   name: string;
-  type: string;
+  type: AgentType;
   is_active: boolean;
 };
 

--- a/src/app/dashboard/agents/[id]/page.tsx
+++ b/src/app/dashboard/agents/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import { supabasebrowser } from "@/lib/supabaseClient";
 import { isValidAgentName } from "@/lib/validators";
+import { AgentType } from "@/lib/types";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -25,7 +26,7 @@ import ActivateAgentButton from "@/components/agents/ActivateAgentButton";
 type Agent = {
   id: string;
   name: string;
-  type: string;
+  type: AgentType;
   is_active: boolean;
 };
 

--- a/src/app/dashboard/agents/new/page.tsx
+++ b/src/app/dashboard/agents/new/page.tsx
@@ -18,16 +18,22 @@ import { isValidAgentName } from "@/lib/validators";
 import { toast } from "sonner";
 import { MAX_AGENTS_PER_COMPANY, ALLOWED_AGENT_TYPES } from "@/lib/constants";
 import { AGENT_TEMPLATES } from "@/lib/agentTemplates";
+import { AgentType } from "@/lib/types";
 
 export default function NewAgentPage() {
   const router = useRouter();
   const [name, setName] = useState("");
-  const [type, setType] = useState("");
+  const [type, setType] = useState<AgentType | "">("");
   const [companyId, setCompanyId] = useState<number | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [agentCount, setAgentCount] = useState(0);
 
-  const agentTypes = [
+  const agentTypes: {
+    value: AgentType;
+    title: string;
+    description: string;
+    disabled?: boolean;
+  }[] = [
     {
       value: "agendamento",
       title: "Agendamento",
@@ -70,7 +76,7 @@ export default function NewAgentPage() {
     e.preventDefault();
     if (!isFormValid || !companyId || isSubmitting) return;
 
-    if (!ALLOWED_AGENT_TYPES.includes(type)) {
+    if (!type || !ALLOWED_AGENT_TYPES.includes(type)) {
       toast.error("Tipo de agente inválido.");
       return;
     }
@@ -180,7 +186,7 @@ export default function NewAgentPage() {
                       description={option.description}
                       disabled={option.disabled}
                       selected={type === option.value}
-                      onSelect={setType}
+                      onSelect={(value) => setType(value)}
                     />
                   ))}
                 </div>

--- a/src/lib/agentTemplates.ts
+++ b/src/lib/agentTemplates.ts
@@ -1,4 +1,5 @@
 import { QualificationTransferRule } from './qualificationTransferRules';
+import { AgentType } from './types';
 
 export interface AgentTemplate {
   personality: {
@@ -20,7 +21,7 @@ export interface AgentTemplate {
   specificInstructions: { context: string; user_says: string; action: string }[];
 }
 
-export const AGENT_TEMPLATES: Record<string, AgentTemplate> = {
+export const AGENT_TEMPLATES: Record<AgentType, AgentTemplate> = {
   agendamento: {
     personality: {
       voice_tone: 'formal',

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,6 +1,8 @@
+import { AgentType } from "./types";
+
 export const MAX_AGENTS_PER_COMPANY = 5;
 
-export const ALLOWED_AGENT_TYPES = [
+export const ALLOWED_AGENT_TYPES: AgentType[] = [
   "agendamento",
   "sdr",
   "suporte",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,2 @@
+export type AgentType = 'agendamento' | 'sdr' | 'suporte';
+


### PR DESCRIPTION
## Summary
- add shared `AgentType` union
- use `AgentType` in agent components and pages
- type `ALLOWED_AGENT_TYPES` with `AgentType[]`

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af66df8e6c832f83c0bc4f7cf3d53f