### PR TITLE
Centraliza verticalmente o menu de navegação na edição de agentes

### DIFF
--- a/components/agents/AgentMenu.tsx
+++ b/components/agents/AgentMenu.tsx
@@ -80,8 +80,8 @@ export default function AgentMenu({ agent }: { agent: Agent }) {
             </p>
           </div>
         </Card>
-        <Card className="w-full md:flex-1 p-4 md:p-6 flex items-center justify-center">
-          <nav className="flex flex-wrap justify-center gap-2 md:flex-nowrap md:items-center md:justify-around md:gap-0">
+        <Card className="w-full md:flex-1 p-4 md:p-6 flex">
+          <nav className="flex h-full w-full flex-wrap items-center justify-center gap-2 md:flex-nowrap md:justify-around md:gap-0">
             {menuItems.map(({ label, icon: Icon, href }, index) => (
               <Fragment key={label}>
                 <Button

--- a/components/agents/AgentMenu.tsx
+++ b/components/agents/AgentMenu.tsx
@@ -80,7 +80,7 @@ export default function AgentMenu({ agent }: { agent: Agent }) {
             </p>
           </div>
         </Card>
-        <Card className="w-full md:flex-1 p-4 md:p-6">
+        <Card className="w-full md:flex-1 p-4 md:p-6 flex items-center justify-center">
           <nav className="flex flex-wrap justify-center gap-2 md:flex-nowrap md:items-center md:justify-around md:gap-0">
             {menuItems.map(({ label, icon: Icon, href }, index) => (
               <Fragment key={label}>


### PR DESCRIPTION
## Summary
- centraliza o menu de navegação na tela de edição de agentes para melhor alinhamento

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68af773485b4832f8285e3dbcb2163f7