### PR TITLE
Restrict qualification transfer rule to SDR and Agendamento agents

### DIFF
--- a/src/lib/agentTemplates.ts
+++ b/src/lib/agentTemplates.ts
@@ -105,9 +105,8 @@ export const AGENT_TEMPLATES: Record<string, AgentTemplate> = {
       forbidden_words: 'termos técnicos complexos',
       default_fallback:
         'Ainda não sei responder isso, mas vou te direcionar para um de nossos atendentes que poderá atender você.',
-      qualification_transfer_rule: 'personalized',
-      qualification_transfer_conditions:
-        'Quando o usuário solicitar atendimento humano.',
+      qualification_transfer_rule: 'never',
+      qualification_transfer_conditions: '',
     },
     onboarding: {
       welcome_message: 'Olá! Estou aqui para ajudar com o suporte.',


### PR DESCRIPTION
## Summary
- hide lead qualification transfer rule for non-SDR/agendamento agents
- default support agent template to never transfer automatically

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af8386acc4832f93b4a512634de110