### PR TITLE
feat: add dark landing page and standardize components

### DIFF
--- a/components/landing/Features.tsx
+++ b/components/landing/Features.tsx
@@ -69,7 +69,7 @@ export default function Features() {
   }, []);
 
   return (
-    <section className="bg-[#FAFAFA] py-8 md:py-12 lg:py-16" id="solucoes">
+    <section className="bg-background py-8 md:py-12 lg:py-16" id="solucoes">
       <div className="mx-auto max-w-[1140px] px-3 md:px-4 lg:px-6">
         <h2 className="mb-2 text-center text-3xl font-bold">Para quem é a nossa solução?</h2>
         <p className="mb-8 text-center text-1xl text-lg font-medium text-primary">Todos que precisam atender clientes pelo WhatsApp para ter uma venda ou agendamento</p>

--- a/components/landing/Footer.tsx
+++ b/components/landing/Footer.tsx
@@ -1,12 +1,10 @@
 import Image from "next/image";
 import Link from "next/link";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 
 export default function Footer() {
   const year = new Date().getFullYear();
   return (
-    <footer className="bg-[#FAFAFA] text-sm">
+    <footer className="bg-background text-sm">
       <div className="mx-auto max-w-[1140px] px-3 md:px-4 lg:px-6 py-12">
         <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
           <div className="space-y-4">

--- a/components/landing/Hero.tsx
+++ b/components/landing/Hero.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/button";
 
 export default function Hero() {
   return (
-    <section className="bg-[#FAFAFA] py-8 md:py-12 lg:py-16">
+    <section className="bg-background py-8 md:py-12 lg:py-16">
       <div className="mx-auto grid max-w-[1140px] items-center gap-6 md:gap-8 lg:gap-6 px-3 md:px-4 lg:px-6 md:grid-cols-2 lg:grid-cols-12">
         <div className="space-y-4 text-center md:text-left lg:col-span-7">
           <h1 className="text-4xl font-bold sm:text-5xl">

--- a/components/landing/Pricing.tsx
+++ b/components/landing/Pricing.tsx
@@ -37,7 +37,7 @@ const formatPrice = (value: number) =>
   value.toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
 
 export default function Pricing() {
-  const [billing, setBilling] = useState<"monthly" | "annual">("monthly");
+  const [billing] = useState<"monthly" | "annual">("monthly");
   const price =
     billing === "monthly" ?
       formatPrice(PRICE_MONTHLY) :
@@ -45,7 +45,7 @@ export default function Pricing() {
   const suffix = billing === "monthly" ? "/mês" : "/ano";
 
   return (
-    <section id="modelos" className="bg-[#FAFAFA] py-24">
+    <section id="modelos" className="bg-background py-24">
       <div className="container mx-auto max-w-6xl px-4">
         <h2 className="mb-4 text-center text-3xl font-bold mb-8">
           Modelos prontos para uso
@@ -54,9 +54,9 @@ export default function Pricing() {
           {plans.map(({ name, tagline, features, popular }) => (
             <li key={name} role="listitem">
               <div className="group rounded-xl bg-gradient-to-br from-purple-500/40 to-blue-500/40 p-[2px] transition-all hover:-translate-y-1 hover:shadow-xl">
-                <Card className="relative flex h-full flex-col rounded-[calc(theme(borderRadius.lg)-2px)] bg-white/90 p-6 backdrop-blur">
+                <Card className="relative flex h-full flex-col rounded-[calc(theme(borderRadius.lg)-2px)] bg-card/90 p-6 backdrop-blur">
                   {popular && (
-                    <span className="absolute right-4 top-4 rounded-full bg-primary px-2 py-1 text-xs font-medium text-white">
+                    <span className="absolute right-4 top-4 rounded-full bg-primary px-2 py-1 text-xs font-medium text-primary-foreground">
                       Mais popular
                     </span>
                   )}

--- a/components/landing/Testimonials.tsx
+++ b/components/landing/Testimonials.tsx
@@ -51,7 +51,7 @@ export default function Testimonials() {
   );
 
   return (
-    <section className="bg-[#FAFAFA] py-8 md:py-12 lg:py-16">
+    <section className="bg-background py-8 md:py-12 lg:py-16">
       <div className="mx-auto max-w-[1140px] px-3 md:px-4 lg:px-6 text-center">
         <h2 className="text-3xl font-bold">Depoimentos</h2>
         <p className="mb-8 text-muted-foreground">Quem já utiliza a Evoluke</p>

--- a/src/app/dark/page.tsx
+++ b/src/app/dark/page.tsx
@@ -1,0 +1,91 @@
+import Header from "@/components/landing/Header";
+import Hero from "@/components/landing/Hero";
+import Features from "@/components/landing/Features";
+import Video from "@/components/landing/Video";
+import Stats from "@/components/landing/Stats";
+import Benefit from "@/components/landing/Benefit";
+import FAQ from "@/components/landing/FAQ";
+import FinalCTA from "@/components/landing/FinalCTA";
+import Footer from "@/components/landing/Footer";
+import Pricing from "@/components/landing/Pricing";
+import type { Metadata } from "next";
+
+const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+
+export const metadata: Metadata = {
+  metadataBase: new URL(baseUrl),
+  alternates: {
+    canonical: "/dark",
+  },
+  title: "Evoluke",
+  description:
+    "A Evoluke oferece soluções de CRM integradas com inteligência artificial, personalizando atendimentos e automatizando processos para empresas.",
+  openGraph: {
+    title: "Evoluke",
+    description:
+      "A Evoluke oferece soluções de CRM integradas com inteligência artificial, personalizando atendimentos e automatizando processos para empresas.",
+    url: `${baseUrl}/dark`,
+    siteName: "Evoluke",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Evoluke",
+    description:
+      "A Evoluke oferece soluções de CRM integradas com inteligência artificial, personalizando atendimentos e automatizando processos para empresas.",
+  },
+};
+
+export default function DarkHomePage() {
+  return (
+    <div className="dark min-h-screen bg-background text-foreground">
+      <Header />
+      <main className="flex flex-col">
+        <Hero />
+        <Features />
+        <Video />
+        <Stats />
+        <Benefit
+          tag="IA + CRM"
+          title="Personalize atendimentos com IA"
+          description="Personalize seu Agente de IA e transforme cada interação em experiência exclusiva."
+          bullets={[
+            "Respostas rápidas e precisas",
+            "Aprendizado contínuo",
+            "Atendimento 24/7",
+            "Escalabilidade",
+          ]}
+          cta="Saiba mais"
+          href="/saiba-mais"
+          image="/window.png"
+          imageWidth={600}
+          imageHeight={400}
+        />
+        <Benefit
+          tag="Omnichannel"
+          title="Centralize todas as conversas"
+          description="Integre seu WhatsApp e tenha todo o histórico centralizado em um só lugar."
+          bullets={[
+            "Visão 360º do cliente",
+            "Registro automático",
+            "Board Kanban",
+            "Análises em tempo real",
+          ]}
+          cta="Começar agora"
+          href="/signup"
+          image="/mobile-app.avif"
+          imageWidth={300}
+          imageHeight={600}
+          reverse
+          primary
+        />
+        <Pricing />
+        {/* <Testimonials /> */}
+        <FAQ />
+        <FinalCTA />
+        <Footer />
+      </main>
+    </div>
+  );
+}
+

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -5,6 +5,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
 
   const routes = [
     { path: "", changefreq: "weekly", priority: 1 },
+    { path: "dark", changefreq: "weekly", priority: 0.8 },
     { path: "pricing", changefreq: "monthly", priority: 0.8 },
     { path: "login", changefreq: "monthly", priority: 0.5 },
     { path: "signup", changefreq: "monthly", priority: 0.5 },


### PR DESCRIPTION
## Summary
- add dedicated dark landing page
- update landing components to use theme tokens
- include dark route in sitemap

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af995d6f0c832f884d9fc4d35fc7f8