### PR TITLE
feat: alternate landing page sections

### DIFF
--- a/components/landing/Benefit.tsx
+++ b/components/landing/Benefit.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import Link from "next/link";
 import * as Dialog from "@radix-ui/react-dialog";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/components/ui/utils";
 
 type BenefitProps = {
   tag: string;
@@ -17,6 +18,7 @@ type BenefitProps = {
   imageHeight?: number;
   reverse?: boolean;
   primary?: boolean;
+  className?: string;
 };
 
 export default function Benefit({
@@ -31,9 +33,10 @@ export default function Benefit({
   imageHeight = 300,
   reverse,
   primary,
+  className,
 }: BenefitProps) {
   return (
-    <section className="py-8 md:py-12 lg:py-16">
+    <section className={cn("py-8 md:py-12 lg:py-16", className)}>
       <div className="mx-auto grid max-w-[1140px] items-center gap-6 md:gap-8 lg:gap-6 px-3 md:px-4 lg:px-6 md:grid-cols-2 lg:grid-cols-12">
         <div className={`space-y-4 lg:col-span-6 ${reverse ? "md:order-2" : ""}`}>
           <span className="text-sm uppercase text-primary">{tag}</span>

--- a/components/landing/FAQ.tsx
+++ b/components/landing/FAQ.tsx
@@ -15,7 +15,7 @@ const faqs = [
 
 export default function FAQ() {
   return (
-    <section className="py-8 md:py-12 lg:py-16" id="faq">
+    <section className="bg-white text-black py-8 md:py-12 lg:py-16" id="faq">
       <div className="mx-auto max-w-[920px] px-3 md:px-4 lg:px-6">
         <h2 className="mb-8 text-center text-3xl font-bold">Perguntas frequentes</h2>
         <div className="space-y-4">

--- a/components/landing/Features.tsx
+++ b/components/landing/Features.tsx
@@ -69,7 +69,7 @@ export default function Features() {
   }, []);
 
   return (
-    <section className="bg-[#FAFAFA] py-8 md:py-12 lg:py-16" id="solucoes">
+    <section className="bg-white text-black py-8 md:py-12 lg:py-16" id="solucoes">
       <div className="mx-auto max-w-[1140px] px-3 md:px-4 lg:px-6">
         <h2 className="mb-2 text-center text-3xl font-bold">Para quem é a nossa solução?</h2>
         <p className="mb-8 text-center text-1xl text-lg font-medium text-primary">Todos que precisam atender clientes pelo WhatsApp para ter uma venda ou agendamento</p>

--- a/components/landing/FinalCTA.tsx
+++ b/components/landing/FinalCTA.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button";
 
 export default function FinalCTA() {
   return (
-    <section className="bg-primary/10 py-12 md:py-16 lg:py-20">
+    <section className="bg-[#0D0D0D] text-white py-12 md:py-16 lg:py-20">
       <div className="mx-auto max-w-[1140px] px-3 md:px-4 lg:px-6 text-center">
         <div className="mb-4">
           <h2 className="text-3xl font-bold">Pronto para transformar seu atendimento?</h2>

--- a/components/landing/Footer.tsx
+++ b/components/landing/Footer.tsx
@@ -1,12 +1,10 @@
 import Image from "next/image";
 import Link from "next/link";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 
 export default function Footer() {
   const year = new Date().getFullYear();
   return (
-    <footer className="bg-[#FAFAFA] text-sm">
+    <footer className="bg-white text-black text-sm">
       <div className="mx-auto max-w-[1140px] px-3 md:px-4 lg:px-6 py-12">
         <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
           <div className="space-y-4">

--- a/components/landing/Hero.tsx
+++ b/components/landing/Hero.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/button";
 
 export default function Hero() {
   return (
-    <section className="bg-[#FAFAFA] py-8 md:py-12 lg:py-16">
+    <section className="bg-[#0D0D0D] text-white py-8 md:py-12 lg:py-16">
       <div className="mx-auto grid max-w-[1140px] items-center gap-6 md:gap-8 lg:gap-6 px-3 md:px-4 lg:px-6 md:grid-cols-2 lg:grid-cols-12">
         <div className="space-y-4 text-center md:text-left lg:col-span-7">
           <h1 className="text-4xl font-bold sm:text-5xl">

--- a/components/landing/Pricing.tsx
+++ b/components/landing/Pricing.tsx
@@ -45,7 +45,7 @@ export default function Pricing() {
   const suffix = billing === "monthly" ? "/mês" : "/ano";
 
   return (
-    <section id="modelos" className="bg-[#FAFAFA] py-24">
+    <section id="modelos" className="bg-[#0D0D0D] text-white py-24">
       <div className="container mx-auto max-w-6xl px-4">
         <h2 className="mb-4 text-center text-3xl font-bold mb-8">
           Modelos prontos para uso

--- a/components/landing/Stats.tsx
+++ b/components/landing/Stats.tsx
@@ -11,7 +11,7 @@ const stats = [
 
 export default function Stats() {
   return (
-    <section className="bg-gradient-to-r from-primary/5 to-primary/10 py-8 md:py-12 lg:py-16">
+    <section className="bg-white text-black py-8 md:py-12 lg:py-16">
       <div className="mx-auto max-w-[1140px] px-3 md:px-4 lg:px-6">
         <div className="grid gap-6 text-center sm:grid-cols-3">
           {stats.map(({ icon: Icon, end, label }) => (

--- a/components/landing/Video.tsx
+++ b/components/landing/Video.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 export default function Video() {
   return (
-    <section className="py-8 md:py-12 lg:py-16">
+    <section className="bg-[#0D0D0D] text-white py-8 md:py-12 lg:py-16">
       <div className="mx-auto max-w-[1140px] px-3 md:px-4 lg:px-6">
         <h2 className="mb-8 text-center text-3xl font-bold">Veja em ação</h2>
         <div className="mx-auto w-full lg:w-[70%] aspect-video overflow-hidden rounded-lg shadow-lg">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -57,8 +57,8 @@ body,
 
 :root {
   --radius: 0.5rem;
-  --background: #FAFAFA;
-  --foreground: oklch(0.145 0 0);
+  --background: #0D0D0D;
+  --foreground: #FFFFFF;
   --card: #FFFFFF;
   --card-foreground: oklch(0.145 0 0);
   --popover: #FFFFFF;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -47,6 +47,7 @@ export default function HomePage() {
         <Video />
         <Stats />
         <Benefit
+          className="bg-[#0D0D0D] text-white"
           tag="IA + CRM"
           title="Personalize atendimentos com IA"
           description="Personalize seu Agente de IA e transforme cada interação em experiência exclusiva."
@@ -63,6 +64,7 @@ export default function HomePage() {
           imageHeight={400}
         />
         <Benefit
+          className="bg-white text-black"
           tag="Omnichannel"
           title="Centralize todas as conversas"
           description="Integre seu WhatsApp e tenha todo o histórico centralizado em um só lugar."


### PR DESCRIPTION
## Summary
- set global background to #0D0D0D for dark base theme
- alternate landing sections with black/white styling
- extend Benefit component with className prop for flexible backgrounds

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af9d273170832fa3e758e4946de99a