### PR TITLE
Improve alt text for landing page images

### DIFF
--- a/components/landing/Benefit.tsx
+++ b/components/landing/Benefit.tsx
@@ -13,6 +13,7 @@ type BenefitProps = {
   cta: string;
   href: string;
   image: string;
+  imageAlt: string;
   imageWidth?: number;
   imageHeight?: number;
   reverse?: boolean;
@@ -27,6 +28,7 @@ export default function Benefit({
   cta,
   href,
   image,
+  imageAlt,
   imageWidth = 300,
   imageHeight = 300,
   reverse,
@@ -64,7 +66,7 @@ export default function Benefit({
               <button>
                 <Image
                   src={image}
-                  alt="Benefício"
+                  alt={imageAlt}
                   width={imageWidth}
                   height={imageHeight}
                   className="rounded-md cursor-zoom-in"
@@ -76,7 +78,7 @@ export default function Benefit({
               <Dialog.Content className="fixed left-1/2 top-1/2 w-full max-w-3xl -translate-x-1/2 -translate-y-1/2 p-0">
                 <Image
                   src={image}
-                  alt="Benefício"
+                  alt={imageAlt}
                   width={imageWidth * 2}
                   height={imageHeight * 2}
                   className="rounded-md"

--- a/components/landing/Footer.tsx
+++ b/components/landing/Footer.tsx
@@ -10,7 +10,7 @@ export default function Footer() {
       <div className="mx-auto max-w-[1140px] px-3 md:px-4 lg:px-6 py-12">
         <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
           <div className="space-y-4">
-            <Image src="/logo.svg" alt="Logo" width={120} height={32} />
+            <Image src="/logo.svg" alt="Logotipo da Evoluke" width={120} height={32} />
             <ul className="space-y-2">
               <li>
                 <Link href="/sobre-nos" className="hover:text-primary">

--- a/components/landing/Header.tsx
+++ b/components/landing/Header.tsx
@@ -13,7 +13,7 @@ export default function Header() {
     <header className="border-b bg-background">
       <div className="mx-auto flex h-16 max-w-[1140px] items-center justify-between px-3 md:px-4 lg:px-6">
         <Link href="/" className="flex items-center">
-          <Image src="/logo.svg" alt="Logo" width={120} height={32} />
+          <Image src="/logo.svg" alt="Logotipo da Evoluke" width={120} height={32} />
         </Link>
         <nav className="hidden flex-1 justify-center md:flex">
           <ul className="flex gap-6 text-sm">

--- a/components/landing/Hero.tsx
+++ b/components/landing/Hero.tsx
@@ -31,7 +31,7 @@ export default function Hero() {
         <div className="relative flex justify-center lg:col-span-5">
           <Image
             src="/mascot.png"
-            alt="Ilustração"
+            alt="Mascote representando o agente de IA da Evoluke"
             width={600}
             height={600}
             className="h-auto w-full max-w-[600px] rounded-md"

--- a/components/landing/Testimonials.tsx
+++ b/components/landing/Testimonials.tsx
@@ -36,7 +36,7 @@ export default function Testimonials() {
         <div className="flex items-center gap-3">
           <Image
             src={t.avatar}
-            alt={t.name}
+            alt={`Foto de ${t.name}`}
             width={48}
             height={48}
             className="h-12 w-12 rounded-full object-cover"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -59,6 +59,7 @@ export default function HomePage() {
           cta="Saiba mais"
           href="/saiba-mais"
           image="/window.png"
+          imageAlt="Interface da plataforma Evoluke integrando IA ao atendimento"
           imageWidth={600}
           imageHeight={400}
         />
@@ -75,6 +76,7 @@ export default function HomePage() {
           cta="Começar agora"
           href="/signup"
           image="/mobile-app.avif"
+          imageAlt="Aplicativo móvel da Evoluke centralizando conversas"
           imageWidth={300}
           imageHeight={600}
           reverse


### PR DESCRIPTION
## Summary
- replace generic hero image alt text with detailed description
- allow Benefit component to receive descriptive `imageAlt` prop and update references
- refine alt text for logos and testimonials on the landing page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afa0e353c4832f9545e50805f24677