### PR TITLE
Use iframe for demo and show floating button on marketing pages

### DIFF
--- a/components/landing/ConditionalFloatingIframeButton.tsx
+++ b/components/landing/ConditionalFloatingIframeButton.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import FloatingIframeButton from "./FloatingIframeButton";
+
+const excludedRoutes = [
+  "/login",
+  "/signup",
+  "/forgot-password",
+  "/verify-email",
+  "/complete-profile",
+  "/update-password",
+  "/dashboard",
+];
+
+export default function ConditionalFloatingIframeButton() {
+  const pathname = usePathname();
+  if (excludedRoutes.some((route) => pathname.startsWith(route))) {
+    return null;
+  }
+  return <FloatingIframeButton />;
+}

--- a/components/landing/Video.tsx
+++ b/components/landing/Video.tsx
@@ -6,6 +6,7 @@ export default function Video() {
       <div className="mx-auto max-w-[1140px] px-3 md:px-4 lg:px-6">
         <h2 className="mb-8 text-center text-3xl font-bold">Veja em ação</h2>
         <div className="mx-auto w-full lg:w-[70%] aspect-video overflow-hidden rounded-lg shadow-lg">
+          {/*
           <video
             className="h-full w-full object-cover"
             src="/demo.mp4"
@@ -13,6 +14,12 @@ export default function Video() {
             muted
             loop
             playsInline
+          />
+          */}
+          <iframe
+            src="https://example.com"
+            title="iframe"
+            className="h-full w-full border-0"
           />
         </div>
       </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from "next";
 import { Inter, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { Toaster } from "sonner";
+import ConditionalFloatingIframeButton from "@/components/landing/ConditionalFloatingIframeButton";
 
 const inter = Inter({ variable: "--font-inter", subsets: ["latin"] });
 const geistMono = Geist_Mono({ variable: "--font-geist-mono", subsets: ["latin"] });
@@ -47,6 +48,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body className="font-sans antialiased h-full">
         <Toaster position="top-right" />
         {children}
+        <ConditionalFloatingIframeButton />
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,6 @@ import FAQ from "@/components/landing/FAQ";
 import FinalCTA from "@/components/landing/FinalCTA";
 import Footer from "@/components/landing/Footer";
 import Pricing from "@/components/landing/Pricing";
-import FloatingIframeButton from "@/components/landing/FloatingIframeButton";
 import type { Metadata } from "next";
 
 const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
@@ -89,7 +88,6 @@ export default function HomePage() {
         <FinalCTA />
         <Footer />
       </main>
-      <FloatingIframeButton />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- replace demo video with embedded iframe on landing page
- add floating iframe button to layout with route exclusions
- remove duplicate button from home page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0b01d6b40832f8bb8abc8d8ab28ff