### PR TITLE
feat: add lateral spacing to pricing page

### DIFF
--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -12,7 +12,7 @@ export default function PricingPage() {
   return (
     <>
       <Header />
-      <main className="flex flex-col">
+      <main className="flex flex-col w-[70%] mx-auto">
         <Pricing />
       </main>
       <Footer />


### PR DESCRIPTION
## Summary
- center pricing page content with 15% side margins

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0b5ca7714832f87de23de6d61bded