### PR TITLE
Share iframe source between landing page and floating button

### DIFF
--- a/components/landing/FloatingIframeButton.tsx
+++ b/components/landing/FloatingIframeButton.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import Image from "next/image";
+import { IFRAME_SRC } from "./iframeConfig";
 
 export default function FloatingIframeButton() {
   const [open, setOpen] = useState(false);
@@ -26,7 +27,7 @@ export default function FloatingIframeButton() {
               ×
             </button>
             <iframe
-              src="https://difyplatform.tracelead.com.br/chatbot/pvKADqaaY0eWXy68"
+              src={IFRAME_SRC}
               title="iframe"
               style={{ width: "100%", height: "100%" }}
               frameBorder={0}

--- a/components/landing/Video.tsx
+++ b/components/landing/Video.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { IFRAME_SRC } from "./iframeConfig";
 
 export default function Video() {
   return (
@@ -17,9 +18,12 @@ export default function Video() {
           />
           */}
           <iframe
-            src="https://example.com"
+            src={IFRAME_SRC}
             title="iframe"
-            className="h-full w-full border-0"
+            style={{ width: "100%", height: "100%" }}
+            frameBorder={0}
+            allow="microphone"
+            className="border-0"
           />
         </div>
       </div>

--- a/components/landing/iframeConfig.ts
+++ b/components/landing/iframeConfig.ts
@@ -1,0 +1,1 @@
+export const IFRAME_SRC = "https://difyplatform.tracelead.com.br/chatbot/pvKADqaaY0eWXy68";


### PR DESCRIPTION
## Summary
- reuse the same iframe URL across landing page video and floating button
- centralize iframe source in a shared config

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0b5da3d88832f9b45fef59253c844