### PR TITLE
Add BNI page with full-screen iframe

### DIFF
--- a/components/landing/ConditionalFloatingIframeButton.tsx
+++ b/components/landing/ConditionalFloatingIframeButton.tsx
@@ -11,6 +11,7 @@ const excludedRoutes = [
   "/complete-profile",
   "/update-password",
   "/dashboard",
+  "/bni",
 ];
 
 export default function ConditionalFloatingIframeButton() {

--- a/src/app/bni/page.tsx
+++ b/src/app/bni/page.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "BNI",
+  description: "Conteúdo incorporado do BNI",
+};
+
+export default function BniPage() {
+  return (
+    <iframe
+      src="https://www.bni.com"
+      className="w-full h-screen"
+      frameBorder={0}
+      allowFullScreen
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add /bni route displaying only a full-page iframe
- hide floating contact button on the new /bni page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b9884e84832f997b028f1751de55