### PR TITLE
feat: add chatbot script to landing page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,7 @@ import FinalCTA from "@/components/landing/FinalCTA";
 import Footer from "@/components/landing/Footer";
 import Pricing from "@/components/landing/Pricing";
 import type { Metadata } from "next";
+import Script from "next/script";
 
 const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
 
@@ -39,6 +40,32 @@ export const metadata: Metadata = {
 export default function HomePage() {
   return (
     <>
+      <Script id="dify-chatbot-config" strategy="afterInteractive">
+        {`
+          window.difyChatbotConfig = {
+            token: '69wjfGN2b8dN8Unn',
+            baseUrl: 'https://difyplatform.tracelead.com.br',
+            inputs: {},
+            systemVariables: {},
+            userVariables: {},
+          }
+        `}
+      </Script>
+      <Script
+        src="https://difyplatform.tracelead.com.br/embed.min.js"
+        id="69wjfGN2b8dN8Unn"
+        strategy="afterInteractive"
+        defer
+      />
+      <style jsx global>{`
+        #dify-chatbot-bubble-button {
+          background-color: #1C64F2 !important;
+        }
+        #dify-chatbot-bubble-window {
+          width: 24rem !important;
+          height: 40rem !important;
+        }
+      `}</style>
       <Header />
       <main className="flex flex-col">
         <Hero />


### PR DESCRIPTION
## Summary
- embed Dify chatbot on landing page
- style chatbot bubble and window

## Testing
- `npm test` *(fails: missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0bbebe774832f99e3713527500727