### PR TITLE
Add Dify chatbot to landing page

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -163,3 +163,14 @@ body,
   }
 }
 
+#dify-chatbot-bubble-button {
+  background-color: #1C64F2 !important;
+  border-radius: 50% !important;
+}
+
+#dify-chatbot-bubble-window {
+  width: 24rem !important;
+  height: 40rem !important;
+  border-radius: 1rem !important;
+}
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -104,18 +104,6 @@ export default function HomePage() {
         strategy="afterInteractive"
         defer
       />
-      <style jsx global>{`
-        #dify-chatbot-bubble-button {
-          background-color: #1C64F2 !important;
-          border-radius: 50% !important;
-        }
-
-        #dify-chatbot-bubble-window {
-          width: 24rem !important;
-          height: 40rem !important;
-          border-radius: 1rem !important;
-        }
-      `}</style>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- embed Dify chatbot script and styles on landing page for direct chat support

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b0bd24c028832fad8fe1095a72bf43