### PR TITLE
feat: responsivo para planos na landingpage

### DIFF
--- a/components/landing/Pricing.tsx
+++ b/components/landing/Pricing.tsx
@@ -1,6 +1,4 @@
 "use client";
-
-import { useState } from "react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import {
@@ -37,11 +35,12 @@ const formatPrice = (value: number) =>
   value.toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
 
 export default function Pricing() {
-  const [billing, setBilling] = useState<"monthly" | "annual">("monthly");
+  // eslint-disable-next-line prefer-const
+  let billing: "monthly" | "annual" = "monthly";
   const price =
-    billing === "monthly" ?
-      formatPrice(PRICE_MONTHLY) :
-      formatPrice(PRICE_ANNUAL);
+    billing === "monthly"
+      ? formatPrice(PRICE_MONTHLY)
+      : formatPrice(PRICE_ANNUAL);
   const suffix = billing === "monthly" ? "/mês" : "/ano";
 
   return (
@@ -50,9 +49,16 @@ export default function Pricing() {
         <h2 className="mb-4 text-center text-3xl font-bold mb-8">
           Modelos prontos para uso
         </h2>
-        <ul className="grid gap-6 sm:grid-cols-2" role="list">
+        <ul
+          className="flex snap-x snap-mandatory gap-6 overflow-x-auto sm:grid sm:grid-cols-2 sm:overflow-visible sm:snap-none"
+          role="list"
+        >
           {plans.map(({ name, tagline, features, popular }) => (
-            <li key={name} role="listitem">
+            <li
+              key={name}
+              role="listitem"
+              className="w-80 flex-shrink-0 snap-center sm:w-auto sm:flex-shrink"
+            >
               <div className="group rounded-xl bg-gradient-to-br from-purple-500/40 to-blue-500/40 p-[2px] transition-all hover:-translate-y-1 hover:shadow-xl">
                 <Card className="relative flex h-full flex-col rounded-[calc(theme(borderRadius.lg)-2px)] bg-white/90 p-6 backdrop-blur">
                   {popular && (
@@ -70,9 +76,6 @@ export default function Pricing() {
                         {suffix}
                       </span>
                     </p>
-                    {billing === "annual" && (
-                      <p className="mb-4 text-sm text-primary">2 meses grátis</p>
-                    )}
                     <p className="mb-4 text-sm text-muted-foreground">{tagline}</p>
                     <ul className="space-y-2">
                       {features.map((feature) => (

--- a/components/landing/Pricing.tsx
+++ b/components/landing/Pricing.tsx
@@ -35,8 +35,7 @@ const formatPrice = (value: number) =>
   value.toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
 
 export default function Pricing() {
-  // eslint-disable-next-line prefer-const
-  let billing: "monthly" | "annual" = "monthly";
+  const billing: "monthly" | "annual" = "monthly";
   const price =
     billing === "monthly"
       ? formatPrice(PRICE_MONTHLY)
@@ -46,7 +45,7 @@ export default function Pricing() {
   return (
     <section id="modelos" className="bg-[#FAFAFA] py-24">
       <div className="container mx-auto max-w-6xl px-4">
-        <h2 className="mb-4 text-center text-3xl font-bold mb-8">
+        <h2 className="mb-8 text-center text-3xl font-bold">
           Modelos prontos para uso
         </h2>
         <ul

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -12,7 +12,7 @@ export default function PricingPage() {
   return (
     <>
       <Header />
-      <main className="flex flex-col w-[70%] mx-auto">
+      <main className="flex flex-col w-full max-w-6xl px-4 mx-auto">
         <Pricing />
       </main>
       <Footer />

--- a/src/app/sob-demanda/SobDemandaContent.tsx
+++ b/src/app/sob-demanda/SobDemandaContent.tsx
@@ -147,7 +147,7 @@ export default function SobDemandaContent() {
   }
 
 @media (max-width:768px){
-  .plan-container{ padding:0 !important; }        /* antes 0 16px */
+  .plan-container{ margin:0 10%; padding:0; }        /* antes 0 16px */
   .table-wrapper{ padding:0; margin:0 0 var(--space); } /* remove auto nas laterais */
 }
 


### PR DESCRIPTION
## Summary
- add horizontal scroll to pricing cards on small screens
- ensure pricing page uses full-width container on mobile

## Testing
- `npm run lint`
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c2e5ca28832fb1294bf143c48485