### PR TITLE
Fix mascot size on mobile

### DIFF
--- a/components/landing/Hero.tsx
+++ b/components/landing/Hero.tsx
@@ -34,7 +34,8 @@ export default function Hero() {
             alt="Mascote representando o agente de IA da Evoluke"
             width={600}
             height={600}
-            className="h-auto w-full max-w-[600px] rounded-md"
+            className="h-auto w-full max-w-[300px] md:max-w-[600px] rounded-md"
+            sizes="(max-width: 768px) 300px, 600px"
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- shrink hero mascot image on mobile screens

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0c5fa788c832f9334a8baec00c2e9