### PR TITLE
Fix mobile status chip wrapping

### DIFF
--- a/src/app/dashboard/payments/page.tsx
+++ b/src/app/dashboard/payments/page.tsx
@@ -143,20 +143,20 @@ export default function PaymentsPage() {
                     <span className="font-medium">Valor (R$)</span>
                     <span>R${p.amount.toFixed(2)}</span>
                   </div>
-                  <div className="flex items-center justify-between">
-                    <span className="font-medium">Status</span>
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="font-medium text-xs">Status</span>
                     {p.status === "pago" ? (
-                      <span className="px-2 py-1 text-xs font-semibold rounded-full bg-green-100 text-green-800">
+                      <span className="px-2 py-1 text-[10px] font-semibold rounded-full bg-green-100 text-green-800 whitespace-nowrap">
                         Quitado
                       </span>
                     ) : p.status === "estorno" ? (
-                      <span className="px-2 py-1 text-xs font-semibold rounded-full bg-red-100 text-red-800">
+                      <span className="px-2 py-1 text-[10px] font-semibold rounded-full bg-red-100 text-red-800 whitespace-nowrap">
                         Estornado
                       </span>
                     ) : (
                       <button
                         onClick={() => handlePay(p.id)}
-                        className="px-2 py-1 text-xs font-semibold rounded-full bg-yellow-100 text-yellow-800 hover:bg-yellow-200"
+                        className="px-2 py-1 text-[10px] font-semibold rounded-full bg-yellow-100 text-yellow-800 hover:bg-yellow-200 whitespace-nowrap"
                       >
                         Pagar
                       </button>


### PR DESCRIPTION
## Summary
- keep payment status chip on a single line for mobile view

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c69eb900832fad5a38c6bebd967f