### PR TITLE
Add chatwoot script to landing page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,7 @@ import FinalCTA from "@/components/landing/FinalCTA";
 import Footer from "@/components/landing/Footer";
 import Pricing from "@/components/landing/Pricing";
 import type { Metadata } from "next";
+import Script from "next/script";
 
 const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
 
@@ -39,6 +40,22 @@ export const metadata: Metadata = {
 export default function HomePage() {
   return (
     <>
+      <Script id="tracelead-chatwoot" strategy="afterInteractive">
+        {`(function(d,t) {
+      var BASE_URL="https://platform.tracelead.com.br";
+      var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
+      g.src=BASE_URL+"/packs/js/sdk.js";
+      g.defer = true;
+      g.async = true;
+      s.parentNode.insertBefore(g,s);
+      g.onload=function(){
+        window.chatwootSDK.run({
+          websiteToken: 'EioqiGzk1toeBkQgLiRNxMuG',
+          baseUrl: BASE_URL
+        })
+      }
+    })(document,"script");`}
+      </Script>
       <Header />
       <main className="flex flex-col">
         <Hero />


### PR DESCRIPTION
## Summary
- load Tracelead Chatwoot SDK on landing page using next/script

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b1c412c480832fa330c84fdafdf315