### PR TITLE
Handle Chatwoot widget visibility per route

### DIFF
--- a/components/ChatwootController.tsx
+++ b/components/ChatwootController.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { usePathname } from "next/navigation";
+
+declare global {
+  interface Window {
+    chatwootSettings?: {
+      hideMessageBubble: boolean;
+      position: string;
+      type: string;
+    };
+    chatwootSDK: {
+      run: (options: { websiteToken: string; baseUrl: string }) => void;
+    };
+    $chatwoot: {
+      toggleBubbleVisibility: (state: "show" | "hide") => void;
+    };
+  }
+}
+
+const ALLOW = ["/contato", "/orcamento"];
+
+export default function ChatwootController() {
+  const pathname = usePathname();
+  const loaded = useRef(false);
+
+  useEffect(() => {
+    if (loaded.current) return;
+    loaded.current = true;
+
+    const BASE_URL = "https://platform.tracelead.com.br";
+    const TOKEN = "EioqiGzk1toeBkQgLiRNxMuG";
+
+    window.chatwootSettings = { hideMessageBubble: true, position: "right", type: "standard" };
+
+    (function (d: Document, t: string) {
+      const g = d.createElement(t) as HTMLScriptElement;
+      const s = d.getElementsByTagName(t)[0]!;
+      g.src = `${BASE_URL}/packs/js/sdk.js`;
+      g.defer = true;
+      g.async = true;
+      s.parentNode!.insertBefore(g, s);
+      g.onload = function () {
+        window.chatwootSDK.run({ websiteToken: TOKEN, baseUrl: BASE_URL });
+        const apply = () => {
+          const ok = ALLOW.some((p) => pathname.startsWith(p));
+          window.$chatwoot.toggleBubbleVisibility(ok ? "show" : "hide");
+        };
+        window.addEventListener("chatwoot:ready", apply, { once: true });
+      };
+    })(document, "script");
+  }, [pathname]);
+
+  useEffect(() => {
+    const ok = ALLOW.some((p) => pathname.startsWith(p));
+    const w = window;
+    if (w.$chatwoot) {
+      w.$chatwoot.toggleBubbleVisibility(ok ? "show" : "hide");
+    } else {
+      const fn = () => w.$chatwoot.toggleBubbleVisibility(ok ? "show" : "hide");
+      window.addEventListener("chatwoot:ready", fn, { once: true });
+      return () => window.removeEventListener("chatwoot:ready", fn);
+    }
+  }, [pathname]);
+
+  return null;
+}
+

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from "next";
 import { Inter, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { Toaster } from "sonner";
+import ChatwootController from "@/components/ChatwootController";
 
 const inter = Inter({ variable: "--font-inter", subsets: ["latin"] });
 const geistMono = Geist_Mono({ variable: "--font-geist-mono", subsets: ["latin"] });
@@ -47,6 +48,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body className="font-sans antialiased h-full">
         <Toaster position="top-right" />
         {children}
+        <ChatwootController />
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- add ChatwootController component to load Chatwoot SDK once and toggle bubble visibility based on allowed routes
- render ChatwootController in root layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1ef064694832fbb6d346093c2bf8d