### PR TITLE
Add loading guard to DeactivateAgentButton

### DIFF
--- a/components/agents/DeactivateAgentButton.tsx
+++ b/components/agents/DeactivateAgentButton.tsx
@@ -16,6 +16,7 @@ export default function DeactivateAgentButton({ agentId, onDeactivated }: Props)
   const [loading, setLoading] = useState(false);
 
   const handleDeactivate = async () => {
+    if (loading) return;
     setLoading(true);
     const { error } = await supabasebrowser
       .from("agents")


### PR DESCRIPTION
## Summary
- prevent double deactivation by returning early when `loading`
- preserve button disable state during loading

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b31d787c84832f9bfe0bfe4d2ac1f9