### PR TITLE
feat: add user notifications system

### DIFF
--- a/components/notifications/NotificationBell.tsx
+++ b/components/notifications/NotificationBell.tsx
@@ -26,25 +26,30 @@ export default function NotificationBell() {
           )}
         </button>
       </DropdownMenu.Trigger>
-      <DropdownMenu.Content align="end" className="w-72 bg-white rounded-md shadow p-2">
-        {notifications.length === 0 ? (
-          <div className="p-2 text-sm text-gray-500">Sem notificações</div>
-        ) : (
-          notifications.map((n) => (
-            <div
-              key={n.id}
-              className={cn('p-2 text-sm rounded flex justify-between gap-2', !n.read_at ? 'font-semibold' : 'text-gray-500')}
-            >
-              <span className="flex-1">{n.message}</span>
-              {!n.read_at && (
-                <button onClick={() => markAsRead(n.id)} className="text-xs text-blue-600">
-                  Marcar como lido
-                </button>
-              )}
-            </div>
-          ))
-        )}
-      </DropdownMenu.Content>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          align="end"
+          className="z-50 w-72 bg-white rounded-md shadow p-2"
+        >
+          {notifications.length === 0 ? (
+            <div className="p-2 text-sm text-gray-500">Sem notificações</div>
+          ) : (
+            notifications.map((n) => (
+              <div
+                key={n.id}
+                className={cn('p-2 text-sm rounded flex justify-between gap-2', !n.read_at ? 'font-semibold' : 'text-gray-500')}
+              >
+                <span className="flex-1">{n.message}</span>
+                {!n.read_at && (
+                  <button onClick={() => markAsRead(n.id)} className="text-xs text-blue-600">
+                    Marcar como lido
+                  </button>
+                )}
+              </div>
+            ))
+          )}
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
     </DropdownMenu.Root>
   );
 }

--- a/components/notifications/NotificationBell.tsx
+++ b/components/notifications/NotificationBell.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
+import { Bell } from 'lucide-react';
+import { useNotifications } from './NotificationProvider';
+import { cn } from '@/components/ui/utils';
+
+export default function NotificationBell() {
+  const { notifications, markAsRead } = useNotifications();
+  const unreadCount = notifications.filter((n) => !n.read_at).length;
+
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger asChild>
+        <button className="relative inline-flex items-center justify-center rounded-md p-2 hover:bg-gray-100">
+          <Bell className="w-5 h-5" />
+          {unreadCount > 0 && (
+            <span className="absolute -top-1 -right-1 flex h-4 w-4 items-center justify-center rounded-full bg-red-500 text-xs text-white">
+              {unreadCount}
+            </span>
+          )}
+        </button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content align="end" className="w-72 bg-white rounded-md shadow p-2">
+        {notifications.length === 0 ? (
+          <div className="p-2 text-sm text-gray-500">Sem notificações</div>
+        ) : (
+          notifications.map((n) => (
+            <div
+              key={n.id}
+              className={cn('p-2 text-sm rounded flex justify-between gap-2', !n.read_at ? 'font-semibold' : 'text-gray-500')}
+            >
+              <span className="flex-1">{n.message}</span>
+              {!n.read_at && (
+                <button onClick={() => markAsRead(n.id)} className="text-xs text-blue-600">
+                  Marcar como lido
+                </button>
+              )}
+            </div>
+          ))
+        )}
+      </DropdownMenu.Content>
+    </DropdownMenu.Root>
+  );
+}

--- a/components/notifications/NotificationBell.tsx
+++ b/components/notifications/NotificationBell.tsx
@@ -15,7 +15,12 @@ export default function NotificationBell() {
         <button className="relative inline-flex items-center justify-center rounded-md p-2 hover:bg-gray-100">
           <Bell className="w-5 h-5" />
           {unreadCount > 0 && (
-            <span className="absolute -top-1 -right-1 flex h-4 w-4 items-center justify-center rounded-full bg-red-500 text-xs text-white">
+            <span
+              className={cn(
+                'absolute -top-1 -right-1 flex h-4 w-4 items-center justify-center rounded-full bg-red-500 text-xs',
+                'text-white'
+              )}
+            >
               {unreadCount}
             </span>
           )}
@@ -43,3 +48,4 @@ export default function NotificationBell() {
     </DropdownMenu.Root>
   );
 }
+

--- a/components/notifications/NotificationProvider.tsx
+++ b/components/notifications/NotificationProvider.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { createContext, useContext, useEffect, useState } from 'react';
+import { supabasebrowser } from '@/lib/supabaseClient';
+import { toast } from 'sonner';
+import type { RealtimeChannel } from '@supabase/supabase-js';
+
+export interface Notification {
+  id: string;
+  message: string;
+  type: string;
+  read_at: string | null;
+  created_at: string;
+}
+
+interface NotificationContextValue {
+  notifications: Notification[];
+  markAsRead: (id: string) => Promise<void>;
+}
+
+const NotificationContext = createContext<NotificationContextValue | undefined>(undefined);
+
+export function useNotifications() {
+  const ctx = useContext(NotificationContext);
+  if (!ctx) throw new Error('useNotifications must be used within NotificationProvider');
+  return ctx;
+}
+
+export function NotificationProvider({ children }: { children: React.ReactNode }) {
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+
+  useEffect(() => {
+    let channel: RealtimeChannel | null = null;
+    const setup = async () => {
+      const { data: { user } } = await supabasebrowser.auth.getUser();
+      if (!user) return;
+      const res = await fetch('/api/notifications');
+      if (res.ok) {
+        const data = await res.json();
+        setNotifications(data);
+      }
+      channel = supabasebrowser
+        .channel(`notifications:user:${user.id}`)
+        .on(
+          'postgres_changes',
+          { event: 'INSERT', schema: 'public', table: 'notifications', filter: `user_id=eq.${user.id}` },
+          (payload) => {
+            const newNotif = payload.new as Notification;
+            setNotifications((prev) => [newNotif, ...prev]);
+            toast(newNotif.message);
+          }
+        )
+        .subscribe();
+    };
+    setup();
+    return () => {
+      if (channel) supabasebrowser.removeChannel(channel);
+    };
+  }, []);
+
+  const markAsRead = async (id: string) => {
+    await fetch('/api/notifications', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id }),
+    });
+    setNotifications((prev) => prev.map((n) => (n.id === id ? { ...n, read_at: new Date().toISOString() } : n)));
+  };
+
+  return (
+    <NotificationContext.Provider value={{ notifications, markAsRead }}>
+      {children}
+    </NotificationContext.Provider>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.14",
+        "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-tooltip": "^1.2.7",
@@ -1851,6 +1852,41 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.16.tgz",
+      "integrity": "sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/react-focus-guards": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.2.tgz",
@@ -1905,6 +1941,150 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.16.tgz",
+      "integrity": "sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-popper": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
+      "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-rect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -2011,6 +2191,43 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
     },
     "node_modules/@radix-ui/react-select": {
       "version": "2.2.5",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.14",
+    "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tooltip": "^1.2.7",

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getUserFromCookie } from '@/lib/auth';
+import { createNotification, getNotifications, markAsRead } from '@/lib/notifications';
+
+export async function GET() {
+  const { user, error } = await getUserFromCookie();
+  if (error || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const { data, error: dbError } = await getNotifications(user.id);
+  if (dbError) {
+    return NextResponse.json({ error: dbError.message }, { status: 500 });
+  }
+  return NextResponse.json(data);
+}
+
+export async function POST(req: NextRequest) {
+  const { user, error } = await getUserFromCookie();
+  if (error || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const { message, type } = await req.json();
+  const { data, error: dbError } = await createNotification(user.id, message, type);
+  if (dbError) {
+    return NextResponse.json({ error: dbError.message }, { status: 500 });
+  }
+  return NextResponse.json(data);
+}
+
+export async function PATCH(req: NextRequest) {
+  const { user, error } = await getUserFromCookie();
+  if (error || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const { id } = await req.json();
+  const { error: dbError } = await markAsRead(id);
+  if (dbError) {
+    return NextResponse.json({ error: dbError.message }, { status: 500 });
+  }
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,13 +1,22 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getUserFromCookie } from '@/lib/auth';
 import { createNotification, getNotifications, markAsRead } from '@/lib/notifications';
+import { supabaseadmin } from '@/lib/supabaseAdmin';
 
 export async function GET() {
   const { user, error } = await getUserFromCookie();
   if (error || !user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
-  const { data, error: dbError } = await getNotifications(user.id);
+  const { data: company, error: companyError } = await supabaseadmin
+    .from('company')
+    .select('id')
+    .eq('user_id', user.id)
+    .single();
+  if (companyError || !company) {
+    return NextResponse.json({ error: 'Company not found' }, { status: 404 });
+  }
+  const { data, error: dbError } = await getNotifications(company.id);
   if (dbError) {
     return NextResponse.json({ error: dbError.message }, { status: 500 });
   }
@@ -19,8 +28,16 @@ export async function POST(req: NextRequest) {
   if (error || !user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
+  const { data: company, error: companyError } = await supabaseadmin
+    .from('company')
+    .select('id')
+    .eq('user_id', user.id)
+    .single();
+  if (companyError || !company) {
+    return NextResponse.json({ error: 'Company not found' }, { status: 404 });
+  }
   const { message, type } = await req.json();
-  const { data, error: dbError } = await createNotification(user.id, message, type);
+  const { data, error: dbError } = await createNotification(company.id, message, type);
   if (dbError) {
     return NextResponse.json({ error: dbError.message }, { status: 500 });
   }
@@ -32,8 +49,16 @@ export async function PATCH(req: NextRequest) {
   if (error || !user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
+  const { data: company, error: companyError } = await supabaseadmin
+    .from('company')
+    .select('id')
+    .eq('user_id', user.id)
+    .single();
+  if (companyError || !company) {
+    return NextResponse.json({ error: 'Company not found' }, { status: 404 });
+  }
   const { id } = await req.json();
-  const { error: dbError } = await markAsRead(id);
+  const { error: dbError } = await markAsRead(id, company.id);
   if (dbError) {
     return NextResponse.json({ error: dbError.message }, { status: 500 });
   }

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -38,9 +38,11 @@ export default function DashboardClientLayout({ children }: Props) {
     <div className="flex h-screen">
         <Sidebar className="hidden sm:flex" />
         <main className="flex-1 bg-[#FAFAFA] p-6 h-full overflow-auto">
-          <div className="flex justify-between">
+          <div className="flex w-full items-center mb-4">
             <MobileSidebar />
-            <NotificationBell />
+            <div className="ml-auto">
+              <NotificationBell />
+            </div>
           </div>
           <DashboardAlerts />
           {children}

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -3,6 +3,7 @@
 import React, { ReactNode, useEffect, useState } from 'react'
 import { Sidebar, MobileSidebar } from '@/components/ui/sidebar'
 import DashboardAlerts from '@/components/ui/dashboard-alerts'
+import NotificationBell from '@/components/notifications/NotificationBell'
 import { supabasebrowser } from '@/lib/supabaseClient'
 import { useRouter } from 'next/navigation'
 
@@ -35,12 +36,15 @@ export default function DashboardClientLayout({ children }: Props) {
 
   return (
     <div className="flex h-screen">
-      <Sidebar className="hidden sm:flex" />
-      <main className="flex-1 bg-[#FAFAFA] p-6 h-full overflow-auto">
-        <MobileSidebar />
-        <DashboardAlerts />
-        {children}
-      </main>
-    </div>
-  )
-}
+        <Sidebar className="hidden sm:flex" />
+        <main className="flex-1 bg-[#FAFAFA] p-6 h-full overflow-auto">
+          <div className="flex justify-between">
+            <MobileSidebar />
+            <NotificationBell />
+          </div>
+          <DashboardAlerts />
+          {children}
+        </main>
+      </div>
+    )
+  }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { Inter, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { Toaster } from "sonner";
 import ChatwootController from "@/components/ChatwootController";
+import { NotificationProvider } from "@/components/notifications/NotificationProvider";
 
 const inter = Inter({ variable: "--font-inter", subsets: ["latin"] });
 const geistMono = Geist_Mono({ variable: "--font-geist-mono", subsets: ["latin"] });
@@ -46,9 +47,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
       </head>
       <body className="font-sans antialiased h-full">
-        <Toaster position="top-right" />
-        {children}
-        <ChatwootController />
+        <NotificationProvider>
+          <Toaster position="top-right" />
+          {children}
+          <ChatwootController />
+        </NotificationProvider>
       </body>
     </html>
   );

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -21,7 +21,9 @@ export async function getNotifications(userId: string) {
     .from('notifications')
     .select('*')
     .eq('user_id', userId)
-    .order('created_at', { ascending: false });
+    .order('read_at', { ascending: true, nullsFirst: true })
+    .order('created_at', { ascending: false })
+    .limit(4);
 }
 
 export async function markAsRead(id: string) {

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -1,0 +1,32 @@
+// src/lib/notifications.ts
+import { supabaseadmin } from '@/lib/supabaseAdmin';
+
+export type NotificationType = 'info' | 'warning' | 'success' | 'error';
+
+export interface Notification {
+  id: string;
+  user_id: string;
+  message: string;
+  type: string;
+  read_at: string | null;
+  created_at: string;
+}
+
+export async function createNotification(userId: string, message: string, type: NotificationType = 'info') {
+  return supabaseadmin.from('notifications').insert({ user_id: userId, message, type }).select().single();
+}
+
+export async function getNotifications(userId: string) {
+  return supabaseadmin
+    .from('notifications')
+    .select('*')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false });
+}
+
+export async function markAsRead(id: string) {
+  return supabaseadmin
+    .from('notifications')
+    .update({ read_at: new Date().toISOString() })
+    .eq('id', id);
+}

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -5,30 +5,35 @@ export type NotificationType = 'info' | 'warning' | 'success' | 'error';
 
 export interface Notification {
   id: string;
-  user_id: string;
+  company_id: number;
   message: string;
   type: string;
   read_at: string | null;
   created_at: string;
 }
 
-export async function createNotification(userId: string, message: string, type: NotificationType = 'info') {
-  return supabaseadmin.from('notifications').insert({ user_id: userId, message, type }).select().single();
+export async function createNotification(companyId: number, message: string, type: NotificationType = 'info') {
+  return supabaseadmin
+    .from('notifications')
+    .insert({ company_id: companyId, message, type })
+    .select()
+    .single();
 }
 
-export async function getNotifications(userId: string) {
+export async function getNotifications(companyId: number) {
   return supabaseadmin
     .from('notifications')
     .select('*')
-    .eq('user_id', userId)
+    .eq('company_id', companyId)
     .order('read_at', { ascending: true, nullsFirst: true })
     .order('created_at', { ascending: false })
     .limit(4);
 }
 
-export async function markAsRead(id: string) {
+export async function markAsRead(id: string, companyId: number) {
   return supabaseadmin
     .from('notifications')
     .update({ read_at: new Date().toISOString() })
-    .eq('id', id);
+    .eq('id', id)
+    .eq('company_id', companyId);
 }

--- a/supabase/migrations/20250215000000_create_notifications_table.sql
+++ b/supabase/migrations/20250215000000_create_notifications_table.sql
@@ -1,0 +1,14 @@
+-- Create notifications table
+create table public.notifications (
+  id uuid not null default gen_random_uuid(),
+  user_id uuid not null,
+  message text not null,
+  type text not null,
+  read_at timestamp with time zone null,
+  created_at timestamp with time zone not null default now(),
+  constraint notifications_pkey primary key (id),
+  constraint notifications_user_id_fkey foreign key (user_id) references auth.users (id) on delete cascade
+);
+
+create index notifications_user_id_idx on public.notifications(user_id);
+create index notifications_read_at_idx on public.notifications(read_at);

--- a/supabase/migrations/20250215000000_create_notifications_table.sql
+++ b/supabase/migrations/20250215000000_create_notifications_table.sql
@@ -1,14 +1,14 @@
 -- Create notifications table
 create table public.notifications (
   id uuid not null default gen_random_uuid(),
-  user_id uuid not null,
+  company_id bigint not null,
   message text not null,
   type text not null,
   read_at timestamp with time zone null,
   created_at timestamp with time zone not null default now(),
   constraint notifications_pkey primary key (id),
-  constraint notifications_user_id_fkey foreign key (user_id) references auth.users (id) on delete cascade
+  constraint notifications_company_id_fkey foreign key (company_id) references public.company (id) on delete cascade
 );
 
-create index notifications_user_id_idx on public.notifications(user_id);
+create index notifications_company_id_idx on public.notifications(company_id);
 create index notifications_read_at_idx on public.notifications(read_at);


### PR DESCRIPTION
## Summary
- add notifications table and service layer
- expose API and real-time provider with bell dropdown
- integrate notifications across layout and dashboard

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b46db4885c832fa5541bac3dc69992