### PR TITLE
Fix CRM page double loading message

### DIFF
--- a/src/app/crm/loading.tsx
+++ b/src/app/crm/loading.tsx
@@ -1,0 +1,10 @@
+import { Loader2 } from "lucide-react";
+
+export default function Loading() {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center space-y-4">
+      <Loader2 className="h-8 w-8 animate-spin" />
+      <p>Estamos preparando tudo...</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a route-level loading component for `/crm` to avoid Next.js default "carregando..." text and show consistent loader

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4e3ed8f70832fa2f6a213c8c0fa99