### PR TITLE
Redirect CRM setup to dashboard automatically

### DIFF
--- a/src/app/crm/page.tsx
+++ b/src/app/crm/page.tsx
@@ -7,23 +7,21 @@ import { Loader2 } from "lucide-react";
 
 export default function CrmPage() {
   const router = useRouter();
-  const [status, setStatus] = useState<"loading" | "error" | "success">("loading");
-  const [crmUrl, setCrmUrl] = useState<string | null>(null);
+  const [status, setStatus] = useState<"loading" | "error">("loading");
 
   useEffect(() => {
     const createCrm = async () => {
       try {
         const res = await fetch("/api/crm/create", { method: "POST" });
         if (!res.ok) throw new Error();
-        const data = await res.json().catch(() => ({}));
-        if (data.crm_url) setCrmUrl(data.crm_url);
-        setStatus("success");
+        await res.json().catch(() => ({}));
+        router.replace("/dashboard");
       } catch {
         setStatus("error");
       }
     };
     createCrm();
-  }, []);
+  }, [router]);
 
   if (status === "loading") {
     return (
@@ -43,17 +41,5 @@ export default function CrmPage() {
     );
   }
 
-  return (
-    <div className="min-h-screen flex flex-col items-center justify-center space-y-4 text-center">
-      <p>Seu CRM está criado!</p>
-      <Button
-        onClick={() => {
-          if (crmUrl) window.open(crmUrl, "_blank");
-          router.replace("/dashboard");
-        }}
-      >
-        Abrir CRM
-      </Button>
-    </div>
-  );
+  return null;
 }


### PR DESCRIPTION
## Summary
- redirect CRM creation flow straight to dashboard on success
- remove CRM URL state and success screen

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4e814daac832f91e7c91525b185a2