### PR TITLE
refactor sso logging and open crm in new tab

### DIFF
--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -126,7 +126,7 @@ export function Sidebar({ className }: { className?: string }) {
         console.error('[Chatwoot SSO] Endpoint error', res.status, data);
         throw new Error();
       }
-      window.location.href = data.url;
+      window.open(data.url, '_blank', 'noopener,noreferrer');
     } catch (err) {
       console.error('[Chatwoot SSO] Failed to open CRM', err);
       toast('SSO indisponível, tente novamente mais tarde');
@@ -314,7 +314,7 @@ export function MobileSidebar() {
         throw new Error();
       }
       setOpen(false);
-      window.location.href = data.url;
+      window.open(data.url, '_blank', 'noopener,noreferrer');
     } catch (err) {
       console.error('[Chatwoot SSO] Failed to open CRM', err);
       toast('SSO indisponível, tente novamente mais tarde');


### PR DESCRIPTION
## Summary
- reduce Chatwoot SSO route logs to only critical errors
- open CRM links in a separate tab

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b50a051680832fb02d6c2ee95e2fb0