### PR TITLE
feat: store agent instructions

### DIFF
--- a/migration.sql
+++ b/migration.sql
@@ -66,6 +66,7 @@ create table public.agents (
   expiration_date timestamp with time zone null,
   created_at timestamp with time zone not null default now(),
   company_id bigint not null,
+  instructions jsonb not null default '{}'::jsonb,
   constraint agents_pkey primary key (id),
   constraint agents_company_id_fkey foreign key (company_id) references company (id)
 ) TABLESPACE pg_default;

--- a/src/app/dashboard/agents/[id]/comportamento/page.tsx
+++ b/src/app/dashboard/agents/[id]/comportamento/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import { supabasebrowser } from "@/lib/supabaseClient";
+import { updateAgentInstructions } from "@/lib/updateAgentInstructions";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Textarea } from "@/components/ui/textarea";
@@ -140,6 +141,7 @@ export default function AgentBehaviorPage() {
     if (error) {
       toast.error("Erro ao salvar comportamento.");
     } else {
+      await updateAgentInstructions(id);
       toast.success("Comportamento salvo com sucesso.");
     }
     setIsSubmitting(false);

--- a/src/app/dashboard/agents/[id]/instrucoes-especificas/page.tsx
+++ b/src/app/dashboard/agents/[id]/instrucoes-especificas/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import { supabasebrowser } from "@/lib/supabaseClient";
+import { updateAgentInstructions } from "@/lib/updateAgentInstructions";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -128,6 +129,7 @@ export default function AgentSpecificInstructionsPage() {
     if (error) {
       toast.error("Erro ao salvar instruções específicas.");
     } else {
+      await updateAgentInstructions(id);
       toast.success("Instruções específicas salvas com sucesso.");
     }
     setIsSubmitting(false);

--- a/src/app/dashboard/agents/[id]/onboarding/page.tsx
+++ b/src/app/dashboard/agents/[id]/onboarding/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import { supabasebrowser } from "@/lib/supabaseClient";
+import { updateAgentInstructions } from "@/lib/updateAgentInstructions";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -137,6 +138,7 @@ export default function AgentOnboardingPage() {
     if (error) {
       toast.error("Erro ao salvar onboarding.");
     } else {
+      await updateAgentInstructions(id);
       toast.success("Onboarding salvo com sucesso.");
     }
     setIsSubmitting(false);

--- a/src/app/dashboard/agents/[id]/page.tsx
+++ b/src/app/dashboard/agents/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import { supabasebrowser } from "@/lib/supabaseClient";
 import { isValidAgentName } from "@/lib/validators";
+import { updateAgentInstructions } from "@/lib/updateAgentInstructions";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -94,6 +95,7 @@ export default function AgentDetailPage() {
     if (agentError || personalityError) {
       toast.error("Erro ao salvar personalidade.");
     } else {
+      await updateAgentInstructions(id);
       toast.success("Personalidade salva com sucesso.");
       window.dispatchEvent(new Event("agentsUpdated"));
     }

--- a/src/app/dashboard/agents/new/page.tsx
+++ b/src/app/dashboard/agents/new/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { supabasebrowser } from "@/lib/supabaseClient";
+import { updateAgentInstructions } from "@/lib/updateAgentInstructions";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -150,6 +151,8 @@ export default function NewAgentPage() {
         return;
       }
     }
+
+    await updateAgentInstructions(data.id);
 
     const dueDate = new Date();
     dueDate.setDate(dueDate.getDate() + 30);

--- a/src/lib/updateAgentInstructions.ts
+++ b/src/lib/updateAgentInstructions.ts
@@ -1,0 +1,46 @@
+import { supabasebrowser } from "./supabaseClient";
+
+export async function updateAgentInstructions(agentId: string) {
+  const [agentRes, personalityRes, behaviorRes, onboardingRes, specificRes] =
+    await Promise.all([
+      supabasebrowser
+        .from("agents")
+        .select("name, type")
+        .eq("id", agentId)
+        .single(),
+      supabasebrowser
+        .from("agent_personality")
+        .select("voice_tone, objective, limits")
+        .eq("agent_id", agentId)
+        .single(),
+      supabasebrowser
+        .from("agent_behavior")
+        .select(
+          "limitations, forbidden_words, default_fallback, qualification_transfer_rule, qualification_transfer_conditions"
+        )
+        .eq("agent_id", agentId)
+        .single(),
+      supabasebrowser
+        .from("agent_onboarding")
+        .select("welcome_message, collection")
+        .eq("agent_id", agentId)
+        .single(),
+      supabasebrowser
+        .from("agent_specific_instructions")
+        .select("context, user_says, action")
+        .eq("agent_id", agentId),
+    ]);
+
+  const instructions = {
+    ...(agentRes.data ?? {}),
+    ...(personalityRes.data ?? {}),
+    ...(behaviorRes.data ?? {}),
+    ...(onboardingRes.data ?? {}),
+    specific_instructions: specificRes.data ?? [],
+  } as Record<string, unknown>;
+
+  await supabasebrowser
+    .from("agents")
+    .update({ instructions })
+    .eq("id", agentId);
+}


### PR DESCRIPTION
## Summary
- add instructions column to agents table
- sync agent instructions on create and save

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6249b3518832fae1c6013159bce1c