### PR TITLE
Remove forbidden words feature

### DIFF
--- a/components/agents/AgentGuide.tsx
+++ b/components/agents/AgentGuide.tsx
@@ -53,7 +53,7 @@ export default function AgentGuide() {
                   </Button>
                 </li>
                 <li>
-                  <strong>Comportamento</strong>: defina limitações, palavras proibidas e saída de segurança padrão.
+                  <strong>Comportamento</strong>: defina limitações e saída de segurança padrão.
                   <Button variant="link" asChild className="px-1">
                     <Link href={`/dashboard/agents/${id}/comportamento`}>
                       Ir para comportamento

--- a/components/landing/LearnMore.tsx
+++ b/components/landing/LearnMore.tsx
@@ -51,7 +51,7 @@ const slides = [
           <p className="mt-2 font-medium">O que você define no painel</p>
           <ul className="list-disc pl-5">
             <li>Personalidade: qual tom de voz, objetivo e limite do agente. </li>
-            <li>Comportamento: quando deve escalar para atendimento humano, palavras proibidas.</li>
+            <li>Comportamento: quando deve escalar para atendimento humano.</li>
             <li>Onboarding: O que o agente precisa coletar de informações para qualificar o lead.</li>
             <li>Base de conhecimento: carregue documentos que servirão de referência para o agente.</li>
             <li>Instruções específicas: detalhe orientações e casos especiais.</li>

--- a/migration.sql
+++ b/migration.sql
@@ -96,7 +96,6 @@ create table public.agent_behavior (
   created_at timestamp with time zone not null default now(),
   agent_id uuid not null,
   limitations text not null default ''::text,
-  forbidden_words text not null default ''::text,
   default_fallback text not null,
   qualification_transfer_rule public.qualification_transfer_rule not null default 'never'::qualification_transfer_rule,
   qualification_transfer_conditions text not null default ''::text,

--- a/src/app/dashboard/agents/[id]/comportamento/page.tsx
+++ b/src/app/dashboard/agents/[id]/comportamento/page.tsx
@@ -26,7 +26,6 @@ export default function AgentBehaviorPage() {
   const id = params?.id as string;
   const [agent, setAgent] = useState<Agent | null>(null);
   const [limitations, setLimitations] = useState("");
-  const [forbiddenWords, setForbiddenWords] = useState("");
   const [fallback, setFallback] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -43,13 +42,12 @@ export default function AgentBehaviorPage() {
 
     supabasebrowser
       .from("agent_behavior")
-      .select("limitations, forbidden_words, default_fallback")
+      .select("limitations, default_fallback")
       .eq("agent_id", id)
       .single()
       .then(({ data }) => {
         if (data) {
           setLimitations(data.limitations);
-          setForbiddenWords(data.forbidden_words);
           setFallback(data.default_fallback);
         }
       });
@@ -57,10 +55,8 @@ export default function AgentBehaviorPage() {
 
   if (!agent) return <div>Carregando...</div>;
   const limitationsValid = limitations.trim().length <= 500;
-  const forbiddenWordsValid = forbiddenWords.trim().length <= 500;
   const fallbackValid = fallback.trim().length >= 10 && fallback.trim().length <= 200;
-  const isFormValid =
-    limitationsValid && forbiddenWordsValid && fallbackValid;
+  const isFormValid = limitationsValid && fallbackValid;
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -73,7 +69,6 @@ export default function AgentBehaviorPage() {
         {
           agent_id: id,
           limitations,
-          forbidden_words: forbiddenWords,
           default_fallback: fallback,
         },
         { onConflict: "agent_id" }
@@ -116,28 +111,6 @@ export default function AgentBehaviorPage() {
               {limitations && !limitationsValid && (
                 <p className="text-xs text-red-500">
                   As limitações devem ter no máximo 500 caracteres
-                </p>
-              )}
-            </div>
-
-            <div className="space-y-2">
-              <label htmlFor="forbiddenWords" className="text-sm font-medium">
-                Palavras proibidas
-              </label>
-              <Textarea
-                id="forbiddenWords"
-                value={forbiddenWords}
-                onChange={(e) => setForbiddenWords(e.target.value)}
-                className="resize-y max-h-50 overflow-auto"
-                maxLength={500}
-              />
-              <div className="flex justify-between text-xs text-gray-500">
-                <p>Filtra expressões e ações.</p>
-                <p className="text-gray-400">0 a 500 caracteres</p>
-              </div>
-              {forbiddenWords && !forbiddenWordsValid && (
-                <p className="text-xs text-red-500">
-                  As palavras proibidas devem ter no máximo 500 caracteres
                 </p>
               )}
             </div>

--- a/src/app/dashboard/agents/new/page.tsx
+++ b/src/app/dashboard/agents/new/page.tsx
@@ -106,11 +106,11 @@ export default function NewAgentPage() {
 
     const template = AGENT_TEMPLATES[type];
     if (template) {
-      const behavior = template.behavior ?? {
-        limitations: "",
-        forbidden_words: "",
-        default_fallback: "",
-      };
+      const behavior =
+        template.behavior ?? {
+          limitations: "",
+          default_fallback: "",
+        };
       const inserts = [];
       inserts.push(
         supabasebrowser.from("agent_personality").insert({

--- a/src/lib/agentTemplates.ts
+++ b/src/lib/agentTemplates.ts
@@ -6,7 +6,6 @@ export interface AgentTemplate {
   };
   behavior: {
     limitations: string;
-    forbidden_words: string;
     default_fallback: string;
   };
   onboarding: {
@@ -25,7 +24,6 @@ export const AGENT_TEMPLATES: Record<string, AgentTemplate> = {
     },
     behavior: {
       limitations: 'Não realiza alterações sem confirmação do usuário',
-      forbidden_words: 'gírias, palavras ofensivas',
       default_fallback:
         'Não consegui compreender, poderia reformular o pedido de agendamento?',
     },
@@ -58,7 +56,6 @@ export const AGENT_TEMPLATES: Record<string, AgentTemplate> = {
     },
     behavior: {
       limitations: '- Solicitações de informações internas\n- Pedidos para falar com atendente',
-      forbidden_words: 'promessas de preço, descontos garantidos, agendamento de reuniões/consultas',
       default_fallback:
         'Agora não consigo te ajudar, mas vou te direcionar para um de nossos atendentes que poderá atender você.',
     },
@@ -93,7 +90,6 @@ export const AGENT_TEMPLATES: Record<string, AgentTemplate> = {
     },
     behavior: {
       limitations: 'Não souber responder uma pergunta do usuário.',
-      forbidden_words: 'termos técnicos complexos',
       default_fallback:
         'Ainda não sei responder isso, mas vou te direcionar para um de nossos atendentes que poderá atender você.',
     },

--- a/src/lib/updateAgentInstructions.ts
+++ b/src/lib/updateAgentInstructions.ts
@@ -15,7 +15,7 @@ export async function updateAgentInstructions(agentId: string) {
         .single(),
       supabasebrowser
         .from("agent_behavior")
-        .select("limitations, forbidden_words, default_fallback")
+        .select("limitations, default_fallback")
         .eq("agent_id", agentId)
         .single(),
       supabasebrowser


### PR DESCRIPTION
## Summary
- remove UI and logic for forbidden words
- drop forbidden_words from agent templates and database schema
- update instruction builder without forbidden words

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b85a239824832faf87b98ea65396c1