### PR TITLE
feat: add company name and pain points to agent setup

### DIFF
--- a/migration.sql
+++ b/migration.sql
@@ -82,6 +82,7 @@ create table public.agent_personality (
   voice_tone public.voice_tone not null,
   objective text not null,
   limits text not null,
+  company_name text not null default ''::text,
   constraint agent_personality_pkey primary key (id),
   constraint agent_personality_agent_id_key unique (agent_id),
   constraint agent_personality_agent_id_fkey foreign key (agent_id) references agents (id)
@@ -111,6 +112,7 @@ create table public.agent_onboarding (
   created_at timestamp with time zone not null default now(),
   agent_id uuid not null,
   welcome_message text not null default ''::text,
+  pain_points character varying(500) not null default ''::character varying,
   collection jsonb not null default '[]'::jsonb,
   constraint agent_onboarding_pkey primary key (id),
   constraint agent_onboarding_agent_id_key unique (agent_id),

--- a/src/app/dashboard/agents/[id]/onboarding/page.tsx
+++ b/src/app/dashboard/agents/[id]/onboarding/page.tsx
@@ -40,6 +40,7 @@ export default function AgentOnboardingPage() {
   const id = params?.id as string;
   const [agent, setAgent] = useState<Agent | null>(null);
   const [welcomeMessage, setWelcomeMessage] = useState("");
+  const [painPoints, setPainPoints] = useState("");
   const [collection, setCollection] = useState<CollectionItem[]>(
     ensureAtLeastTwo([])
   );
@@ -58,12 +59,13 @@ export default function AgentOnboardingPage() {
 
     supabasebrowser
       .from("agent_onboarding")
-      .select("welcome_message, collection")
+      .select("welcome_message, pain_points, collection")
       .eq("agent_id", id)
       .single()
       .then(({ data }) => {
         if (data) {
           setWelcomeMessage(data.welcome_message);
+          setPainPoints(data.pain_points);
           if (Array.isArray(data.collection)) {
             setCollection(ensureAtLeastTwo(data.collection));
           }
@@ -78,6 +80,7 @@ export default function AgentOnboardingPage() {
   const showCollection = agent.type === "sdr" || agent.type === "atendimento";
 
   const welcomeMessageValid = welcomeMessage.trim().length <= 500;
+  const painPointsValid = painPoints.trim().length <= 500;
   const filledCollectionCount = collection.filter(
     (item) => item.question.trim() && item.information.trim()
   ).length;
@@ -95,7 +98,7 @@ export default function AgentOnboardingPage() {
       })
     : true;
 
-  const isFormValid = welcomeMessageValid && collectionValid;
+  const isFormValid = welcomeMessageValid && painPointsValid && collectionValid;
 
   const handleQuestionChange = (index: number, value: string) => {
     const newCollection = [...collection];
@@ -135,6 +138,7 @@ export default function AgentOnboardingPage() {
         {
           agent_id: id,
           welcome_message: welcomeMessage,
+          pain_points: painPoints,
           collection: filtered,
         },
         { onConflict: "agent_id" }
@@ -177,6 +181,28 @@ export default function AgentOnboardingPage() {
               {welcomeMessage && !welcomeMessageValid && (
                 <p className="text-xs text-red-500">
                   A mensagem deve ter no máximo 500 caracteres
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <label htmlFor="pains" className="text-sm font-medium">
+                Principais dores que a empresa resolve
+              </label>
+              <Textarea
+                id="pains"
+                value={painPoints}
+                onChange={(e) => setPainPoints(e.target.value)}
+                className="resize-y max-h-50 overflow-auto"
+                maxLength={500}
+              />
+              <div className="flex justify-between text-xs text-gray-500">
+                <p>Use para direcionar a coleta de informações.</p>
+                <p className="text-gray-400">0 a 500 caracteres</p>
+              </div>
+              {painPoints && !painPointsValid && (
+                <p className="text-xs text-red-500">
+                  O texto deve ter no máximo 500 caracteres
                 </p>
               )}
             </div>

--- a/src/app/dashboard/agents/[id]/page.tsx
+++ b/src/app/dashboard/agents/[id]/page.tsx
@@ -37,6 +37,7 @@ export default function AgentDetailPage() {
   const [tone, setTone] = useState("");
   const [objective, setObjective] = useState("");
   const [limits, setLimits] = useState("");
+  const [companyName, setCompanyName] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
 
 
@@ -54,7 +55,7 @@ export default function AgentDetailPage() {
 
     supabasebrowser
       .from("agent_personality")
-      .select("voice_tone,objective,limits")
+      .select("voice_tone,objective,limits,company_name")
       .eq("agent_id", id)
       .single()
       .then(({ data }) => {
@@ -62,6 +63,7 @@ export default function AgentDetailPage() {
           setTone(data.voice_tone);
           setObjective(data.objective);
           setLimits(data.limits);
+          setCompanyName(data.company_name);
         }
       });
   }, [id]);
@@ -72,8 +74,14 @@ export default function AgentDetailPage() {
     objective.trim().length >= 10 && objective.trim().length <= 500;
   const limitsValid =
     limits.trim().length >= 10 && limits.trim().length <= 1000;
+  const companyNameValid =
+    companyName.trim().length >= 3 && companyName.trim().length <= 100;
   const isFormValid =
-    isValidAgentName(name) && tone !== "" && objectiveValid && limitsValid;
+    isValidAgentName(name) &&
+    tone !== "" &&
+    objectiveValid &&
+    limitsValid &&
+    companyNameValid;
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -88,7 +96,13 @@ export default function AgentDetailPage() {
     const { error: personalityError } = await supabasebrowser
       .from("agent_personality")
       .upsert(
-        { agent_id: id, voice_tone: tone, objective, limits },
+        {
+          agent_id: id,
+          voice_tone: tone,
+          objective,
+          limits,
+          company_name: companyName,
+        },
         { onConflict: "agent_id" }
       );
 
@@ -117,7 +131,11 @@ export default function AgentDetailPage() {
                 <label htmlFor="name" className="text-sm font-medium">
                   Nome interno
                 </label>
-                <Input id="name" value={name} onChange={(e) => setName(e.target.value)} />
+                <Input
+                  id="name"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                />
                 <div className="flex justify-between text-xs text-gray-500">
                   <p>Identifica o agente no dashboard.</p>
                   <p className="text-gray-400"> 3 a 50 caracteres</p>
@@ -125,6 +143,26 @@ export default function AgentDetailPage() {
                 {name && !isValidAgentName(name) && (
                   <p className="text-xs text-red-500">
                     O nome deve ter entre 3 e 50 caracteres
+                  </p>
+                )}
+              </div>
+
+              <div className="flex-1 space-y-2">
+                <label htmlFor="company" className="text-sm font-medium">
+                  Empresa
+                </label>
+                <Input
+                  id="company"
+                  value={companyName}
+                  onChange={(e) => setCompanyName(e.target.value)}
+                />
+                <div className="flex justify-between text-xs text-gray-500">
+                  <p>Nome da empresa que o agente representa.</p>
+                  <p className="text-gray-400">3 a 100 caracteres</p>
+                </div>
+                {companyName && !companyNameValid && (
+                  <p className="text-xs text-red-500">
+                    O nome deve ter entre 3 e 100 caracteres
                   </p>
                 )}
               </div>

--- a/src/lib/agentTemplates.ts
+++ b/src/lib/agentTemplates.ts
@@ -3,6 +3,7 @@ export interface AgentTemplate {
     voice_tone: 'formal' | 'casual';
     objective: string;
     limits: string;
+    company_name: string;
   };
   behavior: {
     limitations: string;
@@ -10,6 +11,7 @@ export interface AgentTemplate {
   };
   onboarding: {
     welcome_message: string;
+    pain_points: string;
     collection: { question: string; information: string }[];
   };
   specificInstructions: { context: string; user_says: string; action: string }[];
@@ -21,6 +23,7 @@ export const AGENT_TEMPLATES: Record<string, AgentTemplate> = {
       voice_tone: 'formal',
       objective: 'Gerenciar horários e compromissos do cliente',
       limits: 'Não confirmar reuniões sem verificar disponibilidade',
+      company_name: '',
     },
     behavior: {
       limitations: 'Não realiza alterações sem confirmação do usuário',
@@ -29,6 +32,7 @@ export const AGENT_TEMPLATES: Record<string, AgentTemplate> = {
     },
     onboarding: {
       welcome_message: 'Olá! Vou ajudar com seus agendamentos.',
+      pain_points: '',
       collection: [
         {
           question: 'Qual é o seu nome completo?',
@@ -53,6 +57,7 @@ export const AGENT_TEMPLATES: Record<string, AgentTemplate> = {
       voice_tone: 'casual',
       objective: 'Qualificar leads e gerar oportunidades de vendas',
       limits: 'Nunca invente, não preencha lacunas com suposições. Se a mensagem for uma dúvida clara e objetiva e a resposta não estiver explícita no contexto ou na base de conhecimento.',
+      company_name: '',
     },
     behavior: {
       limitations: '- Solicitações de informações internas\n- Pedidos para falar com atendente',
@@ -62,6 +67,7 @@ export const AGENT_TEMPLATES: Record<string, AgentTemplate> = {
     onboarding: {
       welcome_message:
         'Olá! Sou o agente SDR e estou aqui para te ajudar!',
+      pain_points: '',
       collection: [
         {
           question: 'Qual é o segmento da sua empresa?',
@@ -87,6 +93,7 @@ export const AGENT_TEMPLATES: Record<string, AgentTemplate> = {
       voice_tone: 'formal',
       objective: 'Ajudar clientes com dúvidas e problemas',
       limits: 'Nunca invente, não preencha lacunas com suposições. Se a mensagem for uma dúvida clara e objetiva e a resposta não estiver explícita no contexto ou na base de conhecimento.',
+      company_name: '',
     },
     behavior: {
       limitations: 'Não souber responder uma pergunta do usuário.',
@@ -95,6 +102,7 @@ export const AGENT_TEMPLATES: Record<string, AgentTemplate> = {
     },
     onboarding: {
       welcome_message: 'Olá! Estou aqui para ajudar com o suporte.',
+      pain_points: '',
       collection: [],
     },
     specificInstructions: [

--- a/src/lib/updateAgentInstructions.ts
+++ b/src/lib/updateAgentInstructions.ts
@@ -10,7 +10,7 @@ export async function updateAgentInstructions(agentId: string) {
         .single(),
       supabasebrowser
         .from("agent_personality")
-        .select("voice_tone, objective, limits")
+        .select("voice_tone, objective, limits, company_name")
         .eq("agent_id", agentId)
         .single(),
       supabasebrowser
@@ -20,7 +20,7 @@ export async function updateAgentInstructions(agentId: string) {
         .single(),
       supabasebrowser
         .from("agent_onboarding")
-        .select("welcome_message, collection")
+        .select("welcome_message, pain_points, collection")
         .eq("agent_id", agentId)
         .single(),
       supabasebrowser


### PR DESCRIPTION
## Summary
- capture company name in personality settings for each agent
- track pain points during onboarding to guide information collection
- propagate new fields through templates and instruction builder

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b882450190832f8116a12b837e3103