### PR TITLE
refactor: rename agent types

### DIFF
--- a/components/agents/AgentMenu.tsx
+++ b/components/agents/AgentMenu.tsx
@@ -23,8 +23,8 @@ type Agent = {
 
 const typeLabels: Record<string, string> = {
   agendamento: "Agendamento",
+  "pre-qualificacao": "Pré-qualificação",
   sdr: "SDR",
-  suporte: "Suporte",
 };
 
 export default function AgentMenu({ agent }: { agent: Agent }) {

--- a/components/landing/Features.tsx
+++ b/components/landing/Features.tsx
@@ -12,11 +12,11 @@ import {
 } from "lucide-react";
 
 const items = [
-  {
-    title: "Dentistas",
-    description: "Agende mais consultas com um atendente 24h",
-    icon: Smile,
-  },
+    {
+      title: "Dentistas",
+      description: "Agende mais consultas com um SDR 24h",
+      icon: Smile,
+    },
   {
     title: "Médicos",
     description: "Automatize agendamentos e reduza o tempo de resposta.",

--- a/components/landing/LearnMore.tsx
+++ b/components/landing/LearnMore.tsx
@@ -10,7 +10,7 @@ const slides = [
         <p>
           Permitimos que sua empresa crie e personalize um agente virtual com inteligência artificial de forma simples e rápida.
           Integrado ao nosso CRM, ele responde dúvidas, coleta informações,
-          qualifica leads e transfere para um atendente humano sempre que necessário — garantindo agilidade,
+          qualifica leads e transfere para um SDR humano sempre que necessário — garantindo agilidade,
           eficiência e uma experiência impecável para seus clientes.
         </p>
         <h3 className="mt-4 font-semibold">Benefícios em poucas linhas</h3>
@@ -39,7 +39,7 @@ const slides = [
           <h4 className="font-semibold">Passo 1 — Criação do Agente</h4>
           <p className="mt-2 font-medium">O que você faz</p>
           <ul className="list-disc pl-5">
-            <li>Escolhe o modelo do agente (ex.: SDR/Vendas, Suporte).</li>
+              <li>Escolhe o modelo do agente (ex.: Pré-qualificação/Vendas, SDR).</li>
             <li>Define o nome interno do agente.</li>
           </ul>
           <p className="mt-2">

--- a/migration.sql
+++ b/migration.sql
@@ -55,7 +55,7 @@ create table public.payments (
 
 
 -- Enum para tipos de agente
-create type public.agent_type as enum ('agendamento', 'sdr', 'suporte');
+create type public.agent_type as enum ('agendamento', 'pre-qualificacao', 'sdr');
 
 -- Tabela de agentes de IA
 create table public.agents (

--- a/src/app/dashboard/agents/[id]/onboarding/page.tsx
+++ b/src/app/dashboard/agents/[id]/onboarding/page.tsx
@@ -75,7 +75,7 @@ export default function AgentOnboardingPage() {
 
   if (!agent) return <div>Carregando...</div>;
 
-  const showCollection = agent.type === "sdr" || agent.type === "atendimento";
+  const showCollection = agent.type === "pre-qualificacao" || agent.type === "sdr";
 
   const welcomeMessageValid = welcomeMessage.trim().length <= 500;
   const filledCollectionCount = collection.filter(

--- a/src/app/dashboard/agents/new/page.tsx
+++ b/src/app/dashboard/agents/new/page.tsx
@@ -40,13 +40,13 @@ export default function NewAgentPage() {
       disabled: true,
     },
     {
-      value: "sdr",
-      title: "SDR",
+      value: "pre-qualificacao",
+      title: "Pré-qualificação",
       description: "Qualifica e interage com leads",
     },
     {
-      value: "suporte",
-      title: "Suporte",
+      value: "sdr",
+      title: "SDR",
       description: "Responde dúvidas e auxilia clientes",
     },
   ];

--- a/src/lib/agentTemplates.ts
+++ b/src/lib/agentTemplates.ts
@@ -48,20 +48,20 @@ export const AGENT_TEMPLATES: Record<string, AgentTemplate> = {
       },
     ],
   },
-  sdr: {
+  "pre-qualificacao": {
     personality: {
       voice_tone: 'casual',
       objective: 'Qualificar leads e gerar oportunidades de vendas',
       limits: 'Nunca invente, não preencha lacunas com suposições. Se a mensagem for uma dúvida clara e objetiva e a resposta não estiver explícita no contexto ou na base de conhecimento.',
     },
     behavior: {
-      limitations: '- Solicitações de informações internas\n- Pedidos para falar com atendente',
+      limitations: '- Solicitações de informações internas\n- Pedidos para falar com SDR',
       default_fallback:
-        'Agora não consigo te ajudar, mas vou te direcionar para um de nossos atendentes que poderá atender você.',
+        'Agora não consigo te ajudar, mas vou te direcionar para um de nossos SDRs que poderá atender você.',
     },
     onboarding: {
       welcome_message:
-        'Olá! Sou o agente SDR e estou aqui para te ajudar!',
+        'Olá! Sou o agente de pré-qualificação e estou aqui para te ajudar!',
       collection: [
         {
           question: 'Qual é o segmento da sua empresa?',
@@ -82,21 +82,21 @@ export const AGENT_TEMPLATES: Record<string, AgentTemplate> = {
       },
     ],
   },
-  suporte: {
+    sdr: {
     personality: {
       voice_tone: 'formal',
       objective: 'Ajudar clientes com dúvidas e problemas',
       limits: 'Nunca invente, não preencha lacunas com suposições. Se a mensagem for uma dúvida clara e objetiva e a resposta não estiver explícita no contexto ou na base de conhecimento.',
     },
-    behavior: {
-      limitations: 'Não souber responder uma pergunta do usuário.',
-      default_fallback:
-        'Ainda não sei responder isso, mas vou te direcionar para um de nossos atendentes que poderá atender você.',
-    },
-    onboarding: {
-      welcome_message: 'Olá! Estou aqui para ajudar com o suporte.',
-      collection: [],
-    },
+      behavior: {
+        limitations: 'Não souber responder uma pergunta do usuário.',
+        default_fallback:
+          'Ainda não sei responder isso, mas vou te direcionar para um de nossos SDRs que poderá atender você.',
+      },
+      onboarding: {
+        welcome_message: 'Olá! Estou aqui para ajudar como SDR.',
+        collection: [],
+      },
     specificInstructions: [
       {
         context: 'Cliente solicita reset de senha',

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -4,8 +4,8 @@ export const AGENT_PRICE = 599;
 
 export const ALLOWED_AGENT_TYPES = [
   "agendamento",
+  "pre-qualificacao",
   "sdr",
-  "suporte",
 ];
 
 export const ALLOWED_KNOWLEDGE_MIME_TYPES = [


### PR DESCRIPTION
## Summary
- rename tipo de agente `sdr` para `pre-qualificacao`
- substituir agentes `suporte`/`atendente` por `sdr`
- ajustar textos e labels relacionados

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8826939d4832fb61beaaf8f41c5af