### PR TITLE
Rename agent types

### DIFF
--- a/components/agents/AgentMenu.tsx
+++ b/components/agents/AgentMenu.tsx
@@ -22,8 +22,8 @@ type Agent = {
 };
 
 const typeLabels: Record<string, string> = {
-  agendamento: "Agendamento",
   sdr: "SDR",
+  "pre-qualificacao": "Pré-qualificação",
   suporte: "Suporte",
 };
 

--- a/migration.sql
+++ b/migration.sql
@@ -55,7 +55,7 @@ create table public.payments (
 
 
 -- Enum para tipos de agente
-create type public.agent_type as enum ('agendamento', 'sdr', 'suporte');
+create type public.agent_type as enum ('sdr', 'pre-qualificacao', 'suporte');
 
 -- Tabela de agentes de IA
 create table public.agents (

--- a/src/app/dashboard/agents/[id]/onboarding/page.tsx
+++ b/src/app/dashboard/agents/[id]/onboarding/page.tsx
@@ -75,7 +75,8 @@ export default function AgentOnboardingPage() {
 
   if (!agent) return <div>Carregando...</div>;
 
-  const showCollection = agent.type === "sdr" || agent.type === "atendimento";
+  const showCollection =
+    agent.type === "pre-qualificacao" || agent.type === "atendimento";
 
   const welcomeMessageValid = welcomeMessage.trim().length <= 500;
   const filledCollectionCount = collection.filter(

--- a/src/app/dashboard/agents/new/page.tsx
+++ b/src/app/dashboard/agents/new/page.tsx
@@ -34,14 +34,14 @@ export default function NewAgentPage() {
 
   const agentTypes = [
     {
-      value: "agendamento",
-      title: "Agendamento",
+      value: "sdr",
+      title: "SDR",
       description: "Gerencia horários e calendários",
       disabled: true,
     },
     {
-      value: "sdr",
-      title: "SDR",
+      value: "pre-qualificacao",
+      title: "Pré-qualificação",
       description: "Qualifica e interage com leads",
     },
     {

--- a/src/lib/agentTemplates.ts
+++ b/src/lib/agentTemplates.ts
@@ -16,7 +16,7 @@ export interface AgentTemplate {
 }
 
 export const AGENT_TEMPLATES: Record<string, AgentTemplate> = {
-  agendamento: {
+  sdr: {
     personality: {
       voice_tone: 'formal',
       objective: 'Gerenciar horários e compromissos do cliente',
@@ -48,7 +48,7 @@ export const AGENT_TEMPLATES: Record<string, AgentTemplate> = {
       },
     ],
   },
-  sdr: {
+  "pre-qualificacao": {
     personality: {
       voice_tone: 'casual',
       objective: 'Qualificar leads e gerar oportunidades de vendas',

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -3,8 +3,8 @@ export const MAX_AGENTS_PER_COMPANY = 5;
 export const AGENT_PRICE = 599;
 
 export const ALLOWED_AGENT_TYPES = [
-  "agendamento",
   "sdr",
+  "pre-qualificacao",
   "suporte",
 ];
 


### PR DESCRIPTION
## Summary
- rename agent type `sdr` to `pre-qualificacao` and `agendamento` to `sdr`
- adjust templates, constants, and UI labels to the new agent types
- update onboarding logic and database enum for new type names

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b89a04e1f0832f9bcc329a2f89ee0f