### PR TITLE
Format collection questions into single instruction key

### DIFF
--- a/src/lib/updateAgentInstructions.ts
+++ b/src/lib/updateAgentInstructions.ts
@@ -29,11 +29,19 @@ export async function updateAgentInstructions(agentId: string) {
         .eq("agent_id", agentId),
     ]);
 
+  const collectionArray = onboardingRes.data?.collection ?? [];
+  const collectionString = collectionArray
+    .map((item: { question: string }, index: number) =>
+      `[var_${index}] - ${item.question}`
+    )
+    .join("\n");
+
   const instructions = {
     ...(agentRes.data ?? {}),
     ...(personalityRes.data ?? {}),
     ...(behaviorRes.data ?? {}),
     ...(onboardingRes.data ?? {}),
+    collection: collectionString,
     specific_instructions: specificRes.data ?? [],
   } as Record<string, unknown>;
 


### PR DESCRIPTION
## Summary
- format onboarding collection questions into a single `collection` string using `[var_#] - question` entries

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b8a7eb17d8832fbf5d8c80e2b00d27