### PR TITLE
Format onboarding collection into single instruction string

### DIFF
--- a/src/lib/updateAgentInstructions.ts
+++ b/src/lib/updateAgentInstructions.ts
@@ -29,11 +29,23 @@ export async function updateAgentInstructions(agentId: string) {
         .eq("agent_id", agentId),
     ]);
 
+  const onboarding = onboardingRes.data ?? {};
+  const collection = Array.isArray(onboarding.collection)
+    ? onboarding.collection
+        .map(
+          (item: { question: string; information: string }, index: number) =>
+            `${index + 2}. Se [${item.information}] não estiver preenchido, pergunte: "${item.question}"`
+        )
+        .join("\n")
+    : "";
+
   const instructions = {
     ...(agentRes.data ?? {}),
     ...(personalityRes.data ?? {}),
     ...(behaviorRes.data ?? {}),
-    ...(onboardingRes.data ?? {}),
+    welcome_message: onboarding.welcome_message,
+    pain_points: onboarding.pain_points,
+    collection,
     specific_instructions: specificRes.data ?? [],
   } as Record<string, unknown>;
 

--- a/src/lib/updateAgentInstructions.ts
+++ b/src/lib/updateAgentInstructions.ts
@@ -29,12 +29,17 @@ export async function updateAgentInstructions(agentId: string) {
         .eq("agent_id", agentId),
     ]);
 
-  const onboarding = onboardingRes.data ?? {};
+  type Onboarding = {
+    welcome_message?: string;
+    pain_points?: string;
+    collection?: { question: string; information: string }[];
+  };
+
+  const onboarding: Onboarding = onboardingRes.data ?? {};
   const collection = Array.isArray(onboarding.collection)
     ? onboarding.collection
-        .map(
-          (item: { question: string; information: string }, index: number) =>
-            `${index + 2}. Se [${item.information}] não estiver preenchido, pergunte: "${item.question}"`
+        .map((item, index) =>
+          `${index + 2}. Se [${item.information}] não estiver preenchido, pergunte: "${item.question}"`
         )
         .join("\n")
     : "";

--- a/src/lib/updateAgentInstructions.ts
+++ b/src/lib/updateAgentInstructions.ts
@@ -38,8 +38,9 @@ export async function updateAgentInstructions(agentId: string) {
   const onboarding: Onboarding = onboardingRes.data ?? {};
   const collection = Array.isArray(onboarding.collection)
     ? onboarding.collection
-        .map((item, index) =>
-          `${index + 2}. Se [${item.information}] não estiver preenchido, pergunte: "${item.question}"`
+        .map(
+          (item, index) =>
+            `${index + 2}. Se [var_${index}] não estiver preenchido, pergunte: "${item.question}"`
         )
         .join("\n")
     : "";


### PR DESCRIPTION
## Summary
- format onboarding collection prompts into a single enumerated instruction string

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8a8220364832f8f0b5ae0baa19695