### PR TITLE
Format specific instructions into single string

### DIFF
--- a/src/lib/updateAgentInstructions.ts
+++ b/src/lib/updateAgentInstructions.ts
@@ -36,13 +36,23 @@ export async function updateAgentInstructions(agentId: string) {
     )
     .join("\n");
 
+  const specificInstructionsString =
+    specificRes.data
+      ?.map(
+        (item: { context?: string; user_says?: string; action?: string }) =>
+          `Context: "${item.context ?? ""}"\n` +
+          `User says: "${item.user_says ?? ""}"\n` +
+          `Act like this: "${item.action ?? ""}"`
+      )
+      .join("\n\n") ?? "";
+
   const instructions = {
     ...(agentRes.data ?? {}),
     ...(personalityRes.data ?? {}),
     ...(behaviorRes.data ?? {}),
     ...(onboardingRes.data ?? {}),
     collection: collectionString,
-    specific_instructions: specificRes.data ?? [],
+    specific_instructions: specificInstructionsString,
   } as Record<string, unknown>;
 
   await supabasebrowser


### PR DESCRIPTION
## Summary
- store specific agent instructions in a formatted single-string field

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8b49ed67c832fad8e1120e2c5e335