### PR TITLE
Expand agent editing layout width

### DIFF
--- a/components/agents/AgentMenu.tsx
+++ b/components/agents/AgentMenu.tsx
@@ -54,7 +54,7 @@ export default function AgentMenu({ agent }: { agent: Agent }) {
 
   return (
     <div className="flex justify-center">
-      <div className="w-full md:w-4/5 flex flex-col md:flex-row gap-4">
+      <div className="w-full md:w-[90%] flex flex-col md:flex-row gap-4">
         <Card className="w-full md:w-52 p-4 flex flex-col items-center justify-center gap-3 text-sm text-center">
           <div>
             <p className="text-xs text-gray-500">Status do agente</p>

--- a/src/app/dashboard/agents/[id]/base-conhecimento/page.tsx
+++ b/src/app/dashboard/agents/[id]/base-conhecimento/page.tsx
@@ -246,7 +246,7 @@ export default function AgentKnowledgeBasePage() {
       <AgentGuide />
 
       <div className="flex justify-center">
-        <Card className="w-full md:w-4/5 p-6">
+        <Card className="w-full md:w-[90%] p-6">
           <p className="text-xs italic text-gray-500 mb-4">
             Adicione arquivos para compor a base de conhecimento do agente.
           </p>
@@ -362,7 +362,7 @@ export default function AgentKnowledgeBasePage() {
         </Card>
       </div>
       <div className="flex justify-center">
-        <div className="w-full md:w-4/5 flex justify-end gap-2">
+        <div className="w-full md:w-[90%] flex justify-end gap-2">
           {agent.is_active ? (
             <DeactivateAgentButton
               agentId={id}

--- a/src/app/dashboard/agents/[id]/comportamento/page.tsx
+++ b/src/app/dashboard/agents/[id]/comportamento/page.tsx
@@ -88,7 +88,7 @@ export default function AgentBehaviorPage() {
       <AgentMenu agent={agent} />
       <AgentGuide />
       <div className="flex justify-center">
-        <Card className="w-full md:w-4/5 p-6">
+        <Card className="w-full md:w-[90%] p-6">
           <p className="text-xs italic text-gray-500 mb-4">
             Configure como o agente deve se comportar durante as interações.
           </p>
@@ -146,7 +146,7 @@ export default function AgentBehaviorPage() {
         </Card>
       </div>
       <div className="flex justify-center">
-        <div className="w-full md:w-4/5 flex justify-end gap-2">
+        <div className="w-full md:w-[90%] flex justify-end gap-2">
           {agent.is_active ? (
             <DeactivateAgentButton
               agentId={id}

--- a/src/app/dashboard/agents/[id]/instrucoes-especificas/page.tsx
+++ b/src/app/dashboard/agents/[id]/instrucoes-especificas/page.tsx
@@ -140,7 +140,7 @@ export default function AgentSpecificInstructionsPage() {
       <AgentMenu agent={agent} />
       <AgentGuide />
       <div className="flex justify-center">
-        <Card className="w-full md:w-4/5 p-6">
+        <Card className="w-full md:w-[90%] p-6">
           <p className="text-xs italic text-gray-500 mb-4">
             Crie respostas específicas para situações ou perguntas frequentes.
           </p>
@@ -280,7 +280,7 @@ export default function AgentSpecificInstructionsPage() {
         </Card>
       </div>
       <div className="flex justify-center">
-        <div className="w-full md:w-4/5 flex justify-end gap-2">
+        <div className="w-full md:w-[90%] flex justify-end gap-2">
           {agent.is_active ? (
             <DeactivateAgentButton
               agentId={id}

--- a/src/app/dashboard/agents/[id]/integracoes/page.tsx
+++ b/src/app/dashboard/agents/[id]/integracoes/page.tsx
@@ -57,7 +57,7 @@ export default function AgentIntegrationsPage() {
       <AgentMenu agent={agent} />
       <AgentGuide />
       <div className="flex justify-center">
-        <Card className="w-full md:w-4/5 p-6 space-y-4">
+        <Card className="w-full md:w-[90%] p-6 space-y-4">
           <h2 className="text-lg font-semibold">Google Calendar</h2>
           {connected ? (
             <p>Google Calendar conectado.</p>
@@ -67,7 +67,7 @@ export default function AgentIntegrationsPage() {
         </Card>
       </div>
       <div className="flex justify-center">
-        <div className="w-full md:w-4/5 flex justify-end gap-2">
+        <div className="w-full md:w-[90%] flex justify-end gap-2">
           {agent.is_active ? (
             <DeactivateAgentButton
               agentId={id}

--- a/src/app/dashboard/agents/[id]/onboarding/page.tsx
+++ b/src/app/dashboard/agents/[id]/onboarding/page.tsx
@@ -159,7 +159,7 @@ export default function AgentOnboardingPage() {
       <AgentMenu agent={agent} />
       <AgentGuide />
       <div className="flex justify-center">
-        <Card className="w-full md:w-4/5 p-6">
+        <Card className="w-full md:w-[90%] p-6">
           <p className="text-xs italic text-gray-500 mb-4">
             Personalize a mensagem inicial e colete dados essenciais dos usuários.
           </p>
@@ -303,7 +303,7 @@ export default function AgentOnboardingPage() {
         </Card>
       </div>
       <div className="flex justify-center">
-        <div className="w-full md:w-4/5 flex justify-end gap-2">
+        <div className="w-full md:w-[90%] flex justify-end gap-2">
           {agent.is_active ? (
             <DeactivateAgentButton
               agentId={id}

--- a/src/app/dashboard/agents/[id]/page.tsx
+++ b/src/app/dashboard/agents/[id]/page.tsx
@@ -128,7 +128,7 @@ export default function AgentDetailPage() {
       <AgentMenu agent={agent} />
       <AgentGuide />
       <div className="flex justify-center">
-        <Card className="w-full md:w-4/5 p-6">
+        <Card className="w-full md:w-[90%] p-6">
           <p className="text-xs italic text-gray-500 mb-4">
             Defina a personalidade e os objetivos do agente.
           </p>
@@ -266,7 +266,7 @@ export default function AgentDetailPage() {
         </Card>
       </div>
       <div className="flex justify-center">
-        <div className="w-full md:w-4/5 flex justify-end gap-2">
+        <div className="w-full md:w-[90%] flex justify-end gap-2">
           {agent.is_active ? (
             <DeactivateAgentButton
               agentId={id}


### PR DESCRIPTION
## Summary
- Expand agent menu container to 90% width for smaller horizontal margins
- Widen agent editing cards to 90% across all agent detail pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68beeb1c6a14832f82aea150b6c6b678