### PR TITLE
feat: improve Google Calendar integration screen

### DIFF
--- a/src/app/api/google-calendar/disconnect/route.ts
+++ b/src/app/api/google-calendar/disconnect/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseadmin } from "@/lib/supabaseAdmin";
+
+export async function DELETE(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const agentId = searchParams.get("agent_id");
+  if (!agentId) {
+    return NextResponse.json({ error: "missing agent_id" }, { status: 400 });
+  }
+
+  const { error } = await supabaseadmin
+    .from("agent_google_tokens")
+    .delete()
+    .eq("agent_id", agentId);
+
+  if (error) {
+    return NextResponse.json({ error: "failed to disconnect" }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/dashboard/agents/[id]/integracoes/page.tsx
+++ b/src/app/dashboard/agents/[id]/integracoes/page.tsx
@@ -52,17 +52,34 @@ export default function AgentIntegrationsPage() {
     }
   };
 
+  const handleDisconnect = async () => {
+    if (!id) return;
+    await fetch(`/api/google-calendar/disconnect?agent_id=${id}`, {
+      method: "DELETE",
+    });
+    setConnected(false);
+  };
+
   return (
     <div className="space-y-6">
       <AgentMenu agent={agent} />
       <AgentGuide />
       <div className="flex justify-center">
-        <Card className="w-full md:w-[90%] p-6 space-y-4">
-          <h2 className="text-lg font-semibold">Google Calendar</h2>
+        <Card className="w-full md:w-[90%] p-6 flex items-center justify-between">
+          <div className="space-y-1">
+            <h2 className="text-lg font-semibold">Google Calendar</h2>
+            <p className="text-sm text-muted-foreground">
+              {connected
+                ? "Google Calendar conectado."
+                : "Conecte seu calendário para sincronizar eventos."}
+            </p>
+          </div>
           {connected ? (
-            <p>Google Calendar conectado.</p>
+            <Button variant="destructive" onClick={handleDisconnect}>
+              Desconectar
+            </Button>
           ) : (
-            <Button onClick={handleConnect}>Conectar Google Calendar</Button>
+            <Button onClick={handleConnect}>Conectar</Button>
           )}
         </Card>
       </div>


### PR DESCRIPTION
## Summary
- refine Google Calendar integration card layout
- allow disconnecting existing Google Calendar connection
- expose API endpoint to remove Google Calendar tokens

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68beef6b0c70832f9b17e9e3c315076a