### PR TITLE
Restrict integrations screen to SDR agents

### DIFF
--- a/components/agents/AgentMenu.tsx
+++ b/components/agents/AgentMenu.tsx
@@ -49,7 +49,15 @@ export default function AgentMenu({ agent }: { agent: Agent }) {
     { label: "Onboarding", icon: BookOpen, href: `/dashboard/agents/${agent.id}/onboarding` },
     { label: "Base de conhecimento", icon: Database, href: `/dashboard/agents/${agent.id}/base-conhecimento` },
     { label: "Instruções Específicas", icon: ClipboardList, href: `/dashboard/agents/${agent.id}/instrucoes-especificas` },
-    { label: "Integrações", icon: Calendar, href: `/dashboard/agents/${agent.id}/integracoes` },
+    ...(agent.type === "sdr"
+      ? [
+          {
+            label: "Integrações",
+            icon: Calendar,
+            href: `/dashboard/agents/${agent.id}/integracoes`,
+          },
+        ]
+      : []),
   ];
 
   return (

--- a/src/app/dashboard/agents/[id]/integracoes/page.tsx
+++ b/src/app/dashboard/agents/[id]/integracoes/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { supabasebrowser } from "@/lib/supabaseClient";
 import AgentMenu from "@/components/agents/AgentMenu";
 import AgentGuide from "@/components/agents/AgentGuide";
@@ -20,6 +20,7 @@ type Agent = {
 export default function AgentIntegrationsPage() {
   const params = useParams();
   const id = params?.id as string;
+  const router = useRouter();
   const [agent, setAgent] = useState<Agent | null>(null);
   const [connected, setConnected] = useState(false);
 
@@ -44,7 +45,14 @@ export default function AgentIntegrationsPage() {
       });
   }, [id]);
 
+  useEffect(() => {
+    if (agent && agent.type !== "sdr") {
+      router.replace(`/dashboard/agents/${id}`);
+    }
+  }, [agent, id, router]);
+
   if (!agent) return <div>Carregando...</div>;
+  if (agent.type !== "sdr") return null;
 
   const handleConnect = () => {
     if (!id) return;


### PR DESCRIPTION
## Summary
- show integrations menu only for SDR agents
- redirect non-SDR agents away from integrations page

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bf3ea6d160832f97c61e746290dafc