### PR TITLE
Rename "Instruções Específicas" to "Instruções"

### DIFF
--- a/components/agents/AgentGuide.tsx
+++ b/components/agents/AgentGuide.tsx
@@ -77,10 +77,10 @@ export default function AgentGuide() {
                   </Button>
                 </li>
                 <li>
-                  <strong>Instruções específicas</strong>: detalhe orientações e casos especiais.
+                  <strong>Instruções</strong>: detalhe orientações e casos especiais.
                   <Button variant="link" asChild className="px-1">
-                    <Link href={`/dashboard/agents/${id}/instrucoes-especificas`}>
-                      Ir para instruções específicas
+                    <Link href={`/dashboard/agents/${id}/instrucoes`}>
+                      Ir para instruções
                     </Link>
                   </Button>
                 </li>

--- a/components/agents/AgentMenu.tsx
+++ b/components/agents/AgentMenu.tsx
@@ -48,7 +48,7 @@ export default function AgentMenu({ agent }: { agent: Agent }) {
     { label: "Comportamento", icon: Settings, href: `/dashboard/agents/${agent.id}/comportamento` },
     { label: "Onboarding", icon: BookOpen, href: `/dashboard/agents/${agent.id}/onboarding` },
     { label: "Base de conhecimento", icon: Database, href: `/dashboard/agents/${agent.id}/base-conhecimento` },
-    { label: "Instruções Específicas", icon: ClipboardList, href: `/dashboard/agents/${agent.id}/instrucoes-especificas` },
+    { label: "Instruções", icon: ClipboardList, href: `/dashboard/agents/${agent.id}/instrucoes` },
     ...(agent.type === "sdr"
       ? [
           {

--- a/components/landing/LearnMore.tsx
+++ b/components/landing/LearnMore.tsx
@@ -54,7 +54,7 @@ const slides = [
             <li>Comportamento: quando deve escalar para atendimento humano.</li>
             <li>Onboarding: O que o agente precisa coletar de informações para qualificar o lead.</li>
             <li>Base de conhecimento: carregue documentos que servirão de referência para o agente.</li>
-            <li>Instruções específicas: detalhe orientações e casos especiais.</li>
+            <li>Instruções: detalhe orientações e casos especiais.</li>
           </ul>
           <p className="mt-2">Resultado: agente pronto para pagamento.</p>
         </li>

--- a/src/app/dashboard/agents/[id]/instrucoes/page.tsx
+++ b/src/app/dashboard/agents/[id]/instrucoes/page.tsx
@@ -28,7 +28,7 @@ interface FaqItem {
   action: string;
 }
 
-export default function AgentSpecificInstructionsPage() {
+export default function AgentInstructionsPage() {
   const params = useParams();
   const id = params?.id as string;
   const [agent, setAgent] = useState<Agent | null>(null);
@@ -110,7 +110,7 @@ export default function AgentSpecificInstructionsPage() {
       .eq("agent_id", id);
 
     if (deleteError) {
-      toast.error("Erro ao salvar instruções específicas.");
+      toast.error("Erro ao salvar instruções.");
       setIsSubmitting(false);
       return;
     }
@@ -127,10 +127,10 @@ export default function AgentSpecificInstructionsPage() {
       );
 
     if (error) {
-      toast.error("Erro ao salvar instruções específicas.");
+      toast.error("Erro ao salvar instruções.");
     } else {
       await updateAgentInstructions(id);
-      toast.success("Instruções específicas salvas com sucesso.");
+      toast.success("Instruções salvas com sucesso.");
     }
     setIsSubmitting(false);
   };


### PR DESCRIPTION
## Summary
- replace "Instruções Específicas" with "Instruções" in menu, guide, and documentation
- rename instructions page and simplify toast messages

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bf7f1006f0832f8e0224c1fcb96703