### PR TITLE
Enforce minimum calendar window duration

### DIFF
--- a/src/app/dashboard/agents/[id]/integracoes/page.tsx
+++ b/src/app/dashboard/agents/[id]/integracoes/page.tsx
@@ -97,6 +97,11 @@ export default function AgentIntegrationsPage() {
       return;
     }
 
+    if (endMinutes - startMinutes < 180) {
+      toast.error("A janela de disponibilidade deve ter no mínimo 3 horas.");
+      return;
+    }
+
     const durationMinutes = parseInt(scheduleDuration, 10);
     if (
       Number.isNaN(durationMinutes) ||
@@ -169,7 +174,8 @@ export default function AgentIntegrationsPage() {
                     Fim da janela
                   </label>
                   <p className="text-xs text-muted-foreground">
-                    Horário final permitido para agendar eventos.
+                    Horário final permitido para agendar eventos. A janela deve ter no
+                    mínimo 3 horas.
                   </p>
                   <Input
                     id="scheduleEnd"


### PR DESCRIPTION
## Summary
- ensure calendar availability window spans at least three hours
- warn users with toast when window is shorter than three hours
- clarify schedule window description in the UI

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bf9375ad48832fbbf876932ba13a03