### PR TITLE
feat: prevent multiple CRM webhook calls

### DIFF
--- a/src/app/api/crm/create/route.ts
+++ b/src/app/api/crm/create/route.ts
@@ -10,7 +10,7 @@ export async function POST() {
 
   const { data: company, error } = await supabaseadmin
     .from("company")
-    .select("id")
+    .select("id, chatwoot_id")
     .eq("user_id", user.id)
     .single();
 
@@ -19,6 +19,10 @@ export async function POST() {
       { error: error?.message || "Empresa não encontrada" },
       { status: 404 }
     );
+  }
+
+  if (company.chatwoot_id) {
+    return NextResponse.json({ message: "CRM já criado" });
   }
 
   const webhookUrl = process.env.N8N_CRM_WEBHOOK_URL;

--- a/src/app/crm/page.tsx
+++ b/src/app/crm/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Loader2 } from "lucide-react";
@@ -8,8 +8,11 @@ import { Loader2 } from "lucide-react";
 export default function CrmPage() {
   const router = useRouter();
   const [status, setStatus] = useState<"loading" | "error">("loading");
+  const hasRequested = useRef(false);
 
   useEffect(() => {
+    if (hasRequested.current) return;
+    hasRequested.current = true;
     const createCrm = async () => {
       try {
         const res = await fetch("/api/crm/create", { method: "POST" });


### PR DESCRIPTION
## Summary
- avoid re-running CRM creation webhook when user already has a Chatwoot CRM
- guard CRM page effect so webhook is called only once per mount

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1f5201fec832f850d87d7ad85b9e5