### PR TITLE
Enable SDR agent creation

### DIFF
--- a/src/app/dashboard/agents/new/page.tsx
+++ b/src/app/dashboard/agents/new/page.tsx
@@ -216,7 +216,6 @@ export default function NewAgentPage() {
                       value={option.value}
                       title={option.title}
                       description={option.description}
-                      disabled={option.disabled}
                       selected={type === option.value}
                       onSelect={setType}
                     />


### PR DESCRIPTION
## Summary
- Allow creation of SDR agents by removing disabled flag on SDR type.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c362ef9520832fa0447f2672e28d9c