### PR TITLE
feat(ui): enlarge button sizes

### DIFF
--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -22,8 +22,8 @@ const buttonVariants = cva(
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        sm: "h-8 rounded-lg gap-1.5 px-3 has-[>svg]:px-2.5",
+        default: "h-11 px-5 py-2 has-[>svg]:px-4",
+        sm: "h-10 rounded-lg gap-1.5 px-4 has-[>svg]:px-3",
         lg: "h-10 rounded-lg px-6 has-[>svg]:px-4",
         icon: "size-9",
       },


### PR DESCRIPTION
## Summary
- increase default button to `h-11` with wider padding
- raise small button to `h-10` and adjust padding

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c630d5f110832fbf7f491fdb43714e