### PR TITLE
feat: adjust hero heading size

### DIFF
--- a/components/landing/Hero.tsx
+++ b/components/landing/Hero.tsx
@@ -9,7 +9,7 @@ export default function Hero() {
     <section className="bg-[#FAFAFA] py-8 md:py-12 lg:py-16">
       <div className="mx-auto grid max-w-[1140px] items-center gap-6 md:gap-8 lg:gap-6 px-3 md:px-4 lg:px-6 md:grid-cols-2 lg:grid-cols-12">
         <div className="space-y-4 text-center md:text-left lg:col-span-8">
-          <h1 className="text-4xl font-bold sm:text-5xl">
+          <h1 className="text-3xl font-bold sm:text-4xl md:text-5xl">
             Empresas inteligentes já usam IA no atendimento
           </h1>
           <p className="text-lg text-muted-foreground">


### PR DESCRIPTION
## Summary
- adjust hero section heading to use `text-3xl sm:text-4xl md:text-5xl`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c630d7f3e8832fb4bc08e3221273da