### PR TITLE
fix: prevent viewport clipping on dashboard layout

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -32,10 +32,10 @@ export default function DashboardClientLayout({ children }: Props) {
     })
   }, [router])
 
-  if (loading) return <div className="min-h-screen flex items-center justify-center">Carregando...</div>
+  if (loading) return <div className="min-h-[100svh] flex items-center justify-center">Carregando...</div>
 
   return (
-    <div className="flex h-screen">
+    <div className="flex min-h-[100svh]">
         <Sidebar className="hidden sm:flex" />
         <main className="flex-1 bg-[#FAFAFA] p-6 h-full overflow-auto">
           <div className="flex w-full items-center mb-4">


### PR DESCRIPTION
## Summary
- ensure dashboard layout uses `min-h-[100svh]` to avoid mobile viewport clipping
- align loading state height with `min-h-[100svh]`

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c630dee834832f875ae8d44b27f49d