### PR TITLE
Adjust sidebar height to viewport

### DIFF
--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -147,7 +147,7 @@ export function Sidebar({ className }: { className?: string }) {
   return (
     <aside
       className={cn(
-        'w-16 bg-white border-r min-h-screen flex flex-col items-center py-4 space-y-4',
+        'w-16 bg-white border-r min-h-[100svh] flex flex-col items-center py-4 space-y-4',
         className,
       )}
     >


### PR DESCRIPTION
## Summary
- ensure the dashboard sidebar uses the viewport height so it fills the visible area without exceeding the full screen

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c89a051c20832f86d09743242a4298