### PR TITLE
Implement server-side support ticket creation with file upload

### DIFF
--- a/src/app/api/support/new/route.ts
+++ b/src/app/api/support/new/route.ts
@@ -1,7 +1,20 @@
 // src/app/api/support/new/route.ts
+import { randomUUID } from "crypto";
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseadmin } from "@/lib/supabaseAdmin";
 import { getUserFromCookie } from "@/lib/auth";
+
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+const ALLOWED_MIME_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "application/pdf",
+]);
+
+const sanitize = (input: string) => input.replace(/<[^>]*>?/gm, "").trim();
+
+const buildPublicUrl = (path: string) =>
+  `${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/ticket-attachments/${path}`;
 
 export async function POST(req: NextRequest) {
   const { user, error: authError } = await getUserFromCookie();
@@ -25,68 +38,131 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  const {
-    title,
-    reason,
-    description,
-    attachmentPath,
-    company_id: requestedCompanyId,
-  } = await req.json();
+  let formData: FormData;
+  try {
+    formData = await req.formData();
+  } catch (error) {
+    console.error("Erro ao ler dados do formulário:", error);
+    return NextResponse.json(
+      { error: "Dados de formulário inválidos" },
+      { status: 400 }
+    );
+  }
 
-  if (!title || typeof title !== "string" || title.trim().length < 3) {
+  const titleEntry = formData.get("title");
+  const reasonEntry = formData.get("reason");
+  const descriptionEntry = formData.get("description");
+
+  if (typeof titleEntry !== "string" || titleEntry.trim().length < 3) {
     return NextResponse.json(
       { error: "Título é obrigatório e deve ter ao menos 3 caracteres" },
       { status: 400 }
     );
   }
 
-  if (!reason || typeof reason !== "string" || reason.trim().length < 3) {
+  if (typeof reasonEntry !== "string" || reasonEntry.trim().length < 3) {
     return NextResponse.json(
       { error: "Motivo é obrigatório e deve ter ao menos 3 caracteres" },
       { status: 400 }
     );
   }
 
-  if (!description || typeof description !== "string" || description.trim().length < 10) {
+  if (
+    typeof descriptionEntry !== "string" ||
+    descriptionEntry.trim().length < 10
+  ) {
     return NextResponse.json(
       { error: "Descrição é obrigatória e deve ter ao menos 10 caracteres" },
       { status: 400 }
     );
   }
 
-  const sanitize = (input: string) => input.replace(/<[^>]*>?/gm, "").trim();
+  const sanitizedTitle = sanitize(titleEntry);
+  const sanitizedReason = sanitize(reasonEntry);
+  const sanitizedDescription = sanitize(descriptionEntry);
 
-  const sanitizedTitle = sanitize(title);
-  const sanitizedReason = sanitize(reason);
-  const sanitizedDescription = sanitize(description);
-
-  if (requestedCompanyId && requestedCompanyId !== company.id) {
+  if (sanitizedTitle.length < 3) {
     return NextResponse.json(
-      { error: "Empresa inválida" },
-      { status: 403 }
+      { error: "Título é obrigatório e deve ter ao menos 3 caracteres" },
+      { status: 400 }
     );
   }
 
-  const attachment_url = attachmentPath
-    ? `${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/ticket-attachments/${attachmentPath}`
-    : null;
-
-  const { error } = await supabaseadmin
-    .from("tickets")
-    .insert([
-      {
-        title: sanitizedTitle,
-        reason: sanitizedReason,
-        description: sanitizedDescription,
-        attachment_url,
-        company_id: company.id,
-      },
-    ]);
-
-  if (error) {
-    console.error('Erro ao criar ticket:', error.message);
+  if (sanitizedReason.length < 3) {
     return NextResponse.json(
-      { error: 'Erro ao criar ticket' },
+      { error: "Motivo é obrigatório e deve ter ao menos 3 caracteres" },
+      { status: 400 }
+    );
+  }
+
+  if (sanitizedDescription.length < 10) {
+    return NextResponse.json(
+      { error: "Descrição é obrigatória e deve ter ao menos 10 caracteres" },
+      { status: 400 }
+    );
+  }
+
+  const attachmentEntry = formData.get("attachment");
+  let attachmentUrl: string | null = null;
+
+  if (attachmentEntry instanceof File && attachmentEntry.size > 0) {
+    if (!ALLOWED_MIME_TYPES.has(attachmentEntry.type)) {
+      return NextResponse.json(
+        { error: "Formato de arquivo não suportado" },
+        { status: 400 }
+      );
+    }
+
+    if (attachmentEntry.size > MAX_FILE_SIZE) {
+      return NextResponse.json(
+        { error: "Arquivo muito grande (máx. 5 MB)" },
+        { status: 400 }
+      );
+    }
+
+    const arrayBuffer = await attachmentEntry.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+    const sanitizedName = (attachmentEntry.name || "anexo")
+      .replace(/[^a-zA-Z0-9._-]/g, "_")
+      .slice(-150);
+    const fileName = sanitizedName || `anexo-${Date.now()}`;
+    const filePath = `user_ticket/${company.id}/${randomUUID()}-${fileName}`;
+
+    const { data: uploadData, error: uploadError } = await supabaseadmin.storage
+      .from("ticket-attachments")
+      .upload(filePath, buffer, {
+        contentType: attachmentEntry.type || undefined,
+        upsert: false,
+      });
+
+    if (uploadError || !uploadData?.path) {
+      console.error("Erro no upload do arquivo:", uploadError?.message);
+      return NextResponse.json(
+        { error: "Falha no upload do arquivo" },
+        { status: 500 }
+      );
+    }
+
+    attachmentUrl = buildPublicUrl(uploadData.path);
+  } else if (attachmentEntry && !(attachmentEntry instanceof File)) {
+    return NextResponse.json(
+      { error: "Anexo inválido" },
+      { status: 400 }
+    );
+  }
+
+  const { error: insertError } = await supabaseadmin.from("tickets").insert({
+    title: sanitizedTitle,
+    reason: sanitizedReason,
+    description: sanitizedDescription,
+    attachment_url: attachmentUrl,
+    company_id: company.id,
+  });
+
+  if (insertError) {
+    console.error("Erro ao criar ticket:", insertError.message);
+    return NextResponse.json(
+      { error: "Erro ao criar ticket" },
       { status: 500 }
     );
   }

--- a/src/app/dashboard/support/new/page.tsx
+++ b/src/app/dashboard/support/new/page.tsx
@@ -4,24 +4,18 @@
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
-import Link from 'next/link';
-import { useRouter } from "next/navigation";
-import { useState, useEffect } from "react";
-import { supabasebrowser } from "@/lib/supabaseClient";
-import { toast } from "sonner";
-import { CardTitle } from "@/components/ui/card";
-import type { User } from "@supabase/supabase-js";
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { ChangeEvent, FormEvent, useState } from "react"
+import { toast } from "sonner"
+import { CardTitle } from "@/components/ui/card"
 import {
-    Select,
-    SelectContent,
-    SelectItem,
-    SelectTrigger,
-    SelectValue,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
 } from "@/components/ui/select"
-
-interface Company {
-    id: string;
-}
 
 const motivos = [
     { value: "bug", label: "Erro no sistema" },
@@ -31,199 +25,153 @@ const motivos = [
 ]
 
 export default function NewSupportPage() {
-    const [titulo, setTitulo] = useState("")
-    const [motivo, setMotivo] = useState<string | undefined>(undefined)
-    const [descricao, setDescricao] = useState("")
-    const [arquivo, setArquivo] = useState<File | null>(null)
-    const [fileError, setFileError] = useState("")
-    const [user, setUser] = useState<User | null>(null);
-    const router = useRouter();
-    const [company, setCompany] = useState<Company | null>(null);
-    const [isSubmitting, setIsSubmitting] = useState(false);
+  const [titulo, setTitulo] = useState("")
+  const [motivo, setMotivo] = useState<string | undefined>(undefined)
+  const [descricao, setDescricao] = useState("")
+  const [arquivo, setArquivo] = useState<File | null>(null)
+  const [fileError, setFileError] = useState("")
+  const router = useRouter()
+  const [isSubmitting, setIsSubmitting] = useState(false)
 
-    useEffect(() => {
-        supabasebrowser.auth.getUser().then(({ data, error }) => {
-            if (!error && data.user) setUser(data.user);
-        });
-    }, []);
+  const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5 MB
+  const ALLOWED_TYPES = [
+    "image/png",
+    "image/jpeg",
+    "application/pdf",
+  ]
+  const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setFileError("")
+    const file = e.target.files?.[0] ?? null
+    if (file && !ALLOWED_TYPES.includes(file.type)) {
+      setArquivo(null)
+      setFileError("Formato não suportado. Apenas PNG, JPG ou PDF.")
+      e.currentTarget.value = ""
+      return
+    }
+    if (file && file.size > MAX_FILE_SIZE) {
+      setArquivo(null)
+      setFileError("Arquivo muito grande (máx. 5 MB).")
+      e.currentTarget.value = "" // limpa seleção
+      return
+    }
+    setArquivo(file)
+  }
 
-    useEffect(() => {
-        if (!user?.id) return;
-        supabasebrowser
-            .from('company')
-            .select('*')
-            .eq('user_id', user.id)
-            .single()          // pega apenas um registro
-            .then(({ data, error }) => {
-                if (error) {
-                    console.error('Erro ao buscar company:', error.message);
-                    toast.error('Erro ao buscar company.');
-                } else {
-                    setCompany(data);
-                }
-            });
-    }, [user]);
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    if (isSubmitting) return
 
-    const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5 MB
-    const ALLOWED_TYPES = [
-        "image/png",
-        "image/jpeg",
-        "image/jpeg",
-        "application/pdf",
-    ]
-    const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        setFileError("")
-        const file = e.target.files?.[0] ?? null
-        if (file && !ALLOWED_TYPES.includes(file.type)) {
-            setArquivo(null);
-            setFileError("Formato não suportado. Apenas PNG, JPG ou PDF.");
-            e.currentTarget.value = "";
-            return;
-        }
-        if (file && file.size > MAX_FILE_SIZE) {
-            setArquivo(null)
-            setFileError("Arquivo muito grande (máx. 5 MB).")
-            e.currentTarget.value = "" // limpa seleção
-            return
-        }
-        setArquivo(file)
+    if (fileError) {
+      toast.error(fileError)
+      return
     }
 
+    if (!motivo) {
+      toast.error("Por favor, selecione um motivo.")
+      return
+    }
 
-    const handleSubmit = async (e: React.FormEvent) => {
-        e.preventDefault()
-        if (isSubmitting) return;
+    setIsSubmitting(true)
+    try {
+      const formData = new FormData()
+      formData.append("title", titulo)
+      formData.append("reason", motivo)
+      formData.append("description", descricao)
+      if (arquivo) {
+        formData.append("attachment", arquivo)
+      }
 
-        if (!user) {
-            toast.error("Erro: usuário não autenticado.");
-            return;
-        }
+      const res = await fetch("/api/support/new", {
+        method: "POST",
+        body: formData,
+      })
 
-        if (fileError) {
-            toast.error(fileError)
-            return
-        }
-
-        if (!motivo) {
-            toast.error("Por favor, selecione um motivo.");
-            return;
-        }
-
-        if (!company) {
-            toast.error("Erro: empresa não encontrada.");
-            return;
-        }
-
-        setIsSubmitting(true);
+      if (!res.ok) {
+        let message = "Erro ao criar chamado."
         try {
-            let attachmentPath: string | null = null;
-            if (arquivo) {
-                const filePath = `user_ticket/${Date.now()}_${arquivo.name}`;
-                const { data: upData, error: upErr } = await supabasebrowser
-                    .storage
-                    .from("ticket-attachments")
-                    .upload(filePath, arquivo);
-
-                if (upErr) {
-                    toast.error('Falha no upload do arquivo.');
-                    setFileError("Falha no upload do arquivo.");
-                    return;
-                }
-
-                attachmentPath = upData.path;
-            }
-
-            const res = await fetch("/api/support/new", {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({
-                    title: titulo,
-                    reason: motivo,
-                    description: descricao,
-                    attachmentPath,
-                    company_id: company.id
-                }),
-            });
-
-            if (!res.ok) {
-                const err = await res.json();
-                toast.error("Erro: " + err.error);
-            } else {
-                toast.success("Chamado criado!");
-                router.push("/dashboard/support");
-            }
-        } finally {
-            setIsSubmitting(false);
+          const err = await res.json()
+          if (err?.error) message = err.error
+        } catch (error) {
+          console.error("Resposta inválida da API de suporte:", error)
         }
+        toast.error("Erro: " + message)
+        return
+      }
 
+      toast.success("Chamado criado!")
+      router.push("/dashboard/support")
+    } catch (error) {
+      console.error("Erro ao enviar chamado:", error)
+      toast.error("Erro ao enviar chamado.")
+    } finally {
+      setIsSubmitting(false)
     }
+  }
 
-    if (!user) return <p className="text-center py-10">Carregando...</p>;
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-[#FAFAFA]">
+      <div className="w-full px-4 sm:max-w-md md:max-w-lg">
+        <Link href="/dashboard/support">
+          <Button variant="ghost" className="mb-4">
+            ← Voltar
+          </Button>
+        </Link>
+        <form
+          onSubmit={handleSubmit}
+          className="w-full bg-white p-6 rounded-lg shadow"
+        >
+          <CardTitle className="text-xl font-semibold text-gray-800 mb-6">Novo Chamado</CardTitle>
 
-    return (
-        <main className="min-h-screen flex items-center justify-center bg-[#FAFAFA]">
-            <div className="w-full px-4 sm:max-w-md md:max-w-lg">
-                <Link href="/dashboard/support">
-                    <Button variant="ghost" className="mb-4">
-                        ← Voltar
-                    </Button>
-                </Link>
-                <form
-                    onSubmit={handleSubmit}
-                    className="w-full bg-white p-6 rounded-lg shadow"
-                >
-                    <CardTitle className="text-xl font-semibold text-gray-800 mb-6">Novo Chamado</CardTitle>
+          <label className="block mb-1">Título do Chamado</label>
+          <Input
+            value={titulo}
+            onChange={e => setTitulo(e.target.value)}
+            placeholder="Digite o título"
+            required
+            maxLength={100}
+            className="mb-4"
+          />
 
-                    <label className="block mb-1">Título do Chamado</label>
-                    <Input
-                        value={titulo}
-                        onChange={e => setTitulo(e.target.value)}
-                        placeholder="Digite o título"
-                        required
-                        maxLength={100}
-                        className="mb-4"
-                    />
+          <label className="block mb-1">Motivo</label>
+          <Select onValueChange={setMotivo} value={motivo}>
+            <SelectTrigger className="w-full mb-4">
+              <SelectValue placeholder="Selecione o motivo" />
+            </SelectTrigger>
+            <SelectContent>
+              {motivos.map(m => (
+                <SelectItem key={m.value} value={m.value}>
+                  {m.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
 
-                    <label className="block mb-1">Motivo</label>
-                    <Select onValueChange={setMotivo} value={motivo}>
-                        <SelectTrigger className="w-full mb-4">
-                            <SelectValue placeholder="Selecione o motivo" />
-                        </SelectTrigger>
-                        <SelectContent>
-                            {motivos.map(m => (
-                                <SelectItem key={m.value} value={m.value}>
-                                    {m.label}
-                                </SelectItem>
-                            ))}
-                        </SelectContent>
-                    </Select>
+          <label className="block mb-1">Descrição</label>
+          <Textarea
+            value={descricao}
+            onChange={e => setDescricao(e.target.value)}
+            placeholder="Explique em detalhes"
+            required
+            rows={5}
+            maxLength={800}
+            className="mb-4"
+          />
 
-                    <label className="block mb-1">Descrição</label>
-                    <Textarea
-                        value={descricao}
-                        onChange={e => setDescricao(e.target.value)}
-                        placeholder="Explique em detalhes"
-                        required
-                        rows={5}
-                        maxLength={800}
-                        className="mb-4"
-                    />
+          <label className="block mb-1">Anexo (PNG, JPG, PDF)</label>
+          <input
+            type="file"
+            accept=".png,.jpg,.jpeg,.pdf"
+            onChange={handleFileChange}
+            className="mb-6 text-blue-600 hover:text-blue-800"
+          />
 
-                    <label className="block mb-1">Anexo (PNG, JPG, PDF)</label>
-                    <input
-                        type="file"
-                        accept=".png,.jpg,.jpeg,.pdf"
-                        onChange={handleFileChange}
-                        className="mb-6 text-blue-600 hover:text-blue-800"
-                    />
+          {fileError && <p className="text-sm text-destructive mb-4">{fileError}</p>}
 
-                    {fileError && <p className="text-sm text-destructive mb-4">{fileError}</p>}
-
-                    <Button type="submit" className="w-full" disabled={isSubmitting}>
-                        {isSubmitting ? "Enviando..." : "Enviar"}
-                    </Button>
-                </form>
-            </div>
-        </main>
-    )
+          <Button type="submit" className="w-full" disabled={isSubmitting}>
+            {isSubmitting ? "Enviando..." : "Enviar"}
+          </Button>
+        </form>
+      </div>
+    </main>
+  )
 }


### PR DESCRIPTION
## Summary
- handle multipart submissions in the support ticket API, validating input, uploading attachments via the service role, and persisting tickets
- update the dashboard support form to send FormData directly to the API without client-side storage access or company lookups

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8c15aee94832fa8a962c8abef6cbc