### PR TITLE
feat: create agent creation API endpoint

### DIFF
--- a/src/app/api/agents/create/route.ts
+++ b/src/app/api/agents/create/route.ts
@@ -1,0 +1,407 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+import { POST as triggerPaymentRequest } from "@/app/api/payments/pay/route";
+import { AGENT_TEMPLATES } from "@/lib/agentTemplates";
+import { getUserFromCookie } from "@/lib/auth";
+import {
+  ALLOWED_AGENT_TYPES,
+  AGENT_PRICE,
+  MAX_AGENTS_PER_COMPANY,
+} from "@/lib/constants";
+import { supabaseadmin } from "@/lib/supabaseAdmin";
+import { isValidAgentName } from "@/lib/validators";
+
+function errorResponse(
+  message: string,
+  status: number,
+  extra?: Record<string, unknown>
+) {
+  return NextResponse.json({ error: message, ...(extra ?? {}) }, { status });
+}
+
+async function rebuildAgentInstructions(agentId: string) {
+  const [agentRes, personalityRes, behaviorRes, onboardingRes, specificRes] =
+    await Promise.all([
+      supabaseadmin
+        .from("agents")
+        .select("name, type")
+        .eq("id", agentId)
+        .single(),
+      supabaseadmin
+        .from("agent_personality")
+        .select("voice_tone, objective, limits, company_name, company_segment")
+        .eq("agent_id", agentId)
+        .single(),
+      supabaseadmin
+        .from("agent_behavior")
+        .select("limitations, default_fallback")
+        .eq("agent_id", agentId)
+        .single(),
+      supabaseadmin
+        .from("agent_onboarding")
+        .select("welcome_message, pain_points, collection")
+        .eq("agent_id", agentId)
+        .single(),
+      supabaseadmin
+        .from("agent_specific_instructions")
+        .select("context, user_says, action")
+        .eq("agent_id", agentId),
+    ]);
+
+  const instructions: Record<string, unknown> = {};
+
+  if (agentRes.data) Object.assign(instructions, agentRes.data);
+  if (personalityRes.data) Object.assign(instructions, personalityRes.data);
+  if (behaviorRes.data) Object.assign(instructions, behaviorRes.data);
+  if (onboardingRes.data) Object.assign(instructions, onboardingRes.data);
+
+  const collectionArray = Array.isArray(onboardingRes.data?.collection)
+    ? (onboardingRes.data?.collection as { question: string }[])
+    : [];
+
+  const collectionString = collectionArray
+    .map(
+      (item: { question: string }, index: number) =>
+        `${index + 2}. Se [var_${index}] não estiver preenchido, pergunte: "${item.question}"`
+    )
+    .join("\n");
+
+  const collectionVarString = collectionArray
+    .map((item: { question: string }, index: number) =>
+      `[var_${index}] - ${item.question}`
+    )
+    .join("\n");
+
+  instructions.collection = collectionString;
+  instructions.collection_var = collectionVarString;
+
+  const specificInstructionsString =
+    specificRes.data
+      ?.map(
+        (item: { context?: string; user_says?: string; action?: string }) =>
+          `Context: "${item.context ?? ""}"\n` +
+          `User says: "${item.user_says ?? ""}"\n` +
+          `Act like this: "${item.action ?? ""}"`
+      )
+      .join("\n\n") ?? "";
+
+  instructions.specific_instructions = specificInstructionsString;
+
+  if (personalityRes.data?.company_name) {
+    instructions.name = personalityRes.data.company_name;
+  }
+
+  const { error: updateError } = await supabaseadmin
+    .from("agents")
+    .update({ instructions })
+    .eq("id", agentId);
+
+  if (updateError) {
+    throw updateError;
+  }
+}
+
+async function applyTemplate(agentId: string, type: string) {
+  const template = AGENT_TEMPLATES[type];
+
+  if (template) {
+    const behavior =
+      template.behavior ?? {
+        limitations: "",
+        default_fallback: "",
+      };
+
+    const insertOperations = [
+      supabaseadmin.from("agent_personality").insert({
+        agent_id: agentId,
+        ...template.personality,
+      }),
+      supabaseadmin.from("agent_behavior").insert({
+        agent_id: agentId,
+        ...behavior,
+      }),
+      supabaseadmin.from("agent_onboarding").insert({
+        agent_id: agentId,
+        ...template.onboarding,
+      }),
+    ];
+
+    if (template.specificInstructions.length > 0) {
+      insertOperations.push(
+        supabaseadmin
+          .from("agent_specific_instructions")
+          .insert(
+            template.specificInstructions.map((item) => ({
+              agent_id: agentId,
+              ...item,
+            }))
+          )
+      );
+    }
+
+    const insertResults = await Promise.all(insertOperations);
+    const firstError = insertResults.find((result) => result.error)?.error;
+
+    if (firstError) {
+      throw firstError;
+    }
+  }
+
+  await rebuildAgentInstructions(agentId);
+}
+
+async function cleanupAgent(agentId: string) {
+  await Promise.allSettled([
+    supabaseadmin
+      .from("agent_specific_instructions")
+      .delete()
+      .eq("agent_id", agentId),
+    supabaseadmin.from("agent_onboarding").delete().eq("agent_id", agentId),
+    supabaseadmin.from("agent_behavior").delete().eq("agent_id", agentId),
+    supabaseadmin
+      .from("agent_personality")
+      .delete()
+      .eq("agent_id", agentId),
+  ]);
+
+  await supabaseadmin.from("agents").delete().eq("id", agentId);
+}
+
+async function triggerPayment(
+  accessToken: string | null,
+  payment: { id: string; amount: number | string; due_date: string }
+) {
+  if (!accessToken) return null;
+
+  const amountNumber =
+    typeof payment.amount === "number"
+      ? payment.amount
+      : Number(payment.amount);
+
+  if (!Number.isFinite(amountNumber) || !payment.due_date) {
+    return null;
+  }
+
+  try {
+    const request = new Request("http://localhost/api/payments/pay", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({
+        id: payment.id,
+        date: payment.due_date.slice(0, 10),
+        total: amountNumber,
+      }),
+    });
+
+    const response = await triggerPaymentRequest(request);
+    let responseData: unknown = null;
+
+    try {
+      responseData = await response.json();
+    } catch {
+      responseData = null;
+    }
+
+    if (!response.ok) {
+      console.error("[agents:create] Falha ao acionar pagamento", responseData);
+      return null;
+    }
+
+    return responseData;
+  } catch (error) {
+    console.error("[agents:create] Erro ao acionar pagamento", error);
+    return null;
+  }
+}
+
+export async function GET() {
+  const { user } = await getUserFromCookie();
+
+  if (!user) {
+    return errorResponse("Não autenticado", 401);
+  }
+
+  const { data: company, error: companyError } = await supabaseadmin
+    .from("company")
+    .select("id")
+    .eq("user_id", user.id)
+    .single();
+
+  if (companyError || !company) {
+    return errorResponse("Empresa não encontrada.", 404);
+  }
+
+  const { count, error: countError } = await supabaseadmin
+    .from("agents")
+    .select("id", { count: "exact", head: true })
+    .eq("company_id", company.id);
+
+  if (countError) {
+    console.error("[agents:create] Erro ao contar agentes", countError);
+    return errorResponse(
+      "Não foi possível carregar informações dos agentes.",
+      500
+    );
+  }
+
+  const agentCount = count ?? 0;
+
+  return NextResponse.json({
+    agentCount,
+    maxAgents: MAX_AGENTS_PER_COMPANY,
+    limitReached: agentCount >= MAX_AGENTS_PER_COMPANY,
+  });
+}
+
+export async function POST(request: Request) {
+  const { user, accessToken } = await getUserFromCookie();
+
+  if (!user) {
+    return errorResponse("Não autenticado", 401);
+  }
+
+  let payload: unknown;
+
+  try {
+    payload = await request.json();
+  } catch {
+    return errorResponse("Corpo da requisição inválido.", 400);
+  }
+
+  if (!payload || typeof payload !== "object") {
+    return errorResponse("Corpo da requisição inválido.", 400);
+  }
+
+  const { name, type } = payload as {
+    name?: unknown;
+    type?: unknown;
+  };
+
+  if (typeof name !== "string" || !isValidAgentName(name)) {
+    return errorResponse(
+      "O nome do agente deve ter entre 3 e 50 caracteres.",
+      400
+    );
+  }
+
+  if (typeof type !== "string" || !ALLOWED_AGENT_TYPES.includes(type)) {
+    return errorResponse("Tipo de agente inválido.", 400);
+  }
+
+  const trimmedName = name.trim();
+
+  const { data: company, error: companyError } = await supabaseadmin
+    .from("company")
+    .select("id")
+    .eq("user_id", user.id)
+    .single();
+
+  if (companyError || !company) {
+    return errorResponse("Empresa não encontrada.", 404);
+  }
+
+  const { count, error: countError } = await supabaseadmin
+    .from("agents")
+    .select("id", { count: "exact", head: true })
+    .eq("company_id", company.id);
+
+  if (countError) {
+    console.error("[agents:create] Erro ao contar agentes", countError);
+    return errorResponse(
+      "Não foi possível verificar o limite de agentes.",
+      500
+    );
+  }
+
+  const existingAgents = count ?? 0;
+
+  if (existingAgents >= MAX_AGENTS_PER_COMPANY) {
+    return errorResponse(
+      `Limite de ${MAX_AGENTS_PER_COMPANY} agentes atingido.`,
+      400,
+      { limitReached: true, agentCount: existingAgents }
+    );
+  }
+
+  const { data: agentData, error: agentError } = await supabaseadmin
+    .from("agents")
+    .insert({
+      name: trimmedName,
+      type,
+      company_id: company.id,
+    })
+    .select("id")
+    .single();
+
+  if (agentError || !agentData) {
+    console.error("[agents:create] Erro ao criar agente", agentError);
+    return errorResponse("Erro ao criar agente.", 500);
+  }
+
+  const agentId = agentData.id as string;
+
+  try {
+    await applyTemplate(agentId, type);
+  } catch (error) {
+    console.error("[agents:create] Erro ao aplicar template", error);
+    await cleanupAgent(agentId);
+    return errorResponse("Erro ao aplicar template do agente.", 500);
+  }
+
+  const dueDate = new Date();
+  dueDate.setDate(dueDate.getDate() + 30);
+  const dueDateIso = dueDate.toISOString();
+
+  const {
+    data: paymentData,
+    error: paymentError,
+  } = await supabaseadmin
+    .from("payments")
+    .insert({
+      company_id: company.id,
+      agent_id: agentId,
+      amount: AGENT_PRICE,
+      due_date: dueDateIso,
+      reference: `Mensalidade ${trimmedName}`,
+    })
+    .select("id, amount, due_date")
+    .single();
+
+  if (paymentError) {
+    console.error("[agents:create] Erro ao criar pagamento", paymentError);
+  }
+
+  let paymentInfo: Record<string, unknown> | null = null;
+
+  if (paymentData) {
+    const asaasResponse = await triggerPayment(accessToken ?? null, {
+      id: paymentData.id as string,
+      amount: paymentData.amount as number | string,
+      due_date: paymentData.due_date as string,
+    });
+
+    paymentInfo = {
+      ...paymentData,
+      ...(asaasResponse ? { asaas: asaasResponse } : {}),
+    };
+  }
+
+  const updatedCount = existingAgents + 1;
+  const limitReached = updatedCount >= MAX_AGENTS_PER_COMPANY;
+
+  return NextResponse.json(
+    {
+      id: agentId,
+      message: "Agente criado com sucesso.",
+      agentCount: updatedCount,
+      maxAgents: MAX_AGENTS_PER_COMPANY,
+      limitReached,
+      payment: paymentInfo,
+    },
+    { status: 201 }
+  );
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -19,14 +19,14 @@ export async function getUserFromCookie() {
   const cookieName = `sb-${projectRef}-auth-token`;
   const tokenCookie = cookieStore.get(cookieName);
   if (!tokenCookie) {
-    return { user: null, error: new Error("No auth cookie") };
+    return { user: null, accessToken: null, error: new Error("No auth cookie") };
   }
   const decoded = decodeCookieValue(tokenCookie.value);
   let session: unknown;
   try {
     session = JSON.parse(decoded);
   } catch {
-    return { user: null, error: new Error("Invalid auth cookie") };
+    return { user: null, accessToken: null, error: new Error("Invalid auth cookie") };
   }
   const accessToken = Array.isArray(session)
     ? session[0]
@@ -34,8 +34,8 @@ export async function getUserFromCookie() {
     ? (session as { access_token: string }).access_token
     : undefined;
   if (!accessToken || typeof accessToken !== "string") {
-    return { user: null, error: new Error("No access token") };
+    return { user: null, accessToken: null, error: new Error("No access token") };
   }
   const { data, error } = await supabaseadmin.auth.getUser(accessToken);
-  return { user: data.user, error };
+  return { user: data.user, accessToken, error };
 }


### PR DESCRIPTION
## Summary
- add a server-side `/api/agents/create` endpoint that validates agent data, seeds template records, updates instructions, and triggers payment creation
- expose the Supabase access token from `getUserFromCookie` so the new API can reuse authenticated requests
- refactor the dashboard agent creation page to call the API, simplifying client-side validation and handling limit messaging

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8c1856dc4832f81a5fb940ad970a7