### PR TITLE
fix: ensure profile completion handled manually

### DIFF
--- a/src/app/complete-profile/page.tsx
+++ b/src/app/complete-profile/page.tsx
@@ -84,16 +84,29 @@ export default function CompleteProfilePage() {
       }
       const uid = data.user.id;
       setUserId(uid);
-      const { data: company } = await supabasebrowser
+
+      const { data: company, error: companyError } = await supabasebrowser
         .from("company")
         .select("profile_complete, company_profile_id")
         .eq("user_id", uid)
-        .single();
-      if (company?.profile_complete) {
+        .maybeSingle();
+
+      if (companyError) {
+        console.error("Erro ao buscar empresa do usuário", companyError.message);
+        setLoading(false);
+        return;
+      }
+
+      if (!company) {
+        setLoading(false);
+        return;
+      }
+
+      if (company.profile_complete) {
         router.replace("/dashboard");
         return;
       }
-      if (company?.company_profile_id) {
+      if (company.company_profile_id) {
         const { data: profile } = await supabasebrowser
           .from("company_profile")
           .select("*")

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -12,6 +12,7 @@ import {
   isValidEmail,
   isValidPassword,
 } from "@/lib/validators";
+import { supabasebrowser } from "@/lib/supabaseClient";
 
 export default function SignupPage() {
   const router = useRouter();
@@ -21,6 +22,28 @@ export default function SignupPage() {
   const [confirm, setConfirm] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [googleLoading, setGoogleLoading] = useState(false);
+
+  const handleGoogleSignIn = async () => {
+    setGoogleLoading(true);
+    try {
+      const baseUrl = process.env.NEXT_PUBLIC_APP_URL || window.location.origin;
+      const redirectTo = new URL("/login", baseUrl).toString();
+      const { error } = await supabasebrowser.auth.signInWithOAuth({
+        provider: "google",
+        options: { redirectTo },
+      });
+      if (error) {
+        console.error("Erro ao entrar com Google:", error.message);
+        toast.error("Não foi possível conectar com o Google. Tente novamente.");
+      }
+    } catch (err) {
+      console.error("Erro inesperado ao entrar com Google:", err);
+      toast.error("Não foi possível conectar com o Google. Tente novamente.");
+    } finally {
+      setGoogleLoading(false);
+    }
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -75,6 +98,23 @@ export default function SignupPage() {
           className="w-full bg-white rounded-lg shadow p-6 space-y-4"
         >
         <h1 className="text-2xl font-semibold text-center">Cadastro</h1>
+
+        <div className="space-y-4">
+          <Button
+            type="button"
+            variant="outline"
+            className="w-full"
+            onClick={handleGoogleSignIn}
+            disabled={googleLoading}
+          >
+            {googleLoading ? "Redirecionando..." : "Continuar com Google"}
+          </Button>
+          <div className="flex items-center gap-2 text-sm text-gray-500">
+            <span className="h-px flex-1 bg-gray-200" />
+            <span>ou crie sua conta com e-mail</span>
+            <span className="h-px flex-1 bg-gray-200" />
+          </div>
+        </div>
 
         {error && (
           <div className="text-red-600 text-sm text-center">{error}</div>


### PR DESCRIPTION
## Summary
- adiciona fluxo de login com Google nas telas de login e cadastro, incluindo feedback de carregamento
- substitui a criação automática da empresa pelo preenchimento manual ao completar o perfil, removendo o endpoint `/api/auth/ensure-company`
- atualiza o fluxo de completar perfil para criar o registro da empresa apenas quando o usuário envia o formulário

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9d3457188832f82c08a70a3ee8c2d