### PR TITLE
Fix notification subscription when RLS hides company data

### DIFF
--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -20,7 +20,7 @@ export async function GET() {
   if (dbError) {
     return NextResponse.json({ error: dbError.message }, { status: 500 });
   }
-  return NextResponse.json(data);
+  return NextResponse.json({ notifications: data ?? [], companyId: company.id });
 }
 
 export async function POST(req: NextRequest) {


### PR DESCRIPTION
## Summary
- return the company id together with notification data from the API so clients can subscribe to realtime updates
- load notifications in the provider from the API response instead of querying the company table directly
- clear notifications on unauthorized responses and log failures so the UI falls back gracefully

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc1d6ce138832f97f3323d9c49ecf3