### PR TITLE
Handle chunked Supabase auth cookies

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,27 +1,38 @@
 import { cookies } from "next/headers";
 import { supabaseadmin } from "@/lib/supabaseAdmin";
 
-function decodeCookieValue(value: string): string {
-  if (value.startsWith("base64-")) {
-    try {
-      return Buffer.from(value.slice(7), "base64").toString("utf-8");
-    } catch {
-      return "";
-    }
-  }
-  return value;
-}
-
 export async function getUserFromCookie() {
   const cookieStore = await cookies();
   const projectUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
   const projectRef = new URL(projectUrl).hostname.split(".")[0];
   const cookieName = `sb-${projectRef}-auth-token`;
-  const tokenCookie = cookieStore.get(cookieName);
-  if (!tokenCookie) {
+  const cookieList = cookieStore.getAll();
+
+  const baseCookie = cookieList.find((cookie) => cookie.name === cookieName);
+
+  let rawCookieValue: string | null = null;
+  if (baseCookie) {
+    rawCookieValue = baseCookie.value;
+  } else {
+    const chunkValues: string[] = [];
+    for (let i = 0; ; i++) {
+      const chunkName = `${cookieName}.${i}`;
+      const chunk = cookieList.find((cookie) => cookie.name === chunkName);
+      if (!chunk) {
+        break;
+      }
+      chunkValues.push(chunk.value);
+    }
+    if (chunkValues.length > 0) {
+      rawCookieValue = chunkValues.join("");
+    }
+  }
+
+  if (!rawCookieValue) {
     return { user: null, accessToken: null, error: new Error("No auth cookie") };
   }
-  const decoded = decodeCookieValue(tokenCookie.value);
+
+  const decoded = decodeCookieValue(rawCookieValue);
   let session: unknown;
   try {
     session = JSON.parse(decoded);
@@ -38,4 +49,19 @@ export async function getUserFromCookie() {
   }
   const { data, error } = await supabaseadmin.auth.getUser(accessToken);
   return { user: data.user, accessToken, error };
+}
+
+function decodeCookieValue(value: string): string {
+  if (value.startsWith("base64-")) {
+    try {
+      const base64Value = value.slice(7).replace(/-/g, "+").replace(/_/g, "/");
+      const padding = base64Value.length % 4;
+      const normalized =
+        padding === 0 ? base64Value : base64Value + "=".repeat(4 - padding);
+      return Buffer.from(normalized, "base64").toString("utf-8");
+    } catch {
+      return "";
+    }
+  }
+  return value;
 }


### PR DESCRIPTION
## Summary
- read chunked Supabase auth cookies by combining base and indexed cookie names
- decode base64 (including URL-safe variants) before parsing session data
- ensure access token retrieval works for split cookies

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc40b1399c832fb77974eebdffdb6c