### PR TITLE
Add Facebook Pixel integration to layout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ AUTH_MAX_AGE=7200
 ASAAS_API_KEY=asaas_test_<seu_token_aqui>
 ASAAS_API_URL=https://api-sandbox.asaas.com/v3
 NEXT_PUBLIC_APP_URL=https://evoluke.com.br
+NEXT_PUBLIC_FACEBOOK_PIXEL_ID=
 N8N_WEBHOOK_URL=
 N8N_WEBHOOK_TOKEN=
 N8N_CRM_WEBHOOK_URL=

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Este repositório contém uma aplicação [Next.js](https://nextjs.org/) prepara
    ```
 
 2. Faça o deploy na [Vercel](https://vercel.com/) (via CLI ou integração com Git). O processo padrão consiste em:
-   - Configurar as variáveis de ambiente no painel da Vercel (incluindo `N8N_WEBHOOK_URL` e `N8N_WEBHOOK_TOKEN`, usadas pelo endpoint interno `/api/knowledge-base/upload`).
+   - Configurar as variáveis de ambiente no painel da Vercel (incluindo `N8N_WEBHOOK_URL`, `N8N_WEBHOOK_TOKEN` e `NEXT_PUBLIC_FACEBOOK_PIXEL_ID`, usadas pelo endpoint interno `/api/knowledge-base/upload` e integrações de rastreamento).
    - Realizar o push para o branch principal para disparar o deploy automático **ou** utilizar o comando `vercel --prod`.
 
 > O fluxo do N8N deve validar o token enviado no header `Authorization` antes de aceitar o upload.

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 // src/app/layout.tsx
 
 import type { Metadata } from "next";
+import Script from "next/script";
 import { Inter, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { Toaster } from "sonner";
@@ -12,6 +13,22 @@ const geistMono = Geist_Mono({ variable: "--font-geist-mono", subsets: ["latin"]
 
 const description =
   "A Evoluke oferece soluções de CRM integradas com inteligência artificial, personalizando atendimentos e automatizando processos para empresas.";
+
+const facebookPixelId = process.env.NEXT_PUBLIC_FACEBOOK_PIXEL_ID;
+const facebookPixelScript = facebookPixelId
+  ? [
+      "!function(f,b,e,v,n,t,s)",
+      "{if(f.fbq)return;n=f.fbq=function(){n.callMethod?",
+      "n.callMethod.apply(n,arguments):n.queue.push(arguments)};",
+      "if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';",
+      "n.queue=[];t=b.createElement(e);t.async=!0;",
+      "t.src=v;s=b.getElementsByTagName(e)[0];",
+      "s.parentNode.insertBefore(t,s)}(window, document,'script',",
+      "'https://connect.facebook.net/en_US/fbevents.js');",
+      `fbq('init', '${facebookPixelId}');`,
+      "fbq('track', 'PageView');",
+    ].join("\n")
+  : null;
 
 export const metadata: Metadata = {
   title: "Evoluke",
@@ -45,8 +62,25 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <head>
         <meta name="viewport" content="width=device-width,initial-scale=1" />
         <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+        {facebookPixelScript ? (
+          <Script id="facebook-pixel" strategy="afterInteractive">
+            {facebookPixelScript}
+          </Script>
+        ) : null}
       </head>
       <body className="font-sans antialiased h-full">
+        {facebookPixelId ? (
+          <noscript>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              height="1"
+              width="1"
+              style={{ display: "none" }}
+              src={`https://www.facebook.com/tr?id=${facebookPixelId}&ev=PageView&noscript=1`}
+              alt=""
+            />
+          </noscript>
+        ) : null}
         <NotificationProvider>
           <Toaster position="top-right" />
           {children}


### PR DESCRIPTION
## Summary
- load the Facebook Pixel script in the application layout with a noscript fallback
- document the NEXT_PUBLIC_FACEBOOK_PIXEL_ID variable in the environment example and README for deployment setup

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc61105d54832fbf5290dd540194ac