### PR TITLE
Add Facebook Pixel tracking script

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 // src/app/layout.tsx
 
 import type { Metadata } from "next";
+import Script from "next/script";
 import { Inter, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { Toaster } from "sonner";
@@ -45,9 +46,32 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <head>
         <meta name="viewport" content="width=device-width,initial-scale=1" />
         <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+        <Script id="facebook-pixel" strategy="afterInteractive">
+          {`
+            !function(f,b,e,v,n,t,s)
+            {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+            n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+            if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+            n.queue=[];t=b.createElement(e);t.async=!0;
+            t.src=v;s=b.getElementsByTagName(e)[0];
+            s.parentNode.insertBefore(t,s)}(window, document,'script',
+            'https://connect.facebook.net/en_US/fbevents.js');
+            fbq('init', '3219137398253344');
+            fbq('track', 'PageView');
+          `}
+        </Script>
       </head>
       <body className="font-sans antialiased h-full">
         <NotificationProvider>
+          <noscript>
+            <img
+              height="1"
+              width="1"
+              style={{ display: "none" }}
+              alt=""
+              src="https://www.facebook.com/tr?id=3219137398253344&ev=PageView&noscript=1"
+            />
+          </noscript>
           <Toaster position="top-right" />
           {children}
           <ChatwootController />


### PR DESCRIPTION
## Summary
- add the Facebook Pixel script to the global layout so it loads on every page
- include a `<noscript>` image fallback for browsers without JavaScript

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc6d422794832f8370530ea37f622d