### PR TITLE
feat: add dashboard onboarding hints for first access

### DIFF
--- a/components/dashboard/DashboardOnboarding.tsx
+++ b/components/dashboard/DashboardOnboarding.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import { RefObject, useEffect, useMemo, useState } from "react";
+import { Sparkles, X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+type StepPlacement = "right" | "left" | "bottom" | "top";
+
+type StepConfig = {
+  id: string;
+  ref: RefObject<HTMLElement>;
+  title: string;
+  description: string;
+  placement?: StepPlacement;
+};
+
+type StepPosition = {
+  top: number;
+  left: number;
+};
+
+const STORAGE_KEY = "dashboard-onboarding-completed";
+
+interface DashboardOnboardingProps {
+  steps: StepConfig[];
+}
+
+export function DashboardOnboarding({ steps }: DashboardOnboardingProps) {
+  const [isVisible, setIsVisible] = useState(false);
+  const [positions, setPositions] = useState<Record<string, StepPosition>>({});
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const hasCompleted = window.localStorage.getItem(STORAGE_KEY);
+    if (!hasCompleted) {
+      setIsVisible(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isVisible) return;
+
+    const highlightedElements: HTMLElement[] = [];
+
+    steps.forEach((step) => {
+      const element = step.ref.current;
+      if (element) {
+        highlightedElements.push(element);
+        element.classList.add("onboarding-highlight");
+      }
+    });
+
+    return () => {
+      highlightedElements.forEach((element) => {
+        element.classList.remove("onboarding-highlight");
+      });
+    };
+  }, [isVisible, steps]);
+
+  useEffect(() => {
+    if (!isVisible) return;
+
+    const updatePositions = () => {
+      const nextPositions: Record<string, StepPosition> = {};
+
+      steps.forEach((step) => {
+        const element = step.ref.current;
+        if (!element) return;
+
+        const rect = element.getBoundingClientRect();
+        const scrollY = window.scrollY;
+        const scrollX = window.scrollX;
+
+        switch (step.placement) {
+          case "left":
+            nextPositions[step.id] = {
+              top: rect.top + scrollY + rect.height / 2,
+              left: rect.left + scrollX - 24,
+            };
+            break;
+          case "bottom":
+            nextPositions[step.id] = {
+              top: rect.bottom + scrollY + 24,
+              left: rect.left + scrollX + rect.width / 2,
+            };
+            break;
+          case "top":
+            nextPositions[step.id] = {
+              top: rect.top + scrollY - 24,
+              left: rect.left + scrollX + rect.width / 2,
+            };
+            break;
+          case "right":
+          default:
+            nextPositions[step.id] = {
+              top: rect.top + scrollY + rect.height / 2,
+              left: rect.right + scrollX + 24,
+            };
+            break;
+        }
+      });
+
+      setPositions(nextPositions);
+    };
+
+    updatePositions();
+    window.addEventListener("resize", updatePositions);
+    window.addEventListener("scroll", updatePositions, { passive: true });
+
+    return () => {
+      window.removeEventListener("resize", updatePositions);
+      window.removeEventListener("scroll", updatePositions);
+    };
+  }, [isVisible, steps]);
+
+  const handleClose = () => {
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(STORAGE_KEY, "true");
+    }
+
+    setIsVisible(false);
+  };
+
+  const placementClass = useMemo(
+    () => ({
+      right: "-translate-y-1/2",
+      left: "-translate-y-1/2 -translate-x-full",
+      bottom: "-translate-x-1/2",
+      top: "-translate-x-1/2 -translate-y-full",
+    }),
+    [],
+  );
+
+  if (!isVisible) return null;
+
+  return (
+    <div className="fixed inset-0 z-50">
+      <div className="pointer-events-none absolute inset-0 bg-slate-950/40 backdrop-blur-[1px]" />
+
+      <div className="absolute inset-0 pointer-events-none">
+        {steps.map((step) => {
+          const position = positions[step.id];
+          if (!position) return null;
+
+          const placement = step.placement ?? "right";
+
+          return (
+            <div
+              key={step.id}
+              style={{ top: position.top, left: position.left }}
+              className={cn(
+                "absolute pointer-events-auto max-w-xs",
+                placementClass[placement],
+              )}
+            >
+              <div className="relative rounded-xl border border-emerald-200 bg-white/95 p-4 shadow-xl shadow-emerald-200/40">
+                <div className="flex items-center gap-2 text-sm font-semibold text-emerald-800">
+                  <Sparkles className="h-4 w-4 text-emerald-600" />
+                  {step.title}
+                </div>
+                <p className="mt-2 text-sm leading-relaxed text-slate-600">
+                  {step.description}
+                </p>
+                <div className="absolute -top-3 right-3">
+                  <span className="rounded-full bg-emerald-50 px-3 py-1 text-xs font-medium text-emerald-700">
+                    Dica
+                  </span>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="absolute bottom-6 right-6 flex items-center gap-3 rounded-full bg-white/95 px-4 py-2 shadow-lg shadow-emerald-200/40">
+        <p className="text-sm text-slate-600">
+          Comece por aqui para aproveitar todos os recursos.
+        </p>
+        <button
+          type="button"
+          onClick={handleClose}
+          className="inline-flex items-center gap-2 rounded-full bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white transition hover:bg-emerald-700"
+        >
+          Entendi
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -10,8 +10,8 @@ import {
   CardContent,
 } from "@/components/ui/card";
 import { Folder, Users, FileText } from "lucide-react";
-import { supabasebrowser } from '@/lib/supabaseClient';
-import { useEffect, useState } from 'react';
+import { supabasebrowser } from "@/lib/supabaseClient";
+import { useEffect, useMemo, useRef, useState } from "react";
 import Link from 'next/link';
 import { toast } from "sonner";
 import {
@@ -23,6 +23,7 @@ import {
   Tooltip,
   ResponsiveContainer,
 } from 'recharts';
+import { DashboardOnboarding } from "@/components/dashboard/DashboardOnboarding";
 
 type User = {
   id: string;
@@ -45,6 +46,40 @@ export default function DashboardPage() {
   const [user, setUser] = useState<User | null>(null);
   const [company, setCompany] = useState<Company | null>(null);
   const [dailyMessages, setDailyMessages] = useState<{ date: string; count: number }[]>([]);
+
+  const overviewRef = useRef<HTMLDivElement>(null);
+  const quickActionsRef = useRef<HTMLDivElement>(null);
+  const messagesRef = useRef<HTMLDivElement>(null);
+
+  const onboardingSteps = useMemo(
+    () => [
+      {
+        id: "overview",
+        ref: overviewRef,
+        title: "Bem-vindo ao seu painel",
+        description:
+          "Aqui você acompanha o status da sua conta e encontra os atalhos principais para começar.",
+        placement: "bottom" as const,
+      },
+      {
+        id: "quick-actions",
+        ref: quickActionsRef,
+        title: "Crie seu primeiro agente",
+        description:
+          "Use estes atalhos para configurar novos agentes e explorar as próximas funcionalidades.",
+        placement: "right" as const,
+      },
+      {
+        id: "messages",
+        ref: messagesRef,
+        title: "Monitore as interações",
+        description:
+          "Acompanhe a evolução das mensagens trocadas pelos seus agentes nos últimos dias.",
+        placement: "top" as const,
+      },
+    ],
+    [overviewRef, quickActionsRef, messagesRef],
+  );
 
   useEffect(() => {
     supabasebrowser.auth.getUser().then(({ data, error }) => {
@@ -100,8 +135,6 @@ export default function DashboardPage() {
 
   if (!user || !company) return null;
 
-
-
   const actionItems = [
     { icon: <Folder className="w-5 h-5 text-[#2F6F68]" />, title: "Criar Agentes", desc: "Criar novo agente de IA", href: "/dashboard/agents/new", disabled: false },
     { icon: <Users className="w-5 h-5 text-[#97B7B4]" />, title: "Monitoramento", desc: "Monitore seus agentes de IA", href: "/dashboard/", disabled: true },
@@ -110,7 +143,7 @@ export default function DashboardPage() {
 
   return (
     <div className="p-4 space-y-6">
-      <div className="flex items-center justify-between">
+      <div ref={overviewRef} className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">Painel de Controle</h1>
       </div>
 
@@ -124,7 +157,10 @@ export default function DashboardPage() {
         </div>
 
         <div className="space-y-1">
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          <div
+            ref={quickActionsRef}
+            className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"
+          >
             {actionItems.map((item) => (
               <Link key={item.title} href={item.href}>
                 <Card
@@ -160,7 +196,7 @@ export default function DashboardPage() {
         </div>
       </div>
 
-      <div className="space-y-2">
+      <div ref={messagesRef} className="space-y-2">
         <h3 className="text-lg font-semibold">Mensagens por dia</h3>
         <div className="h-64 sm:h-80 w-full overflow-x-auto">
           {dailyMessages.length ? (
@@ -247,6 +283,7 @@ export default function DashboardPage() {
         </div>
       </div>
       */}
+      <DashboardOnboarding steps={onboardingSteps} />
     </div>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -161,5 +161,9 @@ body,
   .animate-float {
     animation: float 3s ease-in-out infinite;
   }
+
+  .onboarding-highlight {
+    @apply rounded-xl ring-4 ring-emerald-300/60 transition-shadow duration-300;
+  }
 }
 


### PR DESCRIPTION
## Summary
- add a reusable DashboardOnboarding overlay with floating tips and persistence in localStorage
- integrate the onboarding guidance into the dashboard, highlighting the main sections for first-time users
- style a utility class to emphasize highlighted areas during the onboarding flow

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cdb93b9d3c832fb726c720e60ca0d4