### PR TITLE
Navigate to new agent immediately after creation

### DIFF
--- a/src/app/dashboard/agents/new/page.tsx
+++ b/src/app/dashboard/agents/new/page.tsx
@@ -194,10 +194,7 @@ export default function NewAgentPage() {
       const agentId = data?.id;
 
       if (typeof agentId === "string") {
-        setTimeout(
-          () => window.location.assign(`/dashboard/agents/${agentId}`),
-          2000
-        );
+        router.push(`/dashboard/agents/${agentId}`);
       }
     } catch {
       toast.error("Erro ao criar agente.");


### PR DESCRIPTION
## Summary
- replace the delayed redirect after creating an agent with an immediate navigation via `router.push`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cdbb8b11b4832f91df420a14bc68cd