### PR TITLE
feat: add loading overlay to new agent form

### DIFF
--- a/src/app/dashboard/agents/new/page.tsx
+++ b/src/app/dashboard/agents/new/page.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
+import { Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -211,8 +212,9 @@ export default function NewAgentPage() {
   return (
     <div className="bg-[#FAFAFA] flex items-center justify-center py-6">
       <div className="w-full px-4 sm:max-w-md md:max-w-lg">
-        <Card className="border shadow-lg rounded-lg overflow-hidden">
-          <form onSubmit={handleSubmit}>
+        <div className="relative">
+          <Card className="border shadow-lg rounded-lg overflow-hidden">
+            <form onSubmit={handleSubmit}>
             <CardHeader className="bg-white px-6 py-4 border-b mb-2">
               <CardTitle className="text-xl font-semibold text-gray-800 text-center">Criar novo agente de IA</CardTitle>
               <CardDescription className="text-center">
@@ -281,6 +283,12 @@ export default function NewAgentPage() {
             )}
           </form>
         </Card>
+          {(isSubmitting || isLoadingInfo) && (
+            <div className="absolute inset-0 z-10 flex items-center justify-center rounded-lg bg-white/70 backdrop-blur-sm">
+              <Loader2 className="h-8 w-8 animate-spin text-primary" />
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add Loader2 spinner overlay while new agent info is loading or submitting
- ensure the overlay covers the entire card to block interactions during processing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cdbb8caa4c832f884403c8906ee1c2