### PR TITLE
Adjust features grid layout responsiveness

### DIFF
--- a/components/landing/Features.tsx
+++ b/components/landing/Features.tsx
@@ -73,7 +73,7 @@ export default function Features() {
       <div className="mx-auto max-w-[1140px] px-3 md:px-4 lg:px-6">
         <h2 className="mb-2 text-center text-3xl font-bold">Para quem é a nossa solução?</h2>
         <p className="mb-8 text-center text-1xl text-lg font-medium text-primary">Todos que precisam atender clientes pelo WhatsApp para ter uma venda ou agendamento</p>
-        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 sm:gap-6">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-6 lg:grid-cols-3">
           {items.map(({ title, description, icon: Icon }, index) => (
             <div
               key={title}


### PR DESCRIPTION
## Summary
- update the features card grid to start as a single column and introduce additional columns at larger breakpoints for better responsiveness
- preserve balanced spacing between breakpoints after the layout adjustment

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cdd17f5900832f8264b217b92270ca