### PR TITLE
Adjust complete profile form layout for mobile

### DIFF
--- a/src/app/complete-profile/page.tsx
+++ b/src/app/complete-profile/page.tsx
@@ -243,7 +243,7 @@ export default function CompleteProfilePage() {
               required
             />
           </div>
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <div>
               <label htmlFor="zip" className="block text-sm font-medium">
                 CEP
@@ -272,7 +272,7 @@ export default function CompleteProfilePage() {
               />
             </div>
           </div>
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <div>
               <label htmlFor="state" className="block text-sm font-medium">
                 Estado


### PR DESCRIPTION
## Summary
- update the CEP/Cidade and Estado/Telefone field groups to use a single column by default and restore the two-column layout on larger screens

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cdd18969a4832faf4e7da15771855e