### PR TITLE
Adjust dashboard chart responsiveness

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -164,7 +164,7 @@ export default function DashboardPage() {
         <h3 className="text-lg font-semibold">Mensagens por dia</h3>
         <div className="h-64 sm:h-80 w-full overflow-x-auto">
           {dailyMessages.length ? (
-            <div className="min-w-[600px] h-full">
+            <div className="w-full h-full md:min-w-[600px]">
               <ResponsiveContainer width="100%" height="100%">
                 <AreaChart
                   data={dailyMessages}


### PR DESCRIPTION
## Summary
- relax the chart wrapper minimum width so the dashboard graph uses the full width on small screens while retaining the larger breakpoint minimum

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cdd194c31c832fa3d21d3c27e57c0f