### PR TITLE
Fix dashboard sidebar layout

### DIFF
--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -213,7 +213,8 @@ export function Sidebar({ className }: { className?: string }) {
   return (
     <aside
       className={cn(
-        'w-16 bg-white border-r min-h-[100svh] flex flex-col items-center py-4 space-y-4',
+        'w-16 bg-white border-r min-h-[100svh] flex flex-col items-center py-4 space-y-4 flex-shrink-0',
+        'sm:fixed sm:inset-y-0 sm:left-0 sm:top-0 sm:h-[100svh] sm:z-20',
         className,
       )}
     >

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -39,7 +39,7 @@ export default function DashboardClientLayout({ children }: Props) {
     <div className="flex min-h-[100svh]">
         <OnboardingOverlay />
         <Sidebar className="hidden sm:flex" />
-        <main className="flex-1 bg-[#FAFAFA] p-6 h-full overflow-auto">
+        <main className="flex-1 bg-[#FAFAFA] p-6 min-h-[100svh] overflow-auto sm:ml-16">
           <div className="flex w-full items-center mb-4">
             <MobileSidebar />
             <div className="ml-auto">


### PR DESCRIPTION
## Summary
- make the dashboard sidebar fixed on desktop so it keeps a consistent width independent of surrounding content
- shift the dashboard main area to account for the fixed sidebar while preserving scrolling behaviour

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cdf86812cc832fa8675205542d834e