### PR TITLE
Move company name setup to complete profile

### DIFF
--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -2,24 +2,14 @@
 import { NextResponse } from "next/server";
 import { supabase } from "@/lib/supabaseClient";
 import { supabaseadmin } from "@/lib/supabaseAdmin";
-import {
-  isValidCompanyName,
-  isValidEmail,
-  isValidPassword,
-} from "@/lib/validators";
+import { isValidEmail, isValidPassword } from "@/lib/validators";
 
 export async function POST(req: Request) {
-  const { name, email, password } = await req.json();
-  if (!name || !email || !password) {
+  const { email, password } = await req.json();
+  if (!email || !password) {
     return NextResponse.json({ error: "Dados incompletos" }, { status: 400 });
   }
 
-  if (!isValidCompanyName(name)) {
-    return NextResponse.json(
-      { error: "Nome da empresa deve ter entre 4 e 80 caracteres" },
-      { status: 400 },
-    );
-  }
   if (!isValidEmail(email)) {
     return NextResponse.json(
       { error: "Email inválido" },
@@ -38,9 +28,6 @@ export async function POST(req: Request) {
   const { data, error } = await supabase.auth.signUp({
     email,
     password,
-    options: {
-      data: { name },
-    },
   });
   if (error) {
     console.error("Erro ao criar usuário:", error.message);
@@ -72,7 +59,7 @@ export async function POST(req: Request) {
     // 2) insere na tabela company (service role key ignora RLS)
     const { error: companyError } = await supabaseadmin
       .from("company")
-      .insert({ user_id: userId, company_name: name, profile_complete: false });
+      .insert({ user_id: userId, profile_complete: false });
 
     if (companyError) {
       console.error("Erro ao criar company:", companyError.message);

--- a/src/app/complete-profile/page.tsx
+++ b/src/app/complete-profile/page.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
 import { Loader2 } from "lucide-react";
 import {
+  isValidCompanyName,
   isValidCpfCnpj,
   isValidAddress,
   isValidCep,
@@ -19,6 +20,7 @@ export default function CompleteProfilePage() {
   const router = useRouter();
   const [loading, setLoading] = useState(true);
   const [userId, setUserId] = useState<string | null>(null);
+  const [companyName, setCompanyName] = useState("");
   const [cpfCnpj, setCpfCnpj] = useState("");
   const [address, setAddress] = useState("");
   const [zipCode, setZipCode] = useState("");
@@ -87,7 +89,7 @@ export default function CompleteProfilePage() {
 
       const { data: company, error: companyError } = await supabasebrowser
         .from("company")
-        .select("profile_complete, company_profile_id")
+        .select("profile_complete, company_profile_id, company_name")
         .eq("user_id", uid)
         .maybeSingle();
 
@@ -106,6 +108,8 @@ export default function CompleteProfilePage() {
         router.replace("/dashboard");
         return;
       }
+      setCompanyName(company.company_name || "");
+
       if (company.company_profile_id) {
         const { data: profile } = await supabasebrowser
           .from("company_profile")
@@ -132,6 +136,12 @@ export default function CompleteProfilePage() {
     e.preventDefault();
     if (!userId) return;
     setLoading(true);
+    const normalizedCompanyName = companyName.trim();
+    if (!isValidCompanyName(normalizedCompanyName)) {
+      toast.error("Nome da empresa deve ter entre 4 e 80 caracteres");
+      setLoading(false);
+      return;
+    }
     if (!isValidCpfCnpj(cpfCnpj)) {
       toast.error("CPF/CNPJ inválido");
       setLoading(false);
@@ -167,6 +177,7 @@ export default function CompleteProfilePage() {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
+        company_name: normalizedCompanyName,
         cpf_cnpj: cpfCnpj,
         address,
         zip_code: zipCode,
@@ -216,6 +227,19 @@ export default function CompleteProfilePage() {
           <h1 className="text-2xl font-semibold text-center">
             Completar Perfil
           </h1>
+          <div>
+            <label htmlFor="company" className="block text-sm font-medium">
+              Nome da empresa
+            </label>
+            <Input
+              id="company"
+              type="text"
+              value={companyName}
+              onChange={(e) => setCompanyName(e.target.value)}
+              maxLength={80}
+              required
+            />
+          </div>
           <div>
             <label htmlFor="cpfCnpj" className="block text-sm font-medium">
               CPF/CNPJ

--- a/src/app/dashboard/config/page.tsx
+++ b/src/app/dashboard/config/page.tsx
@@ -208,6 +208,7 @@ export default function ConfigPage() {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
+          company_name: normalizedCompanyName,
           cpf_cnpj: cpfCnpj,
           address,
           zip_code: zipCode,

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -7,16 +7,11 @@ import { Input } from "@/components/ui/input";
 import { PasswordInput } from "@/components/ui/password-input";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
-import {
-  isValidCompanyName,
-  isValidEmail,
-  isValidPassword,
-} from "@/lib/validators";
+import { isValidEmail, isValidPassword } from "@/lib/validators";
 import { supabasebrowser } from "@/lib/supabaseClient";
 
 export default function SignupPage() {
   const router = useRouter();
-  const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [confirm, setConfirm] = useState("");
@@ -48,10 +43,6 @@ export default function SignupPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
-    if (!isValidCompanyName(name)) {
-      setError("Nome da empresa deve ter entre 4 e 80 caracteres");
-      return;
-    }
     if (!isValidEmail(email)) {
       setError("Email inválido");
       return;
@@ -72,7 +63,7 @@ export default function SignupPage() {
       const res = await fetch("/api/auth/signup", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name, email, password }),
+        body: JSON.stringify({ email, password }),
       });
       const data = await res.json();
 
@@ -139,19 +130,6 @@ export default function SignupPage() {
         {error && (
           <div className="text-red-600 text-sm text-center">{error}</div>
         )}
-
-        <div>
-          <label htmlFor="name" className="block text-sm font-medium">
-            Nome da empresa
-          </label>
-          <Input
-            id="name"
-            type="text"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            required
-          />
-        </div>
 
         <div>
           <label htmlFor="email" className="block text-sm font-medium">


### PR DESCRIPTION
## Summary
- stop collecting the company name during sign-up and let the profile completion screen handle it
- require and persist the company name in the `/api/profile/complete` endpoint so the company table is updated when the profile is finished
- update the dashboard config flow to send the company name through the new contract when saving company details

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1af692c248333b695b5fca882f744