### PR TITLE
Handle duplicate signup identities

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -7,6 +7,7 @@ Rotas atuais que dependem do `supabaseadmin`:
 
 - `/api/profile/complete`
 - `/api/auth/signup`
+  - Após chamar o Supabase, verifica se `identities` veio vazio para sinalizar e bloquear emails já cadastrados.
 - `/api/support/new`
 - `/api/payments/pay`
 - `/api/payments/client`

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -29,6 +29,15 @@ export async function POST(req: Request) {
     email,
     password,
   });
+  const identitiesLength = data?.user?.identities?.length;
+
+  // O Supabase sinaliza emails duplicados retornando o array identities vazio
+  if (identitiesLength === 0) {
+    return NextResponse.json(
+      { error: "Email já cadastrado" },
+      { status: 409 },
+    );
+  }
   if (error) {
     console.error("Erro ao criar usuário:", error.message);
     if (
@@ -46,7 +55,7 @@ export async function POST(req: Request) {
     );
   }
 
-  if (!data.user) {
+  if (!data?.user) {
     return NextResponse.json(
       { error: "Erro ao criar usuário" },
       { status: 409 }


### PR DESCRIPTION
## Summary
- stop the signup flow when Supabase returns an empty identities array indicating a duplicated email
- document the duplicate email handling for the signup API route

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1b3c4555c83339dfdea03baf0c78d