### PR TITLE
Add Evolution webhook storage and messaging tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Este repositório contém uma aplicação [Next.js](https://nextjs.org/) prepara
    Principais variáveis relacionadas às integrações externas:
    - `EVOLUTION_API_BASE_URL`: URL base da API Evolution responsável por orquestrar os agentes. Utilize o endpoint informado na sua conta Evolution ou no ambiente configurado pela equipe de infraestrutura.
    - `EVOLUTION_API_TOKEN`: token de acesso gerado no painel da Evolution (ou fornecido pelo time responsável) que autoriza as requisições autenticadas.
+   - `EVOLUTION_WEBHOOK_TOKEN`: segredo validado pela rota `/api/webhooks/evolution`, enviado pelos servidores da Evolution no header `x-evolution-token` (ou `x-webhook-token`).
   - `REDIS_URL`: string de conexão completa para o Redis usado pelos serviços de fila/cache. Inclua nela usuário e senha quando o serviço exigir autenticação (por exemplo, `redis://default:<senha>@<host>:14216`, utilizando a porta 14216 do cluster padrão). Pode ser obtida no provedor de hospedagem (como Upstash, Redis Cloud) ou montada a partir do host, porta e credenciais do servidor interno.
   - `REDIS_USERNAME` e `REDIS_PASSWORD`: caso opte por configurar as credenciais separadamente, informe o usuário e a senha fornecidos pelo provedor (ou definidos na instância autogerenciada) para permitir que os clientes Redis executem a autenticação.
 
@@ -61,4 +62,12 @@ Este repositório contém uma aplicação [Next.js](https://nextjs.org/) prepara
 - `src/lib/redis.ts` concentra o cliente Redis com cache em memória única (singleton) e oferece helpers para enfileirar tarefas (`enqueue`, `dequeue`, `peekQueue`) e manipular chaves de cache (`setCache`, `getCache`, `deleteCache`).
 - Utilize o helper de Redis para implementar filas e caches conforme necessário; por padrão, a rota `/api/support/new` continua persistindo os tickets apenas no Supabase.
 - A rota `/api/notifications` continua consultando o Supabase diretamente para listar, criar e marcar notificações como lidas, sem camada de cache.
+
+## 📬 Webhook da Evolution API
+
+- O endpoint `POST /api/webhooks/evolution` (e suas variações por evento, como `/api/webhooks/evolution/messages-upsert`) recebe notificações da Evolution API.
+- A requisição deve enviar o header `x-evolution-token` (ou `x-webhook-token`) com o mesmo valor armazenado na tabela `evolution_instances.webhook_token` ou na variável `EVOLUTION_WEBHOOK_TOKEN`.
+- Cada payload de mensagem gera registros nas tabelas `whatsapp_conversations` e `whatsapp_messages`, permitindo rastrear histórico por empresa/instância.
+- O processamento publica eventos Redis nas filas `evolution:messages:incoming` e `evolution:messages:status`, enquanto os caches `evolution:conversation:last:<conversationId>` e `evolution:message:<messageId>` armazenam o último estado consultado por 5 minutos.
+- Para habilitar o webhook, crie previamente uma linha em `evolution_instances` associada à empresa e ao identificador da instância configurada na Evolution.
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -12,12 +12,16 @@ Rotas atuais que dependem do `supabaseadmin`:
 - `/api/notifications`
 - `/api/payments/pay`
 - `/api/payments/client`
+- `/api/webhooks/evolution`
 
 ## Filas e cache
 
 - O cliente Redis (`src/lib/redis.ts`) exige `REDIS_URL` ou `REDIS_HOST/PORT`. Garanta que o endpoint esteja protegido por ACLs ou redes privadas, especialmente em ambientes compartilhados.
 - Ao introduzir filas (por exemplo, `support:tickets`), restrinja o acesso ao Redis para escrituras originadas apenas do backend e considere autenticação mútua (TLS + senha).
 - As notificações continuam sendo servidas diretamente do Supabase; garanta que as políticas de RLS cubram leitura, criação e atualização para evitar vazamento entre empresas.
+- As filas `evolution:messages:incoming` e `evolution:messages:status` recebem dados sensíveis (IDs de conversas/mensagens); proteja o Redis contra acessos externos e monitore usos anômalos.
+- Os caches `evolution:conversation:last:<conversationId>` e `evolution:message:<messageId>` guardam resumos temporários. Defina TTLs curtos (já configurados em 5 minutos) e limpe manualmente em incidentes de vazamento.
+- O header `x-evolution-token` é obrigatório no webhook; gere tokens fortes e armazene-os apenas em `evolution_instances.webhook_token` ou na variável `EVOLUTION_WEBHOOK_TOKEN`.
 
 ## Tabelas críticas e políticas de RLS
 As seguintes tabelas requerem políticas de Row Level Security para garantir o isolamento por empresa/usuário:
@@ -29,5 +33,8 @@ As seguintes tabelas requerem políticas de Row Level Security para garantir o i
 | `agent_personality`, `agent_behavior`, `agent_onboarding`, `agent_specific_instructions`, `agent_knowledge_files` | Acesso restrito via relação com `agents.company_id` do usuário |
 | `payments` | Acesso apenas para registros com `company_id` pertencente ao usuário |
 | `tickets` | Acesso apenas para registros com `company_id` pertencente ao usuário |
+| `evolution_instances` | Usuário só acessa instâncias associadas à sua empresa (`company.user_id = auth.uid()`) |
+| `whatsapp_conversations` | Consulta limitada à empresa do usuário; updates restritos à própria empresa |
+| `whatsapp_messages` | Dependente da conversa vinculada; apenas registros onde a conversa pertence à empresa do usuário |
 
 Certifique-se de que o RLS esteja habilitado e que as políticas correspondentes estejam configuradas no Supabase para cada tabela acima.

--- a/src/app/api/webhooks/evolution/[[...slug]]/route.ts
+++ b/src/app/api/webhooks/evolution/[[...slug]]/route.ts
@@ -1,0 +1,181 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import {
+  applyEvolutionMessageUpdate,
+  normalizeEvolutionMessage,
+  persistEvolutionMessage,
+  resolveEvolutionInstance,
+  type EvolutionWebhookPayload,
+} from '@/lib/evolutionWebhook';
+
+function normalizeEventName(event?: string | null): string | undefined {
+  if (!event || typeof event !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = event.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  return trimmed.replace(/-/g, '_').toUpperCase();
+}
+
+function extractMessages(source: unknown): unknown[] {
+  if (!source) {
+    return [];
+  }
+
+  if (Array.isArray(source)) {
+    return source;
+  }
+
+  if (typeof source === 'object' && source !== null) {
+    const record = source as Record<string, unknown>;
+
+    if (Array.isArray(record.messages)) {
+      return record.messages;
+    }
+
+    if (Array.isArray(record.message)) {
+      return record.message;
+    }
+
+    if (record.message) {
+      return [record.message];
+    }
+  }
+
+  return [];
+}
+
+function extractToken(request: NextRequest): string | undefined {
+  const candidates = [
+    request.headers.get('x-evolution-token'),
+    request.headers.get('x-webhook-token'),
+    request.headers.get('authorization'),
+  ];
+
+  for (const candidate of candidates) {
+    if (!candidate) {
+      continue;
+    }
+
+    const value = candidate.replace(/^Bearer\s+/i, '').trim();
+    if (value) {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+function getString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value : undefined;
+}
+
+const GLOBAL_WEBHOOK_TOKEN = process.env.EVOLUTION_WEBHOOK_TOKEN;
+
+export async function POST(
+  request: NextRequest,
+  context: { params: { slug?: string[] } },
+): Promise<NextResponse> {
+  let payload: EvolutionWebhookPayload;
+
+  try {
+    payload = await request.json();
+  } catch (error) {
+    console.error('[evolution] JSON inválido recebido no webhook', error);
+    return NextResponse.json({ error: 'Payload inválido' }, { status: 400 });
+  }
+
+  const eventFromBody = normalizeEventName(payload.event);
+  const eventFromPath = normalizeEventName(context.params?.slug?.[0]);
+  const event = eventFromBody ?? eventFromPath;
+
+  if (!event) {
+    return NextResponse.json({ error: 'Evento não informado' }, { status: 400 });
+  }
+
+  const dataRecord =
+    payload.data && typeof payload.data === 'object'
+      ? (payload.data as Record<string, unknown>)
+      : undefined;
+
+  const instanceId =
+    getString(payload.instanceId) ??
+    getString(dataRecord?.instanceId) ??
+    getString(dataRecord?.instance_id);
+
+  const instanceName =
+    getString(payload.instanceName ?? payload.instance) ??
+    getString(dataRecord?.instanceName) ??
+    getString(dataRecord?.instance);
+
+  let instance;
+
+  try {
+    instance = await resolveEvolutionInstance({ instanceId, instanceName });
+  } catch (error) {
+    console.error('[evolution] Falha ao consultar instância', error);
+    return NextResponse.json({ error: 'Falha ao consultar instância' }, { status: 500 });
+  }
+
+  if (!instance) {
+    return NextResponse.json({ error: 'Instância não localizada' }, { status: 404 });
+  }
+
+  const token = extractToken(request);
+  const expectedTokens = [instance.webhook_token, GLOBAL_WEBHOOK_TOKEN].filter(Boolean) as string[];
+
+  if (expectedTokens.length > 0 && (!token || !expectedTokens.includes(token))) {
+    return NextResponse.json({ error: 'Assinatura inválida' }, { status: 401 });
+  }
+
+  const messages = [
+    ...extractMessages(payload.data),
+    ...extractMessages((payload as Record<string, unknown>).messages),
+  ];
+
+  if (event === 'MESSAGES_UPSERT' || event === 'SEND_MESSAGE') {
+    let processed = 0;
+
+    for (const raw of messages) {
+      const normalized = normalizeEvolutionMessage(raw);
+
+      if (!normalized) {
+        continue;
+      }
+
+      try {
+        const persisted = await persistEvolutionMessage(instance, normalized);
+        if (persisted) {
+          processed += 1;
+        }
+      } catch (error) {
+        console.error('[evolution] Erro ao persistir mensagem', error);
+      }
+    }
+
+    return NextResponse.json({ success: true, processed }, { status: 200 });
+  }
+
+  if (event === 'MESSAGES_UPDATE') {
+    let updated = 0;
+
+    for (const raw of messages) {
+      try {
+        const applied = await applyEvolutionMessageUpdate(instance, raw);
+        if (applied) {
+          updated += 1;
+        }
+      } catch (error) {
+        console.error('[evolution] Erro ao atualizar status da mensagem', error);
+      }
+    }
+
+    return NextResponse.json({ success: true, updated }, { status: 200 });
+  }
+
+  return NextResponse.json({ success: true, ignored: event }, { status: 200 });
+}

--- a/src/lib/evolutionWebhook.ts
+++ b/src/lib/evolutionWebhook.ts
@@ -1,0 +1,543 @@
+import { supabaseadmin } from '@/lib/supabaseAdmin';
+import { enqueue, setCache } from '@/lib/redis';
+
+type JsonRecord = Record<string, unknown>;
+
+export interface EvolutionInstanceRecord {
+  id: string;
+  company_id: number;
+  instance_id: string | null;
+  instance_name: string;
+  webhook_token: string;
+}
+
+export interface EvolutionWebhookPayload {
+  event?: string;
+  instanceId?: string;
+  instanceName?: string;
+  instance?: string;
+  data?: unknown;
+}
+
+export interface NormalizedEvolutionMessage {
+  messageId: string;
+  chatId: string;
+  fromMe: boolean;
+  direction: 'inbound' | 'outbound';
+  sender?: string;
+  senderName?: string;
+  type: string;
+  status?: string;
+  body?: string | null;
+  sentAt: Date;
+  isGroup: boolean;
+  contactNumber?: string;
+  contactWaId?: string;
+  raw: JsonRecord;
+}
+
+export const INCOMING_QUEUE_KEY = 'evolution:messages:incoming';
+export const STATUS_QUEUE_KEY = 'evolution:messages:status';
+export const MESSAGE_CACHE_PREFIX = 'evolution:message:';
+export const CONVERSATION_CACHE_PREFIX = 'evolution:conversation:last:';
+const MESSAGE_CACHE_TTL_SECONDS = 300;
+
+function isRedisConfigured(): boolean {
+  return Boolean(process.env.REDIS_URL || process.env.REDIS_HOST);
+}
+
+async function safeEnqueue(queue: string, value: JsonRecord): Promise<void> {
+  if (!isRedisConfigured()) {
+    return;
+  }
+
+  try {
+    await enqueue(queue, JSON.stringify(value));
+  } catch (error) {
+    console.error(`[redis] Falha ao enfileirar dados em ${queue}`, error);
+  }
+}
+
+async function safeCache(key: string, value: JsonRecord, ttlSeconds = MESSAGE_CACHE_TTL_SECONDS): Promise<void> {
+  if (!isRedisConfigured()) {
+    return;
+  }
+
+  try {
+    await setCache(key, JSON.stringify(value), ttlSeconds);
+  } catch (error) {
+    console.error(`[redis] Falha ao salvar cache ${key}`, error);
+  }
+}
+
+function toJsonRecord(value: unknown): JsonRecord {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    try {
+      return JSON.parse(JSON.stringify(value));
+    } catch (error) {
+      console.error('[evolution] Não foi possível serializar o payload recebido', error);
+    }
+  }
+
+  return {};
+}
+
+function parseTimestamp(value: unknown): Date {
+  if (value instanceof Date) {
+    return value;
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    const timestamp = value > 9_999_999_999 ? value : value * 1000;
+    return new Date(timestamp);
+  }
+
+  if (typeof value === 'string' && value.trim()) {
+    const numeric = Number(value);
+
+    if (!Number.isNaN(numeric)) {
+      const timestamp = numeric > 9_999_999_999 ? numeric : numeric * 1000;
+      return new Date(timestamp);
+    }
+
+    const date = new Date(value);
+    if (!Number.isNaN(date.getTime())) {
+      return date;
+    }
+  }
+
+  return new Date();
+}
+
+function extractTextFromMessage(raw: JsonRecord): string | null {
+  const { body, text, message } = raw;
+
+  if (typeof body === 'string' && body.trim()) {
+    return body.trim();
+  }
+
+  if (typeof text === 'string' && text.trim()) {
+    return text.trim();
+  }
+
+  if (message && typeof message === 'object' && !Array.isArray(message)) {
+    const nested = message as JsonRecord;
+
+    if (typeof nested.conversation === 'string' && nested.conversation.trim()) {
+      return nested.conversation.trim();
+    }
+
+    const extended = nested.extendedTextMessage as JsonRecord | undefined;
+    if (extended && typeof extended.text === 'string' && extended.text.trim()) {
+      return extended.text.trim();
+    }
+
+    const image = nested.imageMessage as JsonRecord | undefined;
+    if (image && typeof image.caption === 'string' && image.caption.trim()) {
+      return image.caption.trim();
+    }
+
+    const buttons = nested.buttonsResponseMessage as JsonRecord | undefined;
+    if (buttons && typeof buttons.selectedDisplayText === 'string' && buttons.selectedDisplayText.trim()) {
+      return buttons.selectedDisplayText.trim();
+    }
+  }
+
+  return null;
+}
+
+function sanitizePreview(body: string | null | undefined, type: string): string | null {
+  if (body && body.trim()) {
+    const trimmed = body.trim();
+    return trimmed.length > 280 ? `${trimmed.slice(0, 277)}...` : trimmed;
+  }
+
+  if (type) {
+    return `[${type}]`;
+  }
+
+  return null;
+}
+
+function readString(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value);
+  }
+
+  return undefined;
+}
+
+function findChatId(raw: JsonRecord, key?: JsonRecord): string | undefined {
+  const candidates: Array<unknown> = [
+    raw.chatId,
+    raw.chat_id,
+    raw.remoteJid,
+    raw.jid,
+    raw.to,
+    raw.from,
+  ];
+
+  if (key) {
+    candidates.push(key.remoteJid, key.remotejid, key.id);
+  }
+
+  for (const candidate of candidates) {
+    const value = readString(candidate);
+    if (value) {
+      const normalized = value.trim();
+      if (normalized) {
+        return normalized;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function extractSender(raw: JsonRecord, key?: JsonRecord): string | undefined {
+  const candidates: Array<unknown> = [
+    raw.participant,
+    raw.author,
+    raw.sender,
+    raw.from,
+  ];
+
+  if (key) {
+    candidates.push(key.participant, key.remoteJid);
+  }
+
+  for (const candidate of candidates) {
+    const value = readString(candidate);
+    if (value) {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+function extractSenderName(raw: JsonRecord): string | undefined {
+  const candidates: Array<unknown> = [
+    raw.pushName,
+    raw.pushname,
+    raw.senderName,
+    raw.contactName,
+    raw.name,
+    raw.displayName,
+  ];
+
+  for (const candidate of candidates) {
+    const value = readString(candidate);
+    if (value) {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+function extractType(raw: JsonRecord): string {
+  const candidates: Array<unknown> = [
+    raw.type,
+    raw.messageType,
+    raw.message_type,
+  ];
+
+  for (const candidate of candidates) {
+    const value = readString(candidate);
+    if (value) {
+      return value;
+    }
+  }
+
+  const message = raw.message;
+  if (message && typeof message === 'object' && !Array.isArray(message)) {
+    const keys = Object.keys(message as JsonRecord);
+    if (keys.length > 0) {
+      return keys[0];
+    }
+  }
+
+  return 'unknown';
+}
+
+function extractStatus(raw: JsonRecord): string | undefined {
+  const candidates: Array<unknown> = [
+    raw.status,
+    raw.messageStatus,
+    raw.ack,
+    raw.acknowledged,
+  ];
+
+  for (const candidate of candidates) {
+    const value = readString(candidate);
+    if (value) {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+function parseBoolean(value: unknown): boolean | undefined {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value === 'number') {
+    return value === 1;
+  }
+
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === 'true' || normalized === '1') {
+      return true;
+    }
+
+    if (normalized === 'false' || normalized === '0') {
+      return false;
+    }
+  }
+
+  return undefined;
+}
+
+export async function resolveEvolutionInstance({
+  instanceId,
+  instanceName,
+}: {
+  instanceId?: string | null;
+  instanceName?: string | null;
+}): Promise<EvolutionInstanceRecord | null> {
+  const filters: string[] = [];
+
+  if (instanceId) {
+    filters.push(`instance_id.eq.${instanceId}`);
+  }
+
+  if (instanceName) {
+    filters.push(`instance_name.eq.${instanceName}`);
+  }
+
+  if (filters.length === 0) {
+    return null;
+  }
+
+  const query = supabaseadmin
+    .from('evolution_instances')
+    .select('id, company_id, instance_id, instance_name, webhook_token')
+    .limit(1);
+
+  if (filters.length > 0) {
+    query.or(filters.join(','));
+  }
+
+  const { data, error } = await query.maybeSingle();
+
+  if (error) {
+    throw new Error(`[evolution] Falha ao localizar instância: ${error.message}`);
+  }
+
+  return data ?? null;
+}
+
+export function normalizeEvolutionMessage(raw: unknown): NormalizedEvolutionMessage | null {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return null;
+  }
+
+  const record = raw as JsonRecord;
+  const key = record.key && typeof record.key === 'object' && !Array.isArray(record.key)
+    ? (record.key as JsonRecord)
+    : undefined;
+
+  const messageId = readString(record.id) || readString(record.messageId) || (key ? readString(key.id) : undefined);
+  const chatId = findChatId(record, key);
+
+  if (!messageId || !chatId) {
+    return null;
+  }
+
+  const fromMe = parseBoolean(record.fromMe) ?? (key ? parseBoolean(key.fromMe) ?? false : false);
+  const direction: 'inbound' | 'outbound' = fromMe ? 'outbound' : 'inbound';
+  const sender = extractSender(record, key);
+  const senderName = extractSenderName(record);
+  const type = extractType(record);
+  const status = extractStatus(record);
+  const body = extractTextFromMessage(record);
+
+  const timestampValue = record.timestamp ?? record.messageTimestamp ?? record.msgTimestamp ?? record.created_at ?? record.updated_at;
+  const sentAt = parseTimestamp(timestampValue);
+
+  const contactWaId = chatId;
+  const contactNumber = chatId.includes('@') ? chatId.split('@')[0] : chatId;
+  const lowerChatId = chatId.toLowerCase();
+  const isGroup = lowerChatId.endsWith('@g.us') || lowerChatId.endsWith('@broadcast');
+
+  return {
+    messageId,
+    chatId,
+    fromMe,
+    direction,
+    sender,
+    senderName,
+    type,
+    status,
+    body,
+    sentAt,
+    isGroup,
+    contactNumber,
+    contactWaId,
+    raw: toJsonRecord(record),
+  };
+}
+
+export async function persistEvolutionMessage(
+  instance: EvolutionInstanceRecord,
+  normalized: NormalizedEvolutionMessage,
+): Promise<{ conversationId: string; messageId: string } | null> {
+  const nowIso = new Date().toISOString();
+
+  const conversationPayload: Record<string, unknown> = {
+    company_id: instance.company_id,
+    instance_id: instance.instance_id,
+    instance_name: instance.instance_name,
+    chat_id: normalized.chatId,
+    contact_wa_id: normalized.contactWaId,
+    contact_number: normalized.contactNumber,
+    is_group: normalized.isGroup,
+    last_message_id: normalized.messageId,
+    last_message_preview: sanitizePreview(normalized.body, normalized.type),
+    last_message_direction: normalized.direction,
+    last_message_at: normalized.sentAt.toISOString(),
+    updated_at: nowIso,
+  };
+
+  if (normalized.senderName) {
+    conversationPayload.contact_name = normalized.senderName;
+  }
+
+  const { data: conversation, error: conversationError } = await supabaseadmin
+    .from('whatsapp_conversations')
+    .upsert(conversationPayload, { onConflict: 'company_id,chat_id' })
+    .select('id, company_id, chat_id')
+    .single();
+
+  if (conversationError) {
+    console.error('[evolution] Falha ao salvar conversa', conversationError);
+    return null;
+  }
+
+  const messagePayload: Record<string, unknown> = {
+    company_id: instance.company_id,
+    conversation_id: conversation.id,
+    instance_name: instance.instance_name,
+    message_id: normalized.messageId,
+    chat_id: normalized.chatId,
+    direction: normalized.direction,
+    from_me: normalized.fromMe,
+    sender: normalized.sender,
+    sender_name: normalized.senderName,
+    type: normalized.type,
+    status: normalized.status,
+    body: normalized.body,
+    raw_payload: normalized.raw,
+    sent_at: normalized.sentAt.toISOString(),
+    updated_at: nowIso,
+  };
+
+  const { data: message, error: messageError } = await supabaseadmin
+    .from('whatsapp_messages')
+    .upsert(messagePayload, { onConflict: 'company_id,message_id' })
+    .select('id, message_id, conversation_id, company_id, status, direction')
+    .single();
+
+  if (messageError) {
+    console.error('[evolution] Falha ao salvar mensagem', messageError);
+    return null;
+  }
+
+  const conversationCachePayload: JsonRecord = {
+    id: conversation.id,
+    chat_id: normalized.chatId,
+    last_message_id: normalized.messageId,
+    last_message_preview: sanitizePreview(normalized.body, normalized.type),
+    last_message_direction: normalized.direction,
+    last_message_at: normalized.sentAt.toISOString(),
+  };
+
+  const messageCachePayload: JsonRecord = {
+    id: message.id,
+    company_id: message.company_id,
+    conversation_id: message.conversation_id,
+    message_id: message.message_id,
+    status: message.status,
+    direction: message.direction,
+  };
+
+  await safeCache(`${CONVERSATION_CACHE_PREFIX}${conversation.id}`, conversationCachePayload);
+  await safeCache(`${MESSAGE_CACHE_PREFIX}${message.message_id}`, messageCachePayload);
+
+  await safeEnqueue(INCOMING_QUEUE_KEY, {
+    company_id: message.company_id,
+    conversation_id: message.conversation_id,
+    message_id: message.message_id,
+    direction: message.direction,
+  });
+
+  return { conversationId: conversation.id, messageId: message.message_id };
+}
+
+export async function applyEvolutionMessageUpdate(
+  instance: EvolutionInstanceRecord,
+  raw: unknown,
+): Promise<boolean> {
+  const normalized = normalizeEvolutionMessage(raw);
+
+  if (!normalized) {
+    return false;
+  }
+
+  if (!normalized.status) {
+    return false;
+  }
+
+  const nowIso = new Date().toISOString();
+  const { data, error } = await supabaseadmin
+    .from('whatsapp_messages')
+    .update({ status: normalized.status, updated_at: nowIso })
+    .eq('company_id', instance.company_id)
+    .eq('message_id', normalized.messageId)
+    .select('id, message_id, conversation_id, company_id, status')
+    .maybeSingle();
+
+  if (error) {
+    console.error('[evolution] Falha ao atualizar status da mensagem', error);
+    return false;
+  }
+
+  if (!data) {
+    return false;
+  }
+
+  await safeCache(`${MESSAGE_CACHE_PREFIX}${data.message_id}`, {
+    id: data.id,
+    company_id: data.company_id,
+    conversation_id: data.conversation_id,
+    message_id: data.message_id,
+    status: data.status,
+  });
+
+  await safeEnqueue(STATUS_QUEUE_KEY, {
+    company_id: data.company_id,
+    conversation_id: data.conversation_id,
+    message_id: data.message_id,
+    status: data.status,
+  });
+
+  return true;
+}

--- a/supabase/migrations/20250222000000_create_evolution_messaging_tables.sql
+++ b/supabase/migrations/20250222000000_create_evolution_messaging_tables.sql
@@ -1,0 +1,167 @@
+-- Estruturas para integração de mensagens via Evolution API
+
+create table public.evolution_instances (
+  id uuid not null default gen_random_uuid(),
+  company_id bigint not null,
+  instance_id text null,
+  instance_name text not null,
+  webhook_token text not null,
+  settings jsonb not null default '{}'::jsonb,
+  created_at timestamp with time zone not null default now(),
+  updated_at timestamp with time zone not null default now(),
+  constraint evolution_instances_pkey primary key (id),
+  constraint evolution_instances_company_id_fkey foreign key (company_id) references public.company (id) on delete cascade
+);
+
+create unique index evolution_instances_instance_name_key on public.evolution_instances (instance_name);
+create unique index evolution_instances_instance_id_key on public.evolution_instances (instance_id) where instance_id is not null;
+
+create table public.whatsapp_conversations (
+  id uuid not null default gen_random_uuid(),
+  company_id bigint not null,
+  instance_id text null,
+  instance_name text not null,
+  chat_id text not null,
+  contact_wa_id text null,
+  contact_number text null,
+  contact_name text null,
+  is_group boolean not null default false,
+  last_message_id text null,
+  last_message_preview text null,
+  last_message_direction text null,
+  last_message_at timestamp with time zone null,
+  unread_count integer not null default 0,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamp with time zone not null default now(),
+  updated_at timestamp with time zone not null default now(),
+  constraint whatsapp_conversations_pkey primary key (id),
+  constraint whatsapp_conversations_company_id_fkey foreign key (company_id) references public.company (id) on delete cascade
+);
+
+create unique index whatsapp_conversations_company_chat_key on public.whatsapp_conversations (company_id, chat_id);
+create index whatsapp_conversations_instance_idx on public.whatsapp_conversations (instance_name);
+create index whatsapp_conversations_last_message_idx on public.whatsapp_conversations (company_id, last_message_at desc);
+
+create table public.whatsapp_messages (
+  id uuid not null default gen_random_uuid(),
+  company_id bigint not null,
+  conversation_id uuid not null,
+  instance_name text not null,
+  message_id text not null,
+  chat_id text not null,
+  direction text not null,
+  from_me boolean not null default false,
+  sender text null,
+  sender_name text null,
+  type text not null,
+  status text null,
+  body text null,
+  raw_payload jsonb not null default '{}'::jsonb,
+  sent_at timestamp with time zone not null,
+  received_at timestamp with time zone not null default now(),
+  updated_at timestamp with time zone not null default now(),
+  constraint whatsapp_messages_pkey primary key (id),
+  constraint whatsapp_messages_company_id_fkey foreign key (company_id) references public.company (id) on delete cascade,
+  constraint whatsapp_messages_conversation_id_fkey foreign key (conversation_id) references public.whatsapp_conversations (id) on delete cascade,
+  constraint whatsapp_messages_direction_check check (direction in ('inbound', 'outbound'))
+);
+
+create unique index whatsapp_messages_company_message_key on public.whatsapp_messages (company_id, message_id);
+create index whatsapp_messages_conversation_idx on public.whatsapp_messages (conversation_id, sent_at desc);
+create index whatsapp_messages_sent_at_idx on public.whatsapp_messages (company_id, sent_at desc);
+
+alter table public.evolution_instances enable row level security;
+create policy evolution_instances_select_own on public.evolution_instances
+  for select
+  using (
+    exists (
+      select 1
+      from public.company
+      where company.id = evolution_instances.company_id
+        and company.user_id = auth.uid()
+    )
+  );
+
+create policy evolution_instances_write_own on public.evolution_instances
+  for all
+  using (
+    exists (
+      select 1
+      from public.company
+      where company.id = evolution_instances.company_id
+        and company.user_id = auth.uid()
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from public.company
+      where company.id = evolution_instances.company_id
+        and company.user_id = auth.uid()
+    )
+  );
+
+alter table public.whatsapp_conversations enable row level security;
+create policy whatsapp_conversations_select_own on public.whatsapp_conversations
+  for select
+  using (
+    exists (
+      select 1
+      from public.company
+      where company.id = whatsapp_conversations.company_id
+        and company.user_id = auth.uid()
+    )
+  );
+
+create policy whatsapp_conversations_write_own on public.whatsapp_conversations
+  for all
+  using (
+    exists (
+      select 1
+      from public.company
+      where company.id = whatsapp_conversations.company_id
+        and company.user_id = auth.uid()
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from public.company
+      where company.id = whatsapp_conversations.company_id
+        and company.user_id = auth.uid()
+    )
+  );
+
+alter table public.whatsapp_messages enable row level security;
+create policy whatsapp_messages_select_own on public.whatsapp_messages
+  for select
+  using (
+    exists (
+      select 1
+      from public.whatsapp_conversations
+      join public.company on company.id = whatsapp_conversations.company_id
+      where whatsapp_conversations.id = whatsapp_messages.conversation_id
+        and company.user_id = auth.uid()
+    )
+  );
+
+create policy whatsapp_messages_write_own on public.whatsapp_messages
+  for all
+  using (
+    exists (
+      select 1
+      from public.whatsapp_conversations
+      join public.company on company.id = whatsapp_conversations.company_id
+      where whatsapp_conversations.id = whatsapp_messages.conversation_id
+        and company.user_id = auth.uid()
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from public.whatsapp_conversations
+      join public.company on company.id = whatsapp_conversations.company_id
+      where whatsapp_conversations.id = whatsapp_messages.conversation_id
+        and company.user_id = auth.uid()
+    )
+  );


### PR DESCRIPTION
## Resumo
- criar migração do Supabase para evolution_instances, whatsapp_conversations e whatsapp_messages com índices e políticas de RLS
- adicionar utilitário evolutionWebhook para normalizar, persistir e publicar mensagens/status em Redis
- expor rota POST /api/webhooks/evolution que valida o token recebido, associa a instância correta e aciona o pipeline de armazenamento
- atualizar README e documentação de CRM/Segurança com instruções do webhook, filas Redis e novas tabelas

## Testes
- npm run lint (com avisos já existentes em componentes legacy)


------
https://chatgpt.com/codex/tasks/task_e_68d2017e39cc8333a33ba02dbc2dc7f5