### PR TITLE
refactor: separate chat messages from legacy metrics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Estas orientações se aplicam a todo o repositório `agent-plugandplay`.
 ## Documentação
 - Atualize documentação relevante (por exemplo, arquivos em `docs/` ou `README.md`) sempre que fizer mudanças que afetem o comportamento observado pelo usuário.
 - Ao modificar arquivos Markdown, utilize títulos em português e mantenha uma estrutura coerente com o restante do projeto.
+- Diferencie nas descrições de banco de dados a tabela transacional `messages_chat` da tabela agregada legada `messages` para evitar regressões em integrações existentes.
 
 ## Mensagens de PR
 - Estruture a mensagem de PR com um resumo em tópicos e uma seção de testes, mencionando cada comando executado.

--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ O módulo de CRM omnichannel opera sobre uma arquitetura dedicada que combina Ne
 
 - **Frontend e BFF**: implementados em Next.js (App Router), reutilizando rotas `/api` tanto para webhooks quanto para endpoints internos que atendem o painel administrativo.
 - **Banco de dados principal**: Supabase (Postgres) com autenticação, RLS, Storage e Realtime habilitados para armazenar conversas, mensagens e anexos de forma segura.
-- **Tempo real**: Supabase Realtime via WebSocket, assinando as tabelas `messages` e `conversations` para atualizar o painel instantaneamente.
+- **Tempo real**: Supabase Realtime via WebSocket, assinando as tabelas `messages_chat` e `conversations` para atualizar o painel instantaneamente.
 - **Fila e processamento assíncrono**: Redis + BullMQ, orquestrando workers independentes responsáveis por sincronizar mensagens, enviar notificações e lidar com tarefas demoradas.
 - **Integração externa**: Evolution API como provedor oficial de WhatsApp, responsável por entrega e recebimento de mensagens desse canal.
 
 ### Componentes e responsabilidades
 
 - **Next.js (Web/App)**: renderiza a UI do painel (lista de conversas, mensagens), publica webhooks rápidos em `/api/webhook` e encaminha chamadas internas para `/api/messages`.
-- **Supabase**: centraliza contatos, conversas, mensagens, anexos, histórico de status e eventos de webhook no Postgres, garantindo isolamento por tenant com RLS e suporte a Storage/Realtime.
+- **Supabase**: centraliza contatos, conversas, mensagens, anexos, histórico de status e eventos de webhook no Postgres, garantindo isolamento por tenant com RLS e suporte a Storage/Realtime. As mensagens são persistidas na tabela `public.messages_chat`, enquanto a tabela agregada legada `public.messages` continua abastecendo relatórios diários.
 - **Redis + BullMQ**: mantém as filas `incoming_message` (processamento de webhooks) e `send_message` (envio para Evolution), controlando _retries_, _backoff_, DLQ e concorrência.
 - **Workers Node.js**: executam fora do Next.js, tratam normalização e idempotência, fazem _upsert_ no Supabase e gerenciam _download_ de mídia quando necessário.
 

--- a/docs/BRANDING.md
+++ b/docs/BRANDING.md
@@ -31,4 +31,5 @@ A unidade base de espaçamento segue o padrão do Tailwind CSS (4 px). Organize
 - Ícones de canal (WhatsApp, email, etc.) devem seguir o estilo linear utilizado no restante da aplicação, aplicando a cor `--primary` para destacar o canal ativo.
 - Mensagens automáticas enviadas pelo CRM devem adotar o tom de voz da marca, evitando linguagem excessivamente técnica ou informal.
 - Quando necessário aplicar estados diferenciados (por exemplo, mensagens não lidas ou fila prioritária), prefira variações de saturação da cor `--accent` em vez de introduzir novas cores.
+- Ao produzir materiais internos, diferencie claramente os dados de "Mensagens do Chat" (`messages_chat`) dos painéis agregados legados (`messages`) para evitar confusões entre times de produto e marketing.
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -27,7 +27,7 @@ Certifique-se de que o RLS esteja habilitado e que as políticas correspondentes
 
 ## Considerações para o Chat Omnichannel/CRM
 
-- **Tabelas do CRM**: garanta políticas de RLS para `crm_conversations`, `crm_messages` e quaisquer tabelas de anexos, sempre vinculando registros ao `company_id` e aos operadores autorizados.
+- **Tabelas do CRM**: garanta políticas de RLS para `public.instance`, `public.contacts`, `public.conversations` e `public.messages_chat`, além de quaisquer tabelas de anexos. Todas devem referenciar `company_id` para restringir acesso aos operadores da empresa. A _view_ `public.crm_message_daily_metrics` herda as políticas de `public.messages_chat` e pode ser exposta com segurança para relatórios. A tabela agregada legada `public.messages` permanece disponível para métricas históricas e deve seguir o mesmo padrão de isolamento se for atualizada.
 - **Webhooks externos**: valide a assinatura ou token enviado pela Evolution API antes de aceitar o evento. Rejeite chamadas sem autenticação ou provenientes de IPs desconhecidos.
 - **Supabase Realtime**: limite os canais de Realtime às empresas autorizadas, evitando que assinantes recebam eventos de outras contas.
 - **Workers BullMQ**: armazene credenciais de provedores externos em variáveis de ambiente seguras e carregue-as apenas quando necessário. Registre falhas de entrega de mensagens com contexto suficiente para auditoria.

--- a/docs/crm.md
+++ b/docs/crm.md
@@ -21,8 +21,24 @@ Estabelecer uma base única para atendimento omnichannel que consolide contatos,
 - Uso de Storage para anexos de mídia compartilhados nas conversas.
 - Versionamento de esquemas realizado por migrações SQL armazenadas no repositório.
 
+#### Esquema de Dados do CRM
+- `public.instance`: representa as instâncias configuradas para cada empresa junto à Evolution API ou demais provedores. Armazena
+  identificadores externos, segredos de webhook, status de sincronização e parâmetros específicos em `settings`.
+- `public.contacts`: mantém contatos unificados por empresa, incluindo dados de perfil, idioma, _tags_, bloqueios e o relacionam
+  ento opcional com a instância responsável por sincronizar o registro.
+- `public.conversations`: agrega as interações por canal, vinculando contato, instância, responsáveis humanos (`assigned_user_id`)
+  ou agentes virtuais (`assigned_agent_id`), além de metadados sobre SLA, prioridade e carimbos de data.
+- `public.messages_chat`: guarda o histórico completo de mensagens com direção (`inbound`/`outbound`), tipo de conteúdo, status de entrega,
+  _payload_ bruto e vínculos opcionais ao usuário/autômato que originou o evento.
+- `public.messages`: tabela agregada legada com contagem diária por empresa, preservada para relatórios e integrações existentes.
+- `public.crm_message_daily_metrics`: _view_ derivada para alimentar o dashboard, calculando volume diário de mensagens por empresa com base
+  em `messages_chat.sent_at`.
+
+Os campos `updated_at` são atualizados automaticamente via _trigger_. Todos os registros carregam `company_id`, permitindo aplic
+ar políticas de RLS que restringem o acesso a operadores da empresa proprietária.
+
 ### Comunicação em Tempo Real
-- Supabase Realtime com WebSockets assinando as tabelas `messages` e `conversations`.
+- Supabase Realtime com WebSockets assinando as tabelas `messages_chat` e `conversations`.
 - Atualizações de status de atendimento e indicadores de digitação propagados instantaneamente para operadores conectados.
 - Estratégia de reconexão automática no frontend para manter o canal ativo.
 
@@ -48,6 +64,6 @@ Estabelecer uma base única para atendimento omnichannel que consolide contatos,
 - Alertas para quedas de conexão com Evolution API, Redis ou Supabase.
 
 ## Próximos Passos
-- Definir esquema completo de tabelas (`conversations`, `messages`, `participants`, `channels`).
+- Mapear entidades auxiliares (participantes adicionais, anexos e etiquetas avançadas) complementando o esquema principal.
 - Documentar processos de suporte para reprocessar mensagens em _dead-letter queue_.
 - Adicionar guias de onboarding para operadores e administradores do CRM.

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -36,7 +36,7 @@ type Company = {
   company_profile_id?: number;
 };
 
-type Message = {
+type DailyMetric = {
   message_date: string;
   message_count: number;
 };
@@ -91,7 +91,7 @@ export default function DashboardPage() {
           return;
         }
         if (!data) return;
-        const formatted = (data as Message[])
+        const formatted = (data as DailyMetric[])
           .map((msg) => ({ date: msg.message_date, count: msg.message_count }))
           .sort((a, b) => a.date.localeCompare(b.date));
         setDailyMessages(formatted);

--- a/supabase/migrations/20250222000000_create_crm_chat_tables.sql
+++ b/supabase/migrations/20250222000000_create_crm_chat_tables.sql
@@ -1,0 +1,383 @@
+-- Create chat CRM tables integrated with Evolution API
+
+-- Atualiza artefatos legados e cria o armazenamento omnichannel do chat
+DROP VIEW IF EXISTS public.crm_message_daily_metrics;
+
+-- Preserve legacy aggregated messages table used by existing dashboards
+CREATE TABLE IF NOT EXISTS public.messages (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  company_id bigint NOT NULL REFERENCES public.company (id),
+  message_date date NOT NULL,
+  message_count integer NOT NULL
+);
+
+-- Enumerations to support omnichannel conversations
+DO $$
+BEGIN
+  CREATE TYPE public.chat_channel AS ENUM (
+    'whatsapp',
+    'instagram',
+    'facebook_messenger',
+    'telegram',
+    'email',
+    'webchat'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END
+$$;
+
+DO $$
+BEGIN
+  CREATE TYPE public.conversation_status AS ENUM (
+    'open',
+    'pending',
+    'closed',
+    'archived'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END
+$$;
+
+DO $$
+BEGIN
+  CREATE TYPE public.message_direction AS ENUM ('inbound', 'outbound');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END
+$$;
+
+DO $$
+BEGIN
+  CREATE TYPE public.message_sender_type AS ENUM (
+    'contact',
+    'agent',
+    'automation',
+    'system'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END
+$$;
+
+DO $$
+BEGIN
+  CREATE TYPE public.message_content_type AS ENUM (
+    'text',
+    'image',
+    'audio',
+    'video',
+    'document',
+    'sticker',
+    'location',
+    'template',
+    'unknown'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END
+$$;
+
+DO $$
+BEGIN
+  CREATE TYPE public.message_delivery_status AS ENUM (
+    'pending',
+    'sent',
+    'delivered',
+    'read',
+    'failed'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END
+$$;
+
+-- Integration instances that connect companies to Evolution API tenants
+CREATE TABLE IF NOT EXISTS public.instance (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  company_id bigint NOT NULL REFERENCES public.company (id) ON DELETE CASCADE,
+  name text NOT NULL,
+  provider text NOT NULL DEFAULT 'evolution',
+  external_id text,
+  webhook_url text,
+  webhook_secret text,
+  is_active boolean NOT NULL DEFAULT true,
+  last_sync_at timestamptz,
+  settings jsonb NOT NULL DEFAULT '{}'::jsonb,
+  UNIQUE (company_id, external_id)
+);
+
+-- Contacts synchronized from Evolution API or created manually by operators
+CREATE TABLE IF NOT EXISTS public.contacts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  company_id bigint NOT NULL REFERENCES public.company (id) ON DELETE CASCADE,
+  instance_id uuid REFERENCES public.instance (id) ON DELETE SET NULL,
+  external_id text,
+  full_name text,
+  first_name text,
+  last_name text,
+  display_name text,
+  phone text,
+  email text,
+  profile_image_url text,
+  language text,
+  timezone text,
+  last_seen_at timestamptz,
+  is_blocked boolean NOT NULL DEFAULT false,
+  is_favorite boolean NOT NULL DEFAULT false,
+  tags text[] DEFAULT '{}'::text[],
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  UNIQUE (company_id, external_id)
+);
+
+-- Conversations aggregate interactions per contact and channel
+CREATE TABLE IF NOT EXISTS public.conversations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  company_id bigint NOT NULL REFERENCES public.company (id) ON DELETE CASCADE,
+  instance_id uuid REFERENCES public.instance (id) ON DELETE SET NULL,
+  contact_id uuid NOT NULL REFERENCES public.contacts (id) ON DELETE CASCADE,
+  external_id text,
+  channel public.chat_channel NOT NULL,
+  subject text,
+  status public.conversation_status NOT NULL DEFAULT 'open',
+  priority text,
+  assigned_user_id uuid REFERENCES auth.users (id) ON DELETE SET NULL,
+  assigned_agent_id uuid REFERENCES public.agents (id) ON DELETE SET NULL,
+  opened_by uuid REFERENCES auth.users (id) ON DELETE SET NULL,
+  closed_by uuid REFERENCES auth.users (id) ON DELETE SET NULL,
+  first_response_at timestamptz,
+  last_message_at timestamptz,
+  closed_at timestamptz,
+  sla_due_at timestamptz,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  UNIQUE (company_id, external_id)
+);
+
+-- Messages exchanged inside each conversation (mantém tabela agregada "public.messages")
+CREATE TABLE IF NOT EXISTS public.messages_chat (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  sent_at timestamptz NOT NULL DEFAULT now(),
+  company_id bigint NOT NULL REFERENCES public.company (id) ON DELETE CASCADE,
+  instance_id uuid REFERENCES public.instance (id) ON DELETE SET NULL,
+  conversation_id uuid NOT NULL REFERENCES public.conversations (id) ON DELETE CASCADE,
+  contact_id uuid REFERENCES public.contacts (id) ON DELETE SET NULL,
+  author_user_id uuid REFERENCES auth.users (id) ON DELETE SET NULL,
+  agent_id uuid REFERENCES public.agents (id) ON DELETE SET NULL,
+  direction public.message_direction NOT NULL,
+  sender_type public.message_sender_type NOT NULL,
+  status public.message_delivery_status NOT NULL DEFAULT 'pending',
+  content_type public.message_content_type NOT NULL DEFAULT 'text',
+  text text,
+  media_url text,
+  media_caption text,
+  payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+  reply_to_message_id uuid REFERENCES public.messages_chat (id) ON DELETE SET NULL,
+  external_id text,
+  external_status text,
+  error_reason text,
+  delivered_at timestamptz,
+  read_at timestamptz,
+  UNIQUE (company_id, external_id)
+);
+
+-- Indexes to optimize frequent queries
+CREATE INDEX IF NOT EXISTS instance_company_id_idx ON public.instance (company_id);
+CREATE INDEX IF NOT EXISTS contacts_company_id_idx ON public.contacts (company_id);
+CREATE INDEX IF NOT EXISTS contacts_instance_id_idx ON public.contacts (instance_id);
+CREATE INDEX IF NOT EXISTS conversations_company_id_idx ON public.conversations (company_id);
+CREATE INDEX IF NOT EXISTS conversations_contact_id_idx ON public.conversations (contact_id);
+CREATE INDEX IF NOT EXISTS conversations_status_idx ON public.conversations (status);
+CREATE INDEX IF NOT EXISTS conversations_instance_id_idx ON public.conversations (instance_id);
+CREATE INDEX IF NOT EXISTS messages_chat_company_id_idx ON public.messages_chat (company_id);
+CREATE INDEX IF NOT EXISTS messages_chat_conversation_id_idx ON public.messages_chat (conversation_id);
+CREATE INDEX IF NOT EXISTS messages_chat_instance_id_idx ON public.messages_chat (instance_id);
+CREATE INDEX IF NOT EXISTS messages_chat_sent_at_idx ON public.messages_chat (sent_at DESC);
+
+-- Function and triggers to maintain updated_at fields
+CREATE OR REPLACE FUNCTION public.handle_updated_at()
+RETURNS trigger AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS handle_updated_at ON public.instance;
+CREATE TRIGGER handle_updated_at
+BEFORE UPDATE ON public.instance
+FOR EACH ROW
+EXECUTE FUNCTION public.handle_updated_at();
+
+DROP TRIGGER IF EXISTS handle_updated_at ON public.contacts;
+CREATE TRIGGER handle_updated_at
+BEFORE UPDATE ON public.contacts
+FOR EACH ROW
+EXECUTE FUNCTION public.handle_updated_at();
+
+DROP TRIGGER IF EXISTS handle_updated_at ON public.conversations;
+CREATE TRIGGER handle_updated_at
+BEFORE UPDATE ON public.conversations
+FOR EACH ROW
+EXECUTE FUNCTION public.handle_updated_at();
+
+DROP TRIGGER IF EXISTS handle_updated_at ON public.messages_chat;
+CREATE TRIGGER handle_updated_at
+BEFORE UPDATE ON public.messages_chat
+FOR EACH ROW
+EXECUTE FUNCTION public.handle_updated_at();
+
+-- Daily aggregation view for dashboard charts (replaces legacy table)
+CREATE OR REPLACE VIEW public.crm_message_daily_metrics AS
+SELECT
+  company_id,
+  (date_trunc('day', sent_at))::date AS message_date,
+  COUNT(*)::bigint AS message_count
+FROM public.messages_chat
+GROUP BY company_id, (date_trunc('day', sent_at))::date;
+
+-- Enable Row Level Security for omnichannel tables
+ALTER TABLE public.instance ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.contacts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.conversations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.messages_chat ENABLE ROW LEVEL SECURITY;
+
+-- Instance policies scoped by company ownership
+DROP POLICY IF EXISTS instance_select_own ON public.instance;
+CREATE POLICY instance_select_own ON public.instance
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.company
+      WHERE company.id = instance.company_id
+        AND company.user_id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS instance_write_own ON public.instance;
+CREATE POLICY instance_write_own ON public.instance
+  FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.company
+      WHERE company.id = instance.company_id
+        AND company.user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.company
+      WHERE company.id = instance.company_id
+        AND company.user_id = auth.uid()
+    )
+  );
+
+-- Contacts policies
+DROP POLICY IF EXISTS contacts_select_own ON public.contacts;
+CREATE POLICY contacts_select_own ON public.contacts
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.company
+      WHERE company.id = contacts.company_id
+        AND company.user_id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS contacts_write_own ON public.contacts;
+CREATE POLICY contacts_write_own ON public.contacts
+  FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.company
+      WHERE company.id = contacts.company_id
+        AND company.user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.company
+      WHERE company.id = contacts.company_id
+        AND company.user_id = auth.uid()
+    )
+  );
+
+-- Conversations policies
+DROP POLICY IF EXISTS conversations_select_own ON public.conversations;
+CREATE POLICY conversations_select_own ON public.conversations
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.company
+      WHERE company.id = conversations.company_id
+        AND company.user_id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS conversations_write_own ON public.conversations;
+CREATE POLICY conversations_write_own ON public.conversations
+  FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.company
+      WHERE company.id = conversations.company_id
+        AND company.user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.company
+      WHERE company.id = conversations.company_id
+        AND company.user_id = auth.uid()
+    )
+  );
+
+-- Messages policies
+DROP POLICY IF EXISTS messages_chat_select_own ON public.messages_chat;
+CREATE POLICY messages_chat_select_own ON public.messages_chat
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.company
+      WHERE company.id = messages_chat.company_id
+        AND company.user_id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS messages_chat_write_own ON public.messages_chat;
+CREATE POLICY messages_chat_write_own ON public.messages_chat
+  FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.company
+      WHERE company.id = messages_chat.company_id
+        AND company.user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.company
+      WHERE company.id = messages_chat.company_id
+        AND company.user_id = auth.uid()
+    )
+  );


### PR DESCRIPTION
## Summary
- preservar a tabela agregada `public.messages` e criar o novo armazenamento transacional `public.messages_chat`, ajustando índices, gatilhos, view e políticas de RLS
- alinhar o arquivo base `migration.sql` e a documentação (README, CRM, Segurança, Branding e instruções para agentes) com a distinção entre `messages` e `messages_chat`
- fazer o dashboard voltar a consumir a tabela legada `messages` enquanto o novo conjunto `messages_chat` alimenta a view agregada

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2ba383d448333b5bd03440fe0143b