### PR TITLE
Embed Chatwoot CRM inside dashboard

### DIFF
--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -23,7 +23,6 @@ import {
   MessageSquare,
   BookOpen,
 } from 'lucide-react';
-import { toast } from 'sonner';
 import { MAX_AGENTS_PER_COMPANY } from '@/lib/constants';
 import { cn } from './utils';
 import type { Session } from '@supabase/supabase-js';
@@ -184,19 +183,8 @@ export function Sidebar({ className }: { className?: string }) {
     router.replace('/login');
   };
 
-  const handleChatwoot = async () => {
-    try {
-      const res = await fetch('/api/chatwoot/sso');
-      const data = await res.json().catch(() => null);
-      if (!res.ok || !data?.url) {
-        console.error('[Chatwoot SSO] Endpoint error', res.status, data);
-        throw new Error();
-      }
-      window.open(data.url, '_blank', 'noopener,noreferrer');
-    } catch (err) {
-      console.error('[Chatwoot SSO] Failed to open CRM', err);
-      toast('SSO indisponível, tente novamente mais tarde');
-    }
+  const handleChatwoot = () => {
+    router.push('/dashboard/crm');
   };
 
   useEffect(() => {
@@ -372,20 +360,9 @@ export function MobileSidebar() {
     router.replace('/login');
   };
 
-  const handleChatwoot = async () => {
-    try {
-      const res = await fetch('/api/chatwoot/sso');
-      const data = await res.json().catch(() => null);
-      if (!res.ok || !data?.url) {
-        console.error('[Chatwoot SSO] Endpoint error', res.status, data);
-        throw new Error();
-      }
-      setOpen(false);
-      window.open(data.url, '_blank', 'noopener,noreferrer');
-    } catch (err) {
-      console.error('[Chatwoot SSO] Failed to open CRM', err);
-      toast('SSO indisponível, tente novamente mais tarde');
-    }
+  const handleChatwoot = () => {
+    setOpen(false);
+    router.push('/dashboard/crm');
   };
 
   return (

--- a/src/app/dashboard/crm/page.tsx
+++ b/src/app/dashboard/crm/page.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useEffect, useState, type ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+import { Loader2 } from "lucide-react";
+
+const DEFAULT_ERROR_MESSAGE =
+  "Não foi possível carregar o CRM agora. Tente novamente em instantes.";
+
+type CrmState =
+  | { status: "loading" }
+  | { status: "ready"; url: string }
+  | { status: "error"; message: string };
+
+export default function DashboardCrmPage() {
+  const [state, setState] = useState<CrmState>({ status: "loading" });
+  const [reloadCount, setReloadCount] = useState(0);
+
+  useEffect(() => {
+    let active = true;
+
+    const fetchSsoUrl = async () => {
+      setState({ status: "loading" });
+      try {
+        const response = await fetch("/api/chatwoot/sso");
+        if (!active) return;
+
+        if (!response.ok) {
+          const data = (await response.json().catch(() => null)) as
+            | { error?: string }
+            | null;
+          setState({
+            status: "error",
+            message: data?.error || DEFAULT_ERROR_MESSAGE,
+          });
+          return;
+        }
+
+        const data = (await response.json().catch(() => null)) as
+          | { url?: string }
+          | null;
+
+        if (!active) return;
+
+        if (!data?.url) {
+          setState({ status: "error", message: DEFAULT_ERROR_MESSAGE });
+          return;
+        }
+
+        setState({ status: "ready", url: data.url });
+      } catch (error) {
+        if (!active) return;
+        console.error("[CRM] Falha ao carregar SSO do Chatwoot", error);
+        setState({ status: "error", message: DEFAULT_ERROR_MESSAGE });
+      }
+    };
+
+    void fetchSsoUrl();
+
+    return () => {
+      active = false;
+    };
+  }, [reloadCount]);
+
+  const handleReload = () => setReloadCount((count) => count + 1);
+
+  let content: ReactNode;
+  if (state.status === "ready") {
+    content = (
+      <iframe
+        key={state.url}
+        src={state.url}
+        title="CRM Evoluke"
+        className="h-full w-full"
+        allow="camera; microphone; clipboard-read; clipboard-write"
+      />
+    );
+  } else if (state.status === "loading") {
+    content = (
+      <div className="flex h-full min-h-[60vh] flex-col items-center justify-center gap-3 p-6 text-center text-sm text-gray-600">
+        <Loader2 className="h-6 w-6 animate-spin text-[#2F6F68]" />
+        <p>Conectando com o CRM...</p>
+      </div>
+    );
+  } else {
+    content = (
+      <div className="flex h-full min-h-[60vh] flex-col items-center justify-center gap-4 p-6 text-center text-sm text-gray-600">
+        <p>{state.message}</p>
+        <Button onClick={handleReload}>Tentar novamente</Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold text-gray-900">CRM Evoluke</h1>
+        <p className="text-sm text-gray-600">
+          Centralize os atendimentos do Chatwoot sem sair da plataforma.
+        </p>
+      </header>
+      <div className="flex-1 overflow-hidden rounded-lg border bg-white">{content}</div>
+    </div>
+  );
+}

--- a/src/app/dashboard/documentacao/page.tsx
+++ b/src/app/dashboard/documentacao/page.tsx
@@ -59,7 +59,7 @@ const documentationSections: DocumentationSection[] = [
         title: "Conectando ao WhatsApp",
         description: "Passo a passo para conectar ao WhatsApp.",
         body: [
-          "Clique em \"CRM\" na barra lateral, assim você será redirecionado para nosso CRM.",
+          "Clique em \"CRM\" na barra lateral para abrir o CRM diretamente dentro da plataforma.",
           "Acesse o menu de Conversas e clique na conversa \"Integração Whatsapp\".",
           "Terá uma mensagem assim \"QRCode gerado com sucesso!\" e uma imagem com o QRCode.",
           "Com o celular em mãos, abra o aplicativo do WhatsApp e toque em \"Aparelhos conectados\" no menu de configurações.",
@@ -111,7 +111,7 @@ const documentationSections: DocumentationSection[] = [
         description: "Como habilitar o acesso ao Chatwoot.",
         body: [
           "Na seção de Configuração informe o identificador do seu workspace no Chatwoot para habilitar o atalho direto no menu.",
-          "Ao clicar em CRM na barra lateral abriremos o Chatwoot em uma nova aba utilizando SSO. Garanta que o usuário tenha permissões válidas.",
+          "Ao clicar em CRM na barra lateral abriremos o Chatwoot embutido na plataforma utilizando SSO. Garanta que o usuário tenha permissões válidas.",
           "Caso o acesso falhe, verifique as credenciais configuradas e tente novamente após alguns minutos.",
         ],
       },


### PR DESCRIPTION
## Summary
- add a dashboard CRM page that loads the Chatwoot session inside the app with loading and retry states
- route the CRM action in the sidebar (desktop and mobile) to the embedded experience
- update the in-app documentation to reflect the new embedded CRM flow

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5c1f272008333bf2f0f83a3f601cb