### PR TITLE
feat: add sales pipeline board

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,5 +12,9 @@ Estas orientações se aplicam a todo o repositório `agent-plugandplay`.
 - Atualize documentação relevante (por exemplo, arquivos em `docs/` ou `README.md`) sempre que fizer mudanças que afetem o comportamento observado pelo usuário.
 - Ao modificar arquivos Markdown, utilize títulos em português e mantenha uma estrutura coerente com o restante do projeto.
 
+## CRM
+- As novas rotas do funil de vendas dependem das tabelas `pipeline`, `stage` e `card`. Sempre sincronize alterações no frontend com as APIs e migrations correspondentes.
+- Lembre-se de validar arrastos e operações de drag and drop com mensagens de erro claras para o usuário final.
+
 ## Mensagens de PR
 - Estruture a mensagem de PR com um resumo em tópicos e uma seção de testes, mencionando cada comando executado.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ Este repositório contém uma aplicação [Next.js](https://nextjs.org/) prepara
 
 > O fluxo do N8N deve validar o token enviado no header `Authorization` antes de aceitar o upload.
 
+## 🧭 Funil de vendas
+
+O painel lateral agora inclui a página **Funil de vendas**, construída sobre um board Kanban para organizar oportunidades comerciais.
+
+- **Funis**: é possível criar, renomear e excluir funis vinculados à empresa logada.
+- **Estágios**: cada funil pode receber estágios personalizados, com suporte a edição e remoção.
+- **Oportunidades**: arraste cartões entre colunas para acompanhar o progresso, registre valores estimados e mantenha notas rápidas.
+
+As alterações são persistidas no Supabase por meio das tabelas `pipeline`, `stage` e `card`, permitindo múltiplos funis por conta e controle de acesso via RLS.
+
 ## 🔗 Links Úteis
 
 - [Next.js](https://nextjs.org/docs)

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -22,6 +22,7 @@ import {
   Menu,
   MessageSquare,
   BookOpen,
+  Kanban,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { MAX_AGENTS_PER_COMPANY } from '@/lib/constants';
@@ -43,6 +44,7 @@ const mainItem: NavItem = {
 const navItems: NavItem[] = [
   { label: 'Pagamentos', href: '/dashboard/payments', icon: <CreditCard size={20} /> },
   { label: 'Configuração', href: '/dashboard/config', icon: <Settings size={20} /> },
+  { label: 'Funil de vendas', href: '/dashboard/funil-de-vendas', icon: <Kanban size={20} /> },
   { label: 'Documentação', href: '/dashboard/documentacao', icon: <BookOpen size={20} /> },
   { label: 'Suporte', href: '/dashboard/support', icon: <HelpCircle size={20} /> },
 ];

--- a/docs/BRANDING.md
+++ b/docs/BRANDING.md
@@ -26,3 +26,8 @@ A unidade base de espaçamento segue o padrão do Tailwind CSS (4 px). Organize
 - Utilize a versão em `#2F6F68` sobre fundos claros e a versão branca sobre fundos escuros.
 - Não distorça, rotacione ou altere as cores oficiais.
 
+## Componentes CRM
+- Colunas do funil utilizam cartões brancos com bordas suaves (`border-gray-100`) e raios de 16 px para reforçar a sensação de módulo.
+- Badges de status seguem as cores `emerald`, `amber` e `rose` em tons claros; mantenha texto em alta legibilidade com contraste mínimo de 4.5:1.
+- Botões de ação secundaria no board utilizam o estilo `ghost` com ícones de 16 px para sinalizar edição ou exclusão sem poluir o layout.
+

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -11,6 +11,8 @@ Rotas atuais que dependem do `supabaseadmin`:
 - `/api/support/new`
 - `/api/payments/pay`
 - `/api/payments/client`
+- `/api/pipelines`
+  - Endpoints REST que criam, editam e removem funis, estágios e cartões. Cada chamada precisa validar a empresa ativa antes de acessar as tabelas `pipeline`, `stage` e `card`.
 
 ## Tabelas críticas e políticas de RLS
 As seguintes tabelas requerem políticas de Row Level Security para garantir o isolamento por empresa/usuário:
@@ -22,5 +24,6 @@ As seguintes tabelas requerem políticas de Row Level Security para garantir o i
 | `agent_personality`, `agent_behavior`, `agent_onboarding`, `agent_specific_instructions`, `agent_knowledge_files` | Acesso restrito via relação com `agents.company_id` do usuário |
 | `payments` | Acesso apenas para registros com `company_id` pertencente ao usuário |
 | `tickets` | Acesso apenas para registros com `company_id` pertencente ao usuário |
+| `pipeline`, `stage`, `card` | Leituras e escritas condicionadas à relação com `company.id` do usuário autenticado |
 
 Certifique-se de que o RLS esteja habilitado e que as políticas correspondentes estejam configuradas no Supabase para cada tabela acima.

--- a/docs/crm.md
+++ b/docs/crm.md
@@ -1,0 +1,25 @@
+# CRM e Funil de vendas
+
+## Visão geral
+A página **Funil de vendas** reúne o funil comercial da empresa autenticada. A interface é baseada em um board Kanban com suporte a drag and drop entre colunas.
+
+## Funcionalidades
+- **Funis**: criação, edição e exclusão de funis através da rota `/api/pipelines`.
+- **Estágios**: adição, edição, ordenação e remoção de estágios por funil utilizando `/api/pipelines/:pipelineId/stages`.
+- **Oportunidades**: cartões arrastáveis, com edição inline e remoção pela rota `/api/pipelines/:pipelineId/cards`.
+
+## Estrutura de dados
+Os dados são armazenados nas tabelas Supabase listadas abaixo:
+
+| Tabela | Finalidade |
+| --- | --- |
+| `pipeline` | Identifica funis por empresa (`company_id`). |
+| `stage` | Estágios ordenados (`position`) pertencentes a um funil. |
+| `card` | Oportunidades vinculadas a um estágio, com campos de valor estimado, status e notas. |
+
+Todas as tabelas possuem RLS baseado em `company_id` e são manipuladas via `supabaseadmin` nos endpoints internos.
+
+## Experiência do usuário
+- Metas e indicadores no topo do board exibem volume total, receita estimada e ticket médio do funil selecionado.
+- Botões fantasma com ícones pequenos sinalizam ações rápidas (editar/remover) mantendo foco no conteúdo dos cartões.
+- Estados de carregamento utilizam `Loader2` e feedbacks são exibidos com `toast` do pacote **sonner**.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "agent-plugandplay",
       "version": "0.1.0",
       "dependencies": {
+        "@hello-pangea/dnd": "^18.0.1",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-select": "^2.2.5",
@@ -753,6 +754,23 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
+    },
+    "node_modules/@hello-pangea/dnd": {
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/@hello-pangea/dnd/-/dnd-18.0.1.tgz",
+      "integrity": "sha512-xojVWG8s/TGrKT1fC8K2tIWeejJYTAeJuj36zM//yEm/ZrnZUSFGS15BpO+jGZT1ybWvyXmeDJwPYb4dhWlbZQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.26.7",
+        "css-box-model": "^1.2.1",
+        "raf-schd": "^4.0.3",
+        "react-redux": "^9.2.0",
+        "redux": "^5.0.1"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -3166,6 +3184,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
+    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -4842,6 +4866,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-box-model": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
+      "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
+      "license": "MIT",
+      "dependencies": {
+        "tiny-invariant": "^1.0.6"
       }
     },
     "node_modules/csstype": {
@@ -9444,6 +9477,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/raf-schd": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
+      "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
+      "license": "MIT"
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -9508,6 +9547,29 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-remove-scroll": {
       "version": "2.7.1",
@@ -9677,6 +9739,12 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
       "license": "MIT"
     },
     "node_modules/reflect.getprototypeof": {
@@ -11340,6 +11408,15 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@hello-pangea/dnd": "^18.0.1",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-select": "^2.2.5",

--- a/src/app/api/pipelines/[pipelineId]/cards/[cardId]/route.ts
+++ b/src/app/api/pipelines/[pipelineId]/cards/[cardId]/route.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getUserFromCookie } from '@/lib/auth'
+import { getCompanyIdForUser, getPipelineForCompany } from '@/lib/pipelines'
+import { supabaseadmin } from '@/lib/supabaseAdmin'
+
+type Params = { params: { pipelineId: string; cardId: string } }
+
+export async function PATCH(req: NextRequest, { params }: Params) {
+  const { pipelineId, cardId } = params
+  const { user, error } = await getUserFromCookie()
+  if (error || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { data: company, error: companyError } = await getCompanyIdForUser(user.id)
+  if (companyError || !company) {
+    return NextResponse.json({ error: 'Company not found' }, { status: 404 })
+  }
+
+  const { data: pipeline, error: pipelineError } = await getPipelineForCompany(pipelineId, company.id)
+  if (pipelineError || !pipeline) {
+    return NextResponse.json({ error: 'Funil não encontrado.' }, { status: 404 })
+  }
+
+  const body = await req.json().catch(() => null)
+  if (!body || typeof body !== 'object') {
+    return NextResponse.json({ error: 'Nenhuma alteração enviada.' }, { status: 400 })
+  }
+
+  const payload: Record<string, unknown> = { updated_at: new Date().toISOString() }
+  if (body.title) payload.title = String(body.title).trim()
+  if ('companyName' in body) payload.company_name = body.companyName?.trim?.() || null
+  if ('owner' in body) payload.owner = body.owner?.trim?.() || null
+  if ('plan' in body) payload.plan = body.plan?.trim?.() || null
+  if ('status' in body) payload.status = body.status?.trim?.() || null
+  if ('estimatedValue' in body) {
+    payload.estimated_value = typeof body.estimatedValue === 'number' ? body.estimatedValue : null
+  }
+  if ('messagesCount' in body) {
+    payload.messages_count = typeof body.messagesCount === 'number' ? body.messagesCount : 0
+  }
+  if ('lastInteractionAt' in body) payload.last_interaction_at = body.lastInteractionAt || null
+  if ('nextActionAt' in body) payload.next_action_at = body.nextActionAt || null
+  if ('note' in body) payload.note = body.note?.trim?.() || null
+
+  if (Object.keys(payload).length === 1) {
+    return NextResponse.json({ error: 'Nenhuma alteração válida enviada.' }, { status: 400 })
+  }
+
+  const { data: updated, error: updateError } = await supabaseadmin
+    .from('card')
+    .update(payload)
+    .eq('id', cardId)
+    .eq('company_id', company.id)
+    .select(
+      'id, title, company_name, owner, plan, status, estimated_value, messages_count, last_interaction_at, next_action_at, note, position, created_at, updated_at, stage_id'
+    )
+    .maybeSingle()
+
+  if (updateError) {
+    return NextResponse.json({ error: updateError.message }, { status: 500 })
+  }
+
+  if (!updated) {
+    return NextResponse.json({ error: 'Oportunidade não encontrada.' }, { status: 404 })
+  }
+
+  return NextResponse.json(updated)
+}
+
+export async function DELETE(_req: NextRequest, { params }: Params) {
+  const { pipelineId, cardId } = params
+  const { user, error } = await getUserFromCookie()
+  if (error || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { data: company, error: companyError } = await getCompanyIdForUser(user.id)
+  if (companyError || !company) {
+    return NextResponse.json({ error: 'Company not found' }, { status: 404 })
+  }
+
+  const { data: pipeline, error: pipelineError } = await getPipelineForCompany(pipelineId, company.id)
+  if (pipelineError || !pipeline) {
+    return NextResponse.json({ error: 'Funil não encontrado.' }, { status: 404 })
+  }
+
+  const { error: deleteError } = await supabaseadmin
+    .from('card')
+    .delete()
+    .eq('id', cardId)
+    .eq('company_id', company.id)
+
+  if (deleteError) {
+    return NextResponse.json({ error: deleteError.message }, { status: 500 })
+  }
+
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/pipelines/[pipelineId]/cards/route.ts
+++ b/src/app/api/pipelines/[pipelineId]/cards/route.ts
@@ -1,0 +1,183 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getUserFromCookie } from '@/lib/auth'
+import { getCompanyIdForUser, getPipelineForCompany, getStagesForPipeline } from '@/lib/pipelines'
+import { supabaseadmin } from '@/lib/supabaseAdmin'
+
+type Params = { params: { pipelineId: string } }
+
+export async function POST(req: NextRequest, { params }: Params) {
+  const { pipelineId } = params
+  const { user, error } = await getUserFromCookie()
+  if (error || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { data: company, error: companyError } = await getCompanyIdForUser(user.id)
+  if (companyError || !company) {
+    return NextResponse.json({ error: 'Company not found' }, { status: 404 })
+  }
+
+  const { data: pipeline, error: pipelineError } = await getPipelineForCompany(pipelineId, company.id)
+  if (pipelineError || !pipeline) {
+    return NextResponse.json({ error: 'Funil não encontrado.' }, { status: 404 })
+  }
+
+  const body = await req.json().catch(() => null)
+  const stageId: string | undefined = body?.stageId
+  const title: string | undefined = body?.title?.trim?.()
+
+  if (!stageId || !title) {
+    return NextResponse.json({ error: 'Estágio e título são obrigatórios.' }, { status: 400 })
+  }
+
+  const { data: stages } = await getStagesForPipeline([stageId], pipeline.id, company.id)
+  const stage = stages?.[0]
+  if (!stage) {
+    return NextResponse.json({ error: 'Estágio inválido.' }, { status: 400 })
+  }
+
+  const { data: lastCard } = await supabaseadmin
+    .from('card')
+    .select('position')
+    .eq('stage_id', stage.id)
+    .order('position', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  const position = typeof lastCard?.position === 'number' ? lastCard.position + 1 : 0
+  const now = new Date().toISOString()
+
+  const { data, error: insertError } = await supabaseadmin
+    .from('card')
+    .insert({
+      stage_id: stage.id,
+      company_id: company.id,
+      title,
+      company_name: body?.companyName?.trim?.() || null,
+      owner: body?.owner?.trim?.() || null,
+      plan: body?.plan?.trim?.() || null,
+      status: body?.status?.trim?.() || 'Ativo',
+      estimated_value: typeof body?.estimatedValue === 'number' ? body.estimatedValue : null,
+      messages_count: typeof body?.messagesCount === 'number' ? body.messagesCount : 0,
+      last_interaction_at: body?.lastInteractionAt || null,
+      next_action_at: body?.nextActionAt || null,
+      note: body?.note?.trim?.() || null,
+      position,
+      created_at: now,
+      updated_at: now,
+    })
+    .select(
+      'id, title, company_name, owner, plan, status, estimated_value, messages_count, last_interaction_at, next_action_at, note, position, created_at, updated_at, stage_id'
+    )
+    .single()
+
+  if (insertError || !data) {
+    return NextResponse.json({ error: insertError?.message ?? 'Erro ao criar oportunidade' }, { status: 500 })
+  }
+
+  return NextResponse.json(data)
+}
+
+export async function PATCH(req: NextRequest, { params }: Params) {
+  const { pipelineId } = params
+  const { user, error } = await getUserFromCookie()
+  if (error || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { data: company, error: companyError } = await getCompanyIdForUser(user.id)
+  if (companyError || !company) {
+    return NextResponse.json({ error: 'Company not found' }, { status: 404 })
+  }
+
+  const { data: pipeline, error: pipelineError } = await getPipelineForCompany(pipelineId, company.id)
+  if (pipelineError || !pipeline) {
+    return NextResponse.json({ error: 'Funil não encontrado.' }, { status: 404 })
+  }
+
+  const body = await req.json().catch(() => null)
+  const cardId: string | undefined = body?.cardId
+  const sourceStageId: string | undefined = body?.sourceStageId
+  const destinationStageId: string | undefined = body?.destinationStageId
+  const destinationIndex: number | undefined = typeof body?.destinationIndex === 'number' ? body.destinationIndex : undefined
+
+  if (!cardId || !sourceStageId || !destinationStageId || typeof destinationIndex !== 'number') {
+    return NextResponse.json({ error: 'Dados insuficientes para reordenar.' }, { status: 400 })
+  }
+
+  const stageIds = sourceStageId === destinationStageId ? [sourceStageId] : [sourceStageId, destinationStageId]
+  const { data: stages, error: stagesError } = await getStagesForPipeline(stageIds, pipeline.id, company.id)
+  if (stagesError) {
+    return NextResponse.json({ error: stagesError.message }, { status: 500 })
+  }
+
+  if (!stages || stages.length !== stageIds.length) {
+    return NextResponse.json({ error: 'Estágios inválidos para este funil.' }, { status: 400 })
+  }
+
+  const { data: card, error: cardError } = await supabaseadmin
+    .from('card')
+    .select('id, stage_id, company_id')
+    .eq('id', cardId)
+    .eq('company_id', company.id)
+    .single()
+
+  if (cardError || !card) {
+    return NextResponse.json({ error: 'Oportunidade não encontrada.' }, { status: 404 })
+  }
+
+  if (card.stage_id !== sourceStageId) {
+    return NextResponse.json({ error: 'Oportunidade fora do estágio informado.' }, { status: 400 })
+  }
+
+  const { data: cardsData, error: cardsError } = await supabaseadmin
+    .from('card')
+    .select('id, stage_id')
+    .in('stage_id', stageIds)
+    .eq('company_id', company.id)
+    .order('position', { ascending: true })
+
+  if (cardsError) {
+    return NextResponse.json({ error: cardsError.message }, { status: 500 })
+  }
+
+  const map = new Map<string, { id: string; stage_id: string }[]>()
+  for (const stageId of stageIds) {
+    map.set(stageId, [])
+  }
+  for (const item of cardsData ?? []) {
+    const list = map.get(item.stage_id)
+    if (list) list.push(item)
+  }
+
+  const sourceList = map.get(sourceStageId) ?? []
+  const destinationList = map.get(destinationStageId) ?? []
+
+  const currentIndex = sourceList.findIndex((item) => item.id === cardId)
+  if (currentIndex === -1) {
+    return NextResponse.json({ error: 'A ordem atual do estágio está desatualizada.' }, { status: 409 })
+  }
+
+  const [moved] = sourceList.splice(currentIndex, 1)
+  moved.stage_id = destinationStageId
+
+  const targetIndex = Math.max(0, Math.min(destinationIndex, destinationList.length))
+  destinationList.splice(targetIndex, 0, moved)
+
+  const now = new Date().toISOString()
+  const updates: { id: string; stage_id: string; position: number; updated_at: string }[] = []
+
+  sourceList.forEach((item, index) => {
+    updates.push({ id: item.id, stage_id: sourceStageId, position: index, updated_at: now })
+  })
+  destinationList.forEach((item, index) => {
+    updates.push({ id: item.id, stage_id: destinationStageId, position: index, updated_at: now })
+  })
+
+  const { error: updateError } = await supabaseadmin.from('card').upsert(updates, { onConflict: 'id' })
+  if (updateError) {
+    return NextResponse.json({ error: updateError.message }, { status: 500 })
+  }
+
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/pipelines/[pipelineId]/route.ts
+++ b/src/app/api/pipelines/[pipelineId]/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getUserFromCookie } from '@/lib/auth'
+import { getCompanyIdForUser, getPipelineForCompany } from '@/lib/pipelines'
+import { supabaseadmin } from '@/lib/supabaseAdmin'
+
+type Params = { params: { pipelineId: string } }
+
+export async function PATCH(req: NextRequest, { params }: Params) {
+  const { pipelineId } = params
+  const { user, error } = await getUserFromCookie()
+  if (error || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { data: company, error: companyError } = await getCompanyIdForUser(user.id)
+  if (companyError || !company) {
+    return NextResponse.json({ error: 'Company not found' }, { status: 404 })
+  }
+
+  const { data: pipeline, error: pipelineError } = await getPipelineForCompany(pipelineId, company.id)
+  if (pipelineError || !pipeline) {
+    return NextResponse.json({ error: 'Funil não encontrado.' }, { status: 404 })
+  }
+
+  const body = await req.json().catch(() => null)
+  const name: string | undefined = body?.name?.trim?.()
+  const description: string | undefined = body?.description?.trim?.()
+
+  if (!name && typeof description === 'undefined') {
+    return NextResponse.json({ error: 'Nenhuma alteração enviada.' }, { status: 400 })
+  }
+
+  const payload: Record<string, unknown> = { updated_at: new Date().toISOString() }
+  if (name) payload.name = name
+  if (typeof description !== 'undefined') {
+    payload.description = description || null
+  }
+
+  const { data: updated, error: updateError } = await supabaseadmin
+    .from('pipeline')
+    .update(payload)
+    .eq('id', pipeline.id)
+    .select('id, name, description, created_at, updated_at')
+    .single()
+
+  if (updateError || !updated) {
+    return NextResponse.json({ error: updateError?.message ?? 'Erro ao atualizar funil' }, { status: 500 })
+  }
+
+  return NextResponse.json(updated)
+}
+
+export async function DELETE(_req: NextRequest, { params }: Params) {
+  const { pipelineId } = params
+  const { user, error } = await getUserFromCookie()
+  if (error || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { data: company, error: companyError } = await getCompanyIdForUser(user.id)
+  if (companyError || !company) {
+    return NextResponse.json({ error: 'Company not found' }, { status: 404 })
+  }
+
+  const { data: pipeline, error: pipelineError } = await getPipelineForCompany(pipelineId, company.id)
+  if (pipelineError || !pipeline) {
+    return NextResponse.json({ error: 'Funil não encontrado.' }, { status: 404 })
+  }
+
+  const { error: deleteError } = await supabaseadmin.from('pipeline').delete().eq('id', pipeline.id)
+  if (deleteError) {
+    return NextResponse.json({ error: deleteError.message }, { status: 500 })
+  }
+
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/pipelines/[pipelineId]/stages/[stageId]/route.ts
+++ b/src/app/api/pipelines/[pipelineId]/stages/[stageId]/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getUserFromCookie } from '@/lib/auth'
+import { getCompanyIdForUser, getPipelineForCompany, getStagesForPipeline } from '@/lib/pipelines'
+import { supabaseadmin } from '@/lib/supabaseAdmin'
+
+type Params = { params: { pipelineId: string; stageId: string } }
+
+export async function PATCH(req: NextRequest, { params }: Params) {
+  const { pipelineId, stageId } = params
+  const { user, error } = await getUserFromCookie()
+  if (error || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { data: company, error: companyError } = await getCompanyIdForUser(user.id)
+  if (companyError || !company) {
+    return NextResponse.json({ error: 'Company not found' }, { status: 404 })
+  }
+
+  const { data: pipeline, error: pipelineError } = await getPipelineForCompany(pipelineId, company.id)
+  if (pipelineError || !pipeline) {
+    return NextResponse.json({ error: 'Funil não encontrado.' }, { status: 404 })
+  }
+
+  const { data: stages } = await getStagesForPipeline([stageId], pipeline.id, company.id)
+  const stage = stages?.[0]
+  if (!stage) {
+    return NextResponse.json({ error: 'Estágio não encontrado.' }, { status: 404 })
+  }
+
+  const body = await req.json().catch(() => null)
+  const name: string | undefined = body?.name?.trim?.()
+  const position: number | undefined = typeof body?.position === 'number' ? body.position : undefined
+
+  if (!name && typeof position === 'undefined') {
+    return NextResponse.json({ error: 'Nenhuma alteração enviada.' }, { status: 400 })
+  }
+
+  const payload: Record<string, unknown> = { updated_at: new Date().toISOString() }
+  if (name) payload.name = name
+  if (typeof position === 'number') payload.position = position
+
+  const { data: updated, error: updateError } = await supabaseadmin
+    .from('stage')
+    .update(payload)
+    .eq('id', stage.id)
+    .select('id, name, position, created_at, updated_at')
+    .single()
+
+  if (updateError || !updated) {
+    return NextResponse.json({ error: updateError?.message ?? 'Erro ao atualizar estágio' }, { status: 500 })
+  }
+
+  return NextResponse.json(updated)
+}
+
+export async function DELETE(_req: NextRequest, { params }: Params) {
+  const { pipelineId, stageId } = params
+  const { user, error } = await getUserFromCookie()
+  if (error || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { data: company, error: companyError } = await getCompanyIdForUser(user.id)
+  if (companyError || !company) {
+    return NextResponse.json({ error: 'Company not found' }, { status: 404 })
+  }
+
+  const { data: pipeline, error: pipelineError } = await getPipelineForCompany(pipelineId, company.id)
+  if (pipelineError || !pipeline) {
+    return NextResponse.json({ error: 'Funil não encontrado.' }, { status: 404 })
+  }
+
+  const { data: stages } = await getStagesForPipeline([stageId], pipeline.id, company.id)
+  const stage = stages?.[0]
+  if (!stage) {
+    return NextResponse.json({ error: 'Estágio não encontrado.' }, { status: 404 })
+  }
+
+  const { error: deleteError } = await supabaseadmin.from('stage').delete().eq('id', stage.id)
+  if (deleteError) {
+    return NextResponse.json({ error: deleteError.message }, { status: 500 })
+  }
+
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/pipelines/[pipelineId]/stages/route.ts
+++ b/src/app/api/pipelines/[pipelineId]/stages/route.ts
@@ -1,0 +1,106 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getUserFromCookie } from '@/lib/auth'
+import { getCompanyIdForUser, getPipelineForCompany, getStagesForPipeline } from '@/lib/pipelines'
+import { supabaseadmin } from '@/lib/supabaseAdmin'
+
+type Params = { params: { pipelineId: string } }
+
+export async function POST(req: NextRequest, { params }: Params) {
+  const { pipelineId } = params
+  const { user, error } = await getUserFromCookie()
+  if (error || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { data: company, error: companyError } = await getCompanyIdForUser(user.id)
+  if (companyError || !company) {
+    return NextResponse.json({ error: 'Company not found' }, { status: 404 })
+  }
+
+  const { data: pipeline, error: pipelineError } = await getPipelineForCompany(pipelineId, company.id)
+  if (pipelineError || !pipeline) {
+    return NextResponse.json({ error: 'Funil não encontrado.' }, { status: 404 })
+  }
+
+  const body = await req.json().catch(() => null)
+  const name: string = body?.name?.trim()
+  if (!name) {
+    return NextResponse.json({ error: 'O nome do estágio é obrigatório.' }, { status: 400 })
+  }
+
+  const { data: lastStage } = await supabaseadmin
+    .from('stage')
+    .select('position')
+    .eq('pipeline_id', pipeline.id)
+    .order('position', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  const position = typeof lastStage?.position === 'number' ? lastStage.position + 1 : 0
+  const now = new Date().toISOString()
+
+  const { data, error: insertError } = await supabaseadmin
+    .from('stage')
+    .insert({
+      name,
+      pipeline_id: pipeline.id,
+      company_id: company.id,
+      position,
+      created_at: now,
+      updated_at: now,
+    })
+    .select('id, name, position, created_at, updated_at')
+    .single()
+
+  if (insertError || !data) {
+    return NextResponse.json({ error: insertError?.message ?? 'Erro ao criar estágio' }, { status: 500 })
+  }
+
+  return NextResponse.json({ ...data, cards: [] })
+}
+
+export async function PATCH(req: NextRequest, { params }: Params) {
+  const { pipelineId } = params
+  const { user, error } = await getUserFromCookie()
+  if (error || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { data: company, error: companyError } = await getCompanyIdForUser(user.id)
+  if (companyError || !company) {
+    return NextResponse.json({ error: 'Company not found' }, { status: 404 })
+  }
+
+  const { data: pipeline, error: pipelineError } = await getPipelineForCompany(pipelineId, company.id)
+  if (pipelineError || !pipeline) {
+    return NextResponse.json({ error: 'Funil não encontrado.' }, { status: 404 })
+  }
+
+  const body = await req.json().catch(() => null)
+  const order: string[] | undefined = Array.isArray(body?.order) ? body.order : undefined
+  if (!order || order.length === 0) {
+    return NextResponse.json({ error: 'Envie a nova ordem dos estágios.' }, { status: 400 })
+  }
+
+  const { data: stages, error: stagesError } = await getStagesForPipeline(order, pipeline.id, company.id)
+  if (stagesError) {
+    return NextResponse.json({ error: stagesError.message }, { status: 500 })
+  }
+
+  if (!stages || stages.length !== order.length) {
+    return NextResponse.json({ error: 'Alguns estágios não pertencem a este funil.' }, { status: 400 })
+  }
+
+  const updates = order.map((stageId, index) => ({
+    id: stageId,
+    position: index,
+    updated_at: new Date().toISOString(),
+  }))
+
+  const { error: updateError } = await supabaseadmin.from('stage').upsert(updates, { onConflict: 'id' })
+  if (updateError) {
+    return NextResponse.json({ error: updateError.message }, { status: 500 })
+  }
+
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/pipelines/route.ts
+++ b/src/app/api/pipelines/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getUserFromCookie } from '@/lib/auth'
+import { getCompanyIdForUser } from '@/lib/pipelines'
+import { supabaseadmin } from '@/lib/supabaseAdmin'
+
+export async function GET() {
+  const { user, error } = await getUserFromCookie()
+  if (error || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { data: company, error: companyError } = await getCompanyIdForUser(user.id)
+  if (companyError || !company) {
+    return NextResponse.json({ error: 'Company not found' }, { status: 404 })
+  }
+
+  const { data, error: dbError } = await supabaseadmin
+    .from('pipeline')
+    .select(
+      `id, name, description, created_at, updated_at,
+        stages:stage(
+          id, name, position, created_at, updated_at,
+          cards:card(
+            id, stage_id, title, company_name, owner, plan, status,
+            estimated_value, messages_count, last_interaction_at,
+            next_action_at, note, position, created_at, updated_at
+          )
+        )`
+    )
+    .eq('company_id', company.id)
+    .order('created_at', { ascending: true })
+    .order('position', { referencedTable: 'stage', ascending: true })
+    .order('position', { referencedTable: 'stage.card', ascending: true })
+
+  if (dbError) {
+    return NextResponse.json({ error: dbError.message }, { status: 500 })
+  }
+
+  return NextResponse.json(data ?? [])
+}
+
+export async function POST(req: NextRequest) {
+  const { user, error } = await getUserFromCookie()
+  if (error || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { data: company, error: companyError } = await getCompanyIdForUser(user.id)
+  if (companyError || !company) {
+    return NextResponse.json({ error: 'Company not found' }, { status: 404 })
+  }
+
+  const body = await req.json().catch(() => null)
+  const name: string = body?.name?.trim()
+  const description: string | undefined = body?.description?.trim?.()
+
+  if (!name) {
+    return NextResponse.json({ error: 'O nome do funil é obrigatório.' }, { status: 400 })
+  }
+
+  const now = new Date().toISOString()
+  const { data, error: insertError } = await supabaseadmin
+    .from('pipeline')
+    .insert({
+      name,
+      description: description || null,
+      company_id: company.id,
+      created_at: now,
+      updated_at: now,
+    })
+    .select('id, name, description, created_at, updated_at')
+    .single()
+
+  if (insertError || !data) {
+    return NextResponse.json({ error: insertError?.message ?? 'Erro ao criar funil' }, { status: 500 })
+  }
+
+  return NextResponse.json({ ...data, stages: [] })
+}

--- a/src/app/dashboard/funil-de-vendas/page.tsx
+++ b/src/app/dashboard/funil-de-vendas/page.tsx
@@ -1,0 +1,1166 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import * as Dialog from '@radix-ui/react-dialog'
+import { DragDropContext, Droppable, Draggable, type DropResult } from '@hello-pangea/dnd'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { toast } from 'sonner'
+import {
+  ArrowUpRight,
+  Edit2,
+  Filter,
+  Loader2,
+  MoreHorizontal,
+  Plus,
+  Trash2,
+} from 'lucide-react'
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
+import { cn } from '@/lib/utils'
+
+const currencyFormatter = new Intl.NumberFormat('pt-BR', {
+  style: 'currency',
+  currency: 'BRL',
+  maximumFractionDigits: 0,
+})
+
+type PipelineCard = {
+  id: string
+  stage_id: string
+  title: string
+  company_name: string | null
+  owner: string | null
+  plan: string | null
+  status: string | null
+  estimated_value: number | null
+  messages_count: number
+  last_interaction_at: string | null
+  next_action_at: string | null
+  note: string | null
+  position: number
+  created_at: string
+  updated_at: string
+}
+
+type PipelineStage = {
+  id: string
+  name: string
+  position: number
+  created_at: string
+  updated_at: string
+  cards: PipelineCard[]
+}
+
+type Pipeline = {
+  id: string
+  name: string
+  description: string | null
+  created_at: string
+  updated_at: string
+  stages: PipelineStage[]
+}
+
+type PipelineFormState = {
+  id: string | null
+  name: string
+  description: string
+}
+
+type StageFormState = {
+  id: string | null
+  name: string
+}
+
+type CardFormState = {
+  id: string | null
+  stageId: string | null
+  title: string
+  companyName: string
+  owner: string
+  plan: string
+  status: string
+  estimatedValue: string
+  messagesCount: string
+  note: string
+}
+
+const defaultPipelineForm: PipelineFormState = {
+  id: null,
+  name: '',
+  description: '',
+}
+
+const defaultStageForm: StageFormState = {
+  id: null,
+  name: '',
+}
+
+const defaultCardForm: CardFormState = {
+  id: null,
+  stageId: null,
+  title: '',
+  companyName: '',
+  owner: '',
+  plan: '',
+  status: 'Ativo',
+  estimatedValue: '',
+  messagesCount: '',
+  note: '',
+}
+
+const statusBadges: Record<string, string> = {
+  Ativo: 'bg-emerald-50 text-emerald-700 border border-emerald-100',
+  Risco: 'bg-amber-50 text-amber-700 border border-amber-100',
+  Perdido: 'bg-rose-50 text-rose-700 border border-rose-100',
+}
+
+function normalizeNumeric(value: unknown): number | null {
+  if (value === null || value === undefined) return null
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function normalizeInteger(value: unknown, fallback = 0): number {
+  if (typeof value === 'number' && Number.isFinite(value)) return Math.round(value)
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? Math.round(parsed) : fallback
+}
+
+function parseNumberInput(value: string): number | null {
+  if (!value) return null
+  const parsed = Number(value.replace(/\./g, '').replace(',', '.'))
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function parseIntegerInput(value: string): number {
+  if (!value) return 0
+  const parsed = Number(value.replace(/\./g, '').replace(',', '.'))
+  return Number.isFinite(parsed) ? Math.max(0, Math.round(parsed)) : 0
+}
+
+export default function SalesPipelinePage() {
+  const [pipelines, setPipelines] = useState<Pipeline[]>([])
+  const [selectedPipelineId, setSelectedPipelineId] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [pipelineDialogOpen, setPipelineDialogOpen] = useState(false)
+  const [stageDialogOpen, setStageDialogOpen] = useState(false)
+  const [cardDialogOpen, setCardDialogOpen] = useState(false)
+  const [pipelineForm, setPipelineForm] = useState<PipelineFormState>(defaultPipelineForm)
+  const [stageForm, setStageForm] = useState<StageFormState>(defaultStageForm)
+  const [cardForm, setCardForm] = useState<CardFormState>(defaultCardForm)
+  const [cardFormMode, setCardFormMode] = useState<'create' | 'edit'>('create')
+  const previousBoardRef = useRef<Pipeline[] | null>(null)
+
+  const selectedPipeline = useMemo(
+    () => pipelines.find((pipeline) => pipeline.id === selectedPipelineId) ?? null,
+    [pipelines, selectedPipelineId]
+  )
+
+  const loadPipelines = useCallback(async () => {
+    setLoading(true)
+    try {
+      const res = await fetch('/api/pipelines', { cache: 'no-store' })
+      if (!res.ok) {
+        throw new Error('Não foi possível carregar os funis')
+      }
+      const rawData = (await res.json()) as Pipeline[]
+      const normalized = rawData.map((pipeline) => ({
+        ...pipeline,
+        stages: (pipeline.stages ?? [])
+          .map((stage) => ({
+            ...stage,
+            cards: (stage.cards ?? [])
+              .map((card) => ({
+                ...card,
+                stage_id: card.stage_id ?? stage.id,
+                estimated_value: normalizeNumeric(card.estimated_value),
+                messages_count: normalizeInteger(card.messages_count),
+              }))
+              .sort((a, b) => a.position - b.position),
+          }))
+          .sort((a, b) => a.position - b.position),
+      }))
+      setPipelines(normalized)
+      setSelectedPipelineId((current) => {
+        if (normalized.length === 0) {
+          return null
+        }
+        const isCurrentValid = current && normalized.some((pipeline) => pipeline.id === current)
+        return isCurrentValid ? (current as string) : normalized[0].id
+      })
+    } catch (err) {
+      console.error(err)
+      toast.error('Não foi possível carregar seus funis de vendas.')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void loadPipelines()
+  }, [loadPipelines])
+
+  const resetPipelineForm = useCallback(() => {
+    setPipelineForm(defaultPipelineForm)
+  }, [])
+
+  const resetStageForm = useCallback(() => {
+    setStageForm(defaultStageForm)
+  }, [])
+
+  const resetCardForm = useCallback(() => {
+    setCardForm(defaultCardForm)
+    setCardFormMode('create')
+  }, [])
+
+  const handleOpenPipelineDialog = useCallback(
+    (pipeline?: Pipeline) => {
+      if (pipeline) {
+        setPipelineForm({
+          id: pipeline.id,
+          name: pipeline.name,
+          description: pipeline.description ?? '',
+        })
+      } else {
+        resetPipelineForm()
+      }
+      setPipelineDialogOpen(true)
+    },
+    [resetPipelineForm]
+  )
+
+  const handleSubmitPipeline = useCallback(async () => {
+    const payload = {
+      name: pipelineForm.name.trim(),
+      description: pipelineForm.description.trim(),
+    }
+    if (!payload.name) {
+      toast.error('Informe um nome para o funil.')
+      return
+    }
+    try {
+      if (pipelineForm.id) {
+        const res = await fetch(`/api/pipelines/${pipelineForm.id}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        })
+        if (!res.ok) throw new Error()
+        const updated = await res.json()
+        setPipelines((prev) =>
+          prev.map((pipeline) =>
+            pipeline.id === updated.id
+              ? { ...pipeline, name: updated.name, description: updated.description ?? null }
+              : pipeline
+          )
+        )
+        toast.success('Funil atualizado com sucesso!')
+      } else {
+        const res = await fetch('/api/pipelines', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        })
+        if (!res.ok) throw new Error()
+        const created = await res.json()
+        const normalized: Pipeline = {
+          ...created,
+          description: created.description ?? null,
+          stages: [],
+        }
+        setPipelines((prev) => [...prev, normalized])
+        setSelectedPipelineId(created.id)
+        toast.success('Funil criado com sucesso!')
+      }
+      setPipelineDialogOpen(false)
+      resetPipelineForm()
+    } catch (err) {
+      console.error(err)
+      toast.error('Não foi possível salvar o funil.')
+    }
+  }, [pipelineForm, resetPipelineForm])
+
+  const handleDeletePipeline = useCallback(
+    async (pipeline: Pipeline) => {
+      const confirmation = window.confirm(
+        `Deseja excluir o funil "${pipeline.name}"? Essa ação removerá todos os estágios e oportunidades relacionadas.`
+      )
+      if (!confirmation) return
+      try {
+        const res = await fetch(`/api/pipelines/${pipeline.id}`, { method: 'DELETE' })
+        if (!res.ok) throw new Error()
+        setPipelines((prev) => {
+          const filtered = prev.filter((item) => item.id !== pipeline.id)
+          if (selectedPipelineId === pipeline.id) {
+            setSelectedPipelineId(filtered.length ? filtered[0].id : null)
+          }
+          return filtered
+        })
+        toast.success('Funil excluído.')
+      } catch (err) {
+        console.error(err)
+        toast.error('Não foi possível excluir o funil.')
+      }
+    },
+    [selectedPipelineId]
+  )
+
+  const handleOpenStageDialog = useCallback(
+    (stage?: PipelineStage) => {
+      if (!selectedPipeline) {
+        toast.error('Escolha um funil antes de adicionar estágios.')
+        return
+      }
+      if (stage) {
+        setStageForm({ id: stage.id, name: stage.name })
+      } else {
+        resetStageForm()
+      }
+      setStageDialogOpen(true)
+    },
+    [resetStageForm, selectedPipeline]
+  )
+
+  const handleSubmitStage = useCallback(async () => {
+    if (!selectedPipeline) return
+    const name = stageForm.name.trim()
+    if (!name) {
+      toast.error('Informe um nome para o estágio.')
+      return
+    }
+    try {
+      if (stageForm.id) {
+        const res = await fetch(`/api/pipelines/${selectedPipeline.id}/stages/${stageForm.id}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name }),
+        })
+        if (!res.ok) throw new Error()
+        const updated = await res.json()
+        setPipelines((prev) =>
+          prev.map((pipeline) =>
+            pipeline.id === selectedPipeline.id
+              ? {
+                  ...pipeline,
+                  stages: pipeline.stages.map((stage) =>
+                    stage.id === updated.id ? { ...stage, name: updated.name } : stage
+                  ),
+                }
+              : pipeline
+          )
+        )
+        toast.success('Estágio atualizado!')
+      } else {
+        const res = await fetch(`/api/pipelines/${selectedPipeline.id}/stages`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name }),
+        })
+        if (!res.ok) throw new Error()
+        const created = await res.json()
+        const newStage: PipelineStage = { ...created, cards: [] }
+        setPipelines((prev) =>
+          prev.map((pipeline) =>
+            pipeline.id === selectedPipeline.id
+              ? {
+                  ...pipeline,
+                  stages: [...pipeline.stages, newStage],
+                }
+              : pipeline
+          )
+        )
+        toast.success('Estágio criado!')
+      }
+      setStageDialogOpen(false)
+      resetStageForm()
+    } catch (err) {
+      console.error(err)
+      toast.error('Não foi possível salvar o estágio.')
+    }
+  }, [resetStageForm, selectedPipeline, stageForm])
+
+  const handleDeleteStage = useCallback(
+    async (stage: PipelineStage) => {
+      if (!selectedPipeline) return
+      const confirmation = window.confirm(
+        `Deseja remover o estágio "${stage.name}" e todas as oportunidades associadas?`
+      )
+      if (!confirmation) return
+      try {
+        const res = await fetch(`/api/pipelines/${selectedPipeline.id}/stages/${stage.id}`, {
+          method: 'DELETE',
+        })
+        if (!res.ok) throw new Error()
+        setPipelines((prev) =>
+          prev.map((pipeline) =>
+            pipeline.id === selectedPipeline.id
+              ? { ...pipeline, stages: pipeline.stages.filter((item) => item.id !== stage.id) }
+              : pipeline
+          )
+        )
+        toast.success('Estágio removido.')
+      } catch (err) {
+        console.error(err)
+        toast.error('Não foi possível remover o estágio.')
+      }
+    },
+    [selectedPipeline]
+  )
+
+  const handleOpenCardDialog = useCallback(
+    (stage: PipelineStage, card?: PipelineCard) => {
+      if (card) {
+        setCardForm({
+          id: card.id,
+          stageId: stage.id,
+          title: card.title,
+          companyName: card.company_name ?? '',
+          owner: card.owner ?? '',
+          plan: card.plan ?? '',
+          status: card.status ?? 'Ativo',
+          estimatedValue: card.estimated_value != null ? String(card.estimated_value) : '',
+          messagesCount: String(card.messages_count ?? 0),
+          note: card.note ?? '',
+        })
+        setCardFormMode('edit')
+      } else {
+        setCardForm({ ...defaultCardForm, stageId: stage.id })
+        setCardFormMode('create')
+      }
+      setCardDialogOpen(true)
+    },
+    []
+  )
+
+  const handleSubmitCard = useCallback(async () => {
+    if (!selectedPipeline || !cardForm.stageId) {
+      toast.error('Escolha um estágio válido para a oportunidade.')
+      return
+    }
+    const payload = {
+      stageId: cardForm.stageId,
+      title: cardForm.title.trim(),
+      companyName: cardForm.companyName.trim(),
+      owner: cardForm.owner.trim(),
+      plan: cardForm.plan.trim(),
+      status: cardForm.status.trim(),
+      estimatedValue: parseNumberInput(cardForm.estimatedValue),
+      messagesCount: parseIntegerInput(cardForm.messagesCount),
+      note: cardForm.note.trim(),
+    }
+
+    if (!payload.title) {
+      toast.error('Informe um título para a oportunidade.')
+      return
+    }
+
+    try {
+      if (cardFormMode === 'edit' && cardForm.id) {
+        const res = await fetch(
+          `/api/pipelines/${selectedPipeline.id}/cards/${cardForm.id}`,
+          {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+          }
+        )
+        if (!res.ok) throw new Error()
+        const updated = await res.json()
+        setPipelines((prev) =>
+          prev.map((pipeline) => {
+            if (pipeline.id !== selectedPipeline.id) return pipeline
+            return {
+              ...pipeline,
+              stages: pipeline.stages.map((stage) => ({
+                ...stage,
+                cards: stage.cards.map((card) =>
+                  card.id === updated.id
+                    ? {
+                        ...card,
+                        title: updated.title,
+                        company_name: updated.company_name,
+                        owner: updated.owner,
+                        plan: updated.plan,
+                        status: updated.status,
+                        estimated_value: normalizeNumeric(updated.estimated_value),
+                        messages_count: normalizeInteger(updated.messages_count),
+                        note: updated.note,
+                      }
+                    : card
+                ),
+              })),
+            }
+          })
+        )
+        toast.success('Oportunidade atualizada!')
+      } else {
+        const res = await fetch(`/api/pipelines/${selectedPipeline.id}/cards`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        })
+        if (!res.ok) throw new Error()
+        const created = await res.json()
+        setPipelines((prev) =>
+          prev.map((pipeline) =>
+            pipeline.id === selectedPipeline.id
+              ? {
+                  ...pipeline,
+                  stages: pipeline.stages.map((stage) =>
+                    stage.id === created.stage_id
+                      ? {
+                          ...stage,
+                          cards: [
+                            ...stage.cards,
+                            {
+                              ...created,
+                              stage_id: created.stage_id,
+                              estimated_value: normalizeNumeric(created.estimated_value),
+                              messages_count: normalizeInteger(created.messages_count),
+                            },
+                          ],
+                        }
+                      : stage
+                  ),
+                }
+              : pipeline
+          )
+        )
+        toast.success('Oportunidade criada!')
+      }
+      resetCardForm()
+      setCardDialogOpen(false)
+    } catch (err) {
+      console.error(err)
+      toast.error('Não foi possível salvar a oportunidade.')
+    }
+  }, [cardForm, cardFormMode, resetCardForm, selectedPipeline])
+
+  const handleDeleteCard = useCallback(
+    async (stage: PipelineStage, card: PipelineCard) => {
+      if (!selectedPipeline) return
+      const confirmation = window.confirm(`Remover "${card.title}" do funil?`)
+      if (!confirmation) return
+      try {
+        const res = await fetch(`/api/pipelines/${selectedPipeline.id}/cards/${card.id}`, {
+          method: 'DELETE',
+        })
+        if (!res.ok) throw new Error()
+        setPipelines((prev) =>
+          prev.map((pipeline) =>
+            pipeline.id === selectedPipeline.id
+              ? {
+                  ...pipeline,
+                  stages: pipeline.stages.map((item) =>
+                    item.id === stage.id
+                      ? { ...item, cards: item.cards.filter((c) => c.id !== card.id) }
+                      : item
+                  ),
+                }
+              : pipeline
+          )
+        )
+        toast.success('Oportunidade removida.')
+      } catch (err) {
+        console.error(err)
+        toast.error('Não foi possível remover a oportunidade.')
+      }
+    },
+    [selectedPipeline]
+  )
+
+  const cloneBoard = useCallback(
+    (board: Pipeline[]): Pipeline[] =>
+      board.map((pipeline) => ({
+        ...pipeline,
+        stages: pipeline.stages.map((stage) => ({
+          ...stage,
+          cards: stage.cards.map((card) => ({ ...card })),
+        })),
+      })),
+    []
+  )
+
+  const handleDragEnd = useCallback(
+    (result: DropResult) => {
+      if (!selectedPipeline) return
+      const { source, destination, draggableId } = result
+      if (!destination) return
+      if (
+        destination.droppableId === source.droppableId &&
+        destination.index === source.index
+      ) {
+        return
+      }
+
+      setPipelines((prev) => {
+        previousBoardRef.current = cloneBoard(prev)
+        return prev.map((pipeline) => {
+          if (pipeline.id !== selectedPipeline.id) return pipeline
+          const stages = pipeline.stages.map((stage) => ({
+            ...stage,
+            cards: [...stage.cards],
+          }))
+          const sourceStage = stages.find((stage) => stage.id === source.droppableId)
+          const destinationStage = stages.find((stage) => stage.id === destination.droppableId)
+          if (!sourceStage || !destinationStage) {
+            return pipeline
+          }
+          const cardIndex = sourceStage.cards.findIndex((card) => card.id === draggableId)
+          if (cardIndex === -1) {
+            return pipeline
+          }
+          const [moved] = sourceStage.cards.splice(cardIndex, 1)
+          moved.stage_id = destinationStage.id
+          const insertIndex = Math.max(0, Math.min(destination.index, destinationStage.cards.length))
+          destinationStage.cards.splice(insertIndex, 0, moved)
+          return { ...pipeline, stages }
+        })
+      })
+
+      const payload = {
+        cardId: draggableId,
+        sourceStageId: source.droppableId,
+        destinationStageId: destination.droppableId,
+        destinationIndex: destination.index,
+      }
+
+      fetch(`/api/pipelines/${selectedPipeline.id}/cards`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+        .then((response) => {
+          if (!response.ok) {
+            throw new Error('Falha ao salvar reordenação')
+          }
+          previousBoardRef.current = null
+        })
+        .catch((err) => {
+          console.error(err)
+          toast.error('Não foi possível mover a oportunidade.')
+          if (previousBoardRef.current) {
+            setPipelines(cloneBoard(previousBoardRef.current))
+            previousBoardRef.current = null
+          }
+        })
+    },
+    [cloneBoard, selectedPipeline]
+  )
+
+  const metrics = useMemo(() => {
+    if (!selectedPipeline) {
+      return {
+        totalCards: 0,
+        totalValue: 0,
+        averageTicket: 0,
+      }
+    }
+    const totals = selectedPipeline.stages.reduce(
+      (acc, stage) => {
+        const stageValue = stage.cards.reduce(
+          (sum, card) => sum + (card.estimated_value ?? 0),
+          0
+        )
+        return {
+          totalCards: acc.totalCards + stage.cards.length,
+          totalValue: acc.totalValue + stageValue,
+        }
+      },
+      { totalCards: 0, totalValue: 0 }
+    )
+    return {
+      ...totals,
+      averageTicket:
+        totals.totalCards > 0 ? Math.round(totals.totalValue / totals.totalCards) : 0,
+    }
+  }, [selectedPipeline])
+
+  return (
+    <div className="space-y-8">
+      <div className="space-y-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p className="text-sm text-gray-500">CRM</p>
+            <h1 className="text-2xl font-semibold">Funil de vendas</h1>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button variant="outline" onClick={() => handleOpenPipelineDialog()}>
+              <Plus className="h-4 w-4" /> Novo funil
+            </Button>
+            {selectedPipeline && (
+              <DropdownMenu.Root>
+                <DropdownMenu.Trigger asChild>
+                  <Button variant="outline" className="flex items-center gap-2">
+                    <MoreHorizontal className="h-4 w-4" /> Gerenciar funil
+                  </Button>
+                </DropdownMenu.Trigger>
+                <DropdownMenu.Portal>
+                  <DropdownMenu.Content className="z-50 min-w-[180px] rounded-md border bg-white p-1 shadow">
+                    <DropdownMenu.Item
+                      className="flex cursor-pointer items-center gap-2 rounded px-2 py-2 text-sm text-gray-700 hover:bg-gray-100"
+                      onSelect={() => handleOpenPipelineDialog(selectedPipeline)}
+                    >
+                      <Edit2 className="h-4 w-4" /> Editar funil
+                    </DropdownMenu.Item>
+                    <DropdownMenu.Item
+                      className="flex cursor-pointer items-center gap-2 rounded px-2 py-2 text-sm text-red-600 hover:bg-red-50"
+                      onSelect={() => handleDeletePipeline(selectedPipeline)}
+                    >
+                      <Trash2 className="h-4 w-4" /> Excluir funil
+                    </DropdownMenu.Item>
+                  </DropdownMenu.Content>
+                </DropdownMenu.Portal>
+              </DropdownMenu.Root>
+            )}
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3">
+          <Select
+            value={selectedPipelineId ?? ''}
+            onValueChange={(value) => setSelectedPipelineId(value)}
+            disabled={pipelines.length === 0}
+          >
+            <SelectTrigger className="w-[220px] bg-white">
+              <SelectValue placeholder="Selecione o funil" />
+            </SelectTrigger>
+            <SelectContent>
+              {pipelines.map((pipeline) => (
+                <SelectItem key={pipeline.id} value={pipeline.id}>
+                  {pipeline.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          <Select disabled>
+            <SelectTrigger className="w-[180px] bg-white">
+              <SelectValue placeholder="Aquisição" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="aqu">Aquisição</SelectItem>
+            </SelectContent>
+          </Select>
+
+          <Select disabled>
+            <SelectTrigger className="w-[180px] bg-white">
+              <SelectValue placeholder="Todos os donos" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">Todos os donos</SelectItem>
+            </SelectContent>
+          </Select>
+
+          <Button variant="outline" className="ml-auto flex items-center gap-2" disabled>
+            <Filter className="h-4 w-4" /> Filtros avançados
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <div className="rounded-xl border bg-white p-5 shadow-sm">
+          <p className="text-sm text-gray-500">Total de oportunidades</p>
+          <div className="mt-2 flex items-end justify-between">
+            <span className="text-3xl font-semibold">{metrics.totalCards}</span>
+            <span className="text-xs text-emerald-600">+12% vs mês anterior</span>
+          </div>
+        </div>
+        <div className="rounded-xl border bg-white p-5 shadow-sm">
+          <p className="text-sm text-gray-500">Receita estimada</p>
+          <div className="mt-2 flex items-end justify-between">
+            <span className="text-3xl font-semibold">
+              {currencyFormatter.format(metrics.totalValue)}
+            </span>
+            <span className="text-xs text-blue-600">Meta 45k</span>
+          </div>
+        </div>
+        <div className="rounded-xl border bg-white p-5 shadow-sm">
+          <p className="text-sm text-gray-500">Ticket médio</p>
+          <div className="mt-2 flex items-end justify-between">
+            <span className="text-3xl font-semibold">
+              {currencyFormatter.format(metrics.averageTicket)}
+            </span>
+            <span className="text-xs text-gray-500">Últimos 30 dias</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="relative">
+        {loading ? (
+          <div className="flex min-h-[360px] items-center justify-center">
+            <div className="flex items-center gap-2 rounded-lg border bg-white px-4 py-3 text-gray-600 shadow-sm">
+              <Loader2 className="h-5 w-5 animate-spin" /> Carregando funil...
+            </div>
+          </div>
+        ) : selectedPipeline ? (
+          <DragDropContext onDragEnd={handleDragEnd}>
+            <div className="flex gap-4 overflow-x-auto pb-4">
+              {selectedPipeline.stages.map((stage) => {
+                const stageValue = stage.cards.reduce(
+                  (sum, card) => sum + (card.estimated_value ?? 0),
+                  0
+                )
+                return (
+                  <Droppable droppableId={stage.id} key={stage.id} type="card">
+                    {(provided, snapshot) => (
+                      <div
+                        ref={provided.innerRef}
+                        {...provided.droppableProps}
+                        className={cn(
+                          'flex w-[320px] shrink-0 flex-col rounded-2xl border bg-white p-4 shadow-sm transition',
+                          snapshot.isDraggingOver ? 'border-blue-200 ring-2 ring-blue-200' : 'border-gray-100'
+                        )}
+                      >
+                        <div className="flex items-start justify-between gap-2">
+                          <div>
+                            <h3 className="text-sm font-semibold text-gray-800">{stage.name}</h3>
+                            <p className="text-xs text-gray-500">
+                              {stage.cards.length} oportunidades · {currencyFormatter.format(stageValue)}
+                            </p>
+                          </div>
+                          <div className="flex items-center gap-1">
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              className="h-8 w-8 p-0 text-gray-500 hover:text-gray-800"
+                              onClick={() => handleOpenStageDialog(stage)}
+                            >
+                              <Edit2 className="h-4 w-4" />
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              className="h-8 w-8 p-0 text-gray-500 hover:text-red-600"
+                              onClick={() => handleDeleteStage(stage)}
+                            >
+                              <Trash2 className="h-4 w-4" />
+                            </Button>
+                          </div>
+                        </div>
+
+                        <div className="mt-3 space-y-3">
+                          {stage.cards.map((card, index) => (
+                            <Draggable key={card.id} draggableId={card.id} index={index}>
+                              {(dragProvided, dragSnapshot) => (
+                                <div
+                                  ref={dragProvided.innerRef}
+                                  {...dragProvided.draggableProps}
+                                  {...dragProvided.dragHandleProps}
+                                  className={cn(
+                                    'space-y-3 rounded-xl border border-gray-100 bg-white p-3 shadow-sm transition',
+                                    dragSnapshot.isDragging && 'border-blue-300 shadow-lg'
+                                  )}
+                                >
+                                  <div className="flex items-start justify-between gap-2">
+                                    <div>
+                                      <p className="text-sm font-medium text-gray-900">{card.title}</p>
+                                      <p className="text-xs text-gray-500">{card.company_name || 'Empresa não informada'}</p>
+                                    </div>
+                                    <span
+                                      className={cn(
+                                        'rounded-full px-2 py-1 text-[11px] font-medium',
+                                        statusBadges[card.status ?? ''] || 'bg-gray-100 text-gray-600'
+                                      )}
+                                    >
+                                      {card.status ?? 'Sem status'}
+                                    </span>
+                                  </div>
+
+                                  <div className="grid grid-cols-2 gap-2 text-xs text-gray-600">
+                                    <div>
+                                      <p className="font-semibold text-gray-500">Plano</p>
+                                      <p>{card.plan || 'Não informado'}</p>
+                                    </div>
+                                    <div>
+                                      <p className="font-semibold text-gray-500">Owner</p>
+                                      <p>{card.owner || 'Não atribuído'}</p>
+                                    </div>
+                                    <div>
+                                      <p className="font-semibold text-gray-500">Valor</p>
+                                      <p>{currencyFormatter.format(card.estimated_value ?? 0)}</p>
+                                    </div>
+                                    <div>
+                                      <p className="font-semibold text-gray-500">Mensagens</p>
+                                      <p>{card.messages_count}</p>
+                                    </div>
+                                  </div>
+
+                                  {card.note && (
+                                    <p className="rounded-lg bg-gray-50 p-2 text-xs text-gray-600">
+                                      {card.note}
+                                    </p>
+                                  )}
+
+                                  <div className="flex items-center justify-between">
+                                    <Button
+                                      variant="ghost"
+                                      size="sm"
+                                      className="h-8 gap-1 px-2 text-xs text-blue-600"
+                                      onClick={() => handleOpenCardDialog(stage, card)}
+                                    >
+                                      <Edit2 className="h-3.5 w-3.5" /> Editar
+                                    </Button>
+                                    <Button
+                                      variant="ghost"
+                                      size="sm"
+                                      className="h-8 gap-1 px-2 text-xs text-red-600"
+                                      onClick={() => handleDeleteCard(stage, card)}
+                                    >
+                                      <Trash2 className="h-3.5 w-3.5" /> Remover
+                                    </Button>
+                                  </div>
+                                </div>
+                              )}
+                            </Draggable>
+                          ))}
+                          {provided.placeholder}
+                        </div>
+
+                        <Button
+                          onClick={() => handleOpenCardDialog(stage)}
+                          className="mt-3 h-9 justify-start gap-2 bg-gray-50 text-gray-700 hover:bg-gray-100"
+                          variant="ghost"
+                        >
+                          <Plus className="h-4 w-4" /> Nova oportunidade
+                        </Button>
+                      </div>
+                    )}
+                  </Droppable>
+                )
+              })}
+
+              <div className="flex h-fit w-[320px] shrink-0 flex-col items-center justify-center rounded-2xl border border-dashed border-gray-200 bg-white/60 p-4 text-center text-sm text-gray-500">
+                <p className="mb-2 font-medium">Adicionar estágio</p>
+                <Button variant="outline" size="sm" onClick={() => handleOpenStageDialog()}>
+                  <Plus className="h-4 w-4" /> Novo estágio
+                </Button>
+              </div>
+            </div>
+          </DragDropContext>
+        ) : (
+          <div className="flex min-h-[320px] flex-col items-center justify-center gap-3 rounded-3xl border border-dashed border-gray-200 bg-white/60 p-6 text-center">
+            <p className="text-lg font-semibold text-gray-700">Crie seu primeiro funil de vendas</p>
+            <p className="max-w-md text-sm text-gray-500">
+              Estruture seus estágios, arraste oportunidades entre colunas e acompanhe suas metas comerciais em tempo real.
+            </p>
+            <Button onClick={() => handleOpenPipelineDialog()} className="gap-2">
+              <Plus className="h-4 w-4" /> Criar funil
+            </Button>
+          </div>
+        )}
+      </div>
+
+      <Dialog.Root open={pipelineDialogOpen} onOpenChange={setPipelineDialogOpen}>
+        <Dialog.Portal>
+          <Dialog.Overlay className="fixed inset-0 bg-black/40" />
+          <Dialog.Content className="fixed left-1/2 top-1/2 w-full max-w-lg -translate-x-1/2 -translate-y-1/2 rounded-2xl bg-white p-6 shadow-xl">
+            <Dialog.Title className="text-lg font-semibold">
+              {pipelineForm.id ? 'Editar funil' : 'Novo funil'}
+            </Dialog.Title>
+            <div className="mt-4 space-y-4">
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-gray-700" htmlFor="pipeline-name">
+                  Nome do funil
+                </label>
+                <Input
+                  id="pipeline-name"
+                  placeholder="Ex.: Aquisição B2B"
+                  value={pipelineForm.name}
+                  onChange={(event) =>
+                    setPipelineForm((prev) => ({ ...prev, name: event.target.value }))
+                  }
+                />
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-gray-700" htmlFor="pipeline-description">
+                  Descrição (opcional)
+                </label>
+                <Textarea
+                  id="pipeline-description"
+                  rows={3}
+                  placeholder="Contextualize como este funil será utilizado"
+                  value={pipelineForm.description}
+                  onChange={(event) =>
+                    setPipelineForm((prev) => ({ ...prev, description: event.target.value }))
+                  }
+                />
+              </div>
+            </div>
+            <div className="mt-6 flex justify-end gap-2">
+              <Button variant="outline" onClick={() => setPipelineDialogOpen(false)}>
+                Cancelar
+              </Button>
+              <Button onClick={handleSubmitPipeline} className="gap-2">
+                <ArrowUpRight className="h-4 w-4" /> Salvar
+              </Button>
+            </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
+
+      <Dialog.Root open={stageDialogOpen} onOpenChange={setStageDialogOpen}>
+        <Dialog.Portal>
+          <Dialog.Overlay className="fixed inset-0 bg-black/40" />
+          <Dialog.Content className="fixed left-1/2 top-1/2 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded-2xl bg-white p-6 shadow-xl">
+            <Dialog.Title className="text-lg font-semibold">
+              {stageForm.id ? 'Editar estágio' : 'Novo estágio'}
+            </Dialog.Title>
+            <div className="mt-4 space-y-2">
+              <label className="text-sm font-medium text-gray-700" htmlFor="stage-name">
+                Nome do estágio
+              </label>
+              <Input
+                id="stage-name"
+                placeholder="Ex.: Qualificação"
+                value={stageForm.name}
+                onChange={(event) => setStageForm((prev) => ({ ...prev, name: event.target.value }))}
+              />
+            </div>
+            <div className="mt-6 flex justify-end gap-2">
+              <Button variant="outline" onClick={() => setStageDialogOpen(false)}>
+                Cancelar
+              </Button>
+              <Button onClick={handleSubmitStage} className="gap-2">
+                <ArrowUpRight className="h-4 w-4" /> Salvar
+              </Button>
+            </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
+
+      <Dialog.Root open={cardDialogOpen} onOpenChange={(open) => {
+        setCardDialogOpen(open)
+        if (!open) resetCardForm()
+      }}>
+        <Dialog.Portal>
+          <Dialog.Overlay className="fixed inset-0 bg-black/40" />
+          <Dialog.Content className="fixed left-1/2 top-1/2 w-full max-w-xl -translate-x-1/2 -translate-y-1/2 rounded-2xl bg-white p-6 shadow-xl">
+            <Dialog.Title className="text-lg font-semibold">
+              {cardFormMode === 'edit' ? 'Editar oportunidade' : 'Nova oportunidade'}
+            </Dialog.Title>
+            <div className="mt-4 grid gap-4 md:grid-cols-2">
+              <div className="md:col-span-2 space-y-2">
+                <label className="text-sm font-medium text-gray-700" htmlFor="card-title">
+                  Título
+                </label>
+                <Input
+                  id="card-title"
+                  placeholder="Ex.: Proposta Ana Souza"
+                  value={cardForm.title}
+                  onChange={(event) => setCardForm((prev) => ({ ...prev, title: event.target.value }))}
+                />
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-gray-700" htmlFor="card-company">
+                  Empresa
+                </label>
+                <Input
+                  id="card-company"
+                  placeholder="Nome da empresa"
+                  value={cardForm.companyName}
+                  onChange={(event) =>
+                    setCardForm((prev) => ({ ...prev, companyName: event.target.value }))
+                  }
+                />
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-gray-700" htmlFor="card-owner">
+                  Responsável
+                </label>
+                <Input
+                  id="card-owner"
+                  placeholder="Time ou pessoa"
+                  value={cardForm.owner}
+                  onChange={(event) => setCardForm((prev) => ({ ...prev, owner: event.target.value }))}
+                />
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-gray-700" htmlFor="card-plan">
+                  Plano
+                </label>
+                <Input
+                  id="card-plan"
+                  placeholder="Ex.: Trial, Enterprise"
+                  value={cardForm.plan}
+                  onChange={(event) => setCardForm((prev) => ({ ...prev, plan: event.target.value }))}
+                />
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-gray-700">Status</label>
+                <Select
+                  value={cardForm.status}
+                  onValueChange={(value) => setCardForm((prev) => ({ ...prev, status: value }))}
+                >
+                  <SelectTrigger className="bg-white">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="Ativo">Ativo</SelectItem>
+                    <SelectItem value="Risco">Risco</SelectItem>
+                    <SelectItem value="Perdido">Perdido</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-gray-700" htmlFor="card-value">
+                  Valor estimado (R$)
+                </label>
+                <Input
+                  id="card-value"
+                  placeholder="12000"
+                  value={cardForm.estimatedValue}
+                  onChange={(event) =>
+                    setCardForm((prev) => ({ ...prev, estimatedValue: event.target.value }))
+                  }
+                />
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-gray-700" htmlFor="card-messages">
+                  Nº de mensagens
+                </label>
+                <Input
+                  id="card-messages"
+                  placeholder="0"
+                  value={cardForm.messagesCount}
+                  onChange={(event) =>
+                    setCardForm((prev) => ({ ...prev, messagesCount: event.target.value }))
+                  }
+                />
+              </div>
+              <div className="md:col-span-2 space-y-2">
+                <label className="text-sm font-medium text-gray-700" htmlFor="card-note">
+                  Observações
+                </label>
+                <Textarea
+                  id="card-note"
+                  rows={3}
+                  placeholder="Próximos passos, objeções ou detalhes relevantes"
+                  value={cardForm.note}
+                  onChange={(event) => setCardForm((prev) => ({ ...prev, note: event.target.value }))}
+                />
+              </div>
+            </div>
+            <div className="mt-6 flex justify-end gap-2">
+              <Button variant="outline" onClick={() => setCardDialogOpen(false)}>
+                Cancelar
+              </Button>
+              <Button onClick={handleSubmitCard} className="gap-2">
+                <ArrowUpRight className="h-4 w-4" /> Salvar oportunidade
+              </Button>
+            </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
+    </div>
+  )
+}

--- a/src/lib/pipelines.ts
+++ b/src/lib/pipelines.ts
@@ -1,0 +1,30 @@
+import { supabaseadmin } from '@/lib/supabaseAdmin'
+
+export async function getCompanyIdForUser(userId: string) {
+  return supabaseadmin
+    .from('company')
+    .select('id')
+    .eq('user_id', userId)
+    .single()
+}
+
+export async function getPipelineForCompany(pipelineId: string, companyId: number) {
+  return supabaseadmin
+    .from('pipeline')
+    .select('id, company_id')
+    .eq('id', pipelineId)
+    .eq('company_id', companyId)
+    .single()
+}
+
+export async function getStagesForPipeline(stageIds: string[], pipelineId: string, companyId: number) {
+  if (stageIds.length === 0) {
+    return { data: [], error: null }
+  }
+  return supabaseadmin
+    .from('stage')
+    .select('id, pipeline_id, company_id')
+    .in('id', stageIds)
+    .eq('pipeline_id', pipelineId)
+    .eq('company_id', companyId)
+}

--- a/supabase/migrations/20250301000000_create_pipeline_tables.sql
+++ b/supabase/migrations/20250301000000_create_pipeline_tables.sql
@@ -1,0 +1,74 @@
+-- Create pipeline tables for CRM funil de vendas
+create table public.pipeline (
+  id uuid primary key default gen_random_uuid(),
+  company_id bigint not null references public.company(id) on delete cascade,
+  name text not null,
+  description text,
+  created_at timestamp with time zone not null default timezone('utc', now()),
+  updated_at timestamp with time zone not null default timezone('utc', now())
+);
+
+create index pipeline_company_idx on public.pipeline (company_id);
+
+create table public.stage (
+  id uuid primary key default gen_random_uuid(),
+  pipeline_id uuid not null references public.pipeline(id) on delete cascade,
+  company_id bigint not null references public.company(id) on delete cascade,
+  name text not null,
+  position integer not null default 0,
+  created_at timestamp with time zone not null default timezone('utc', now()),
+  updated_at timestamp with time zone not null default timezone('utc', now())
+);
+
+create index stage_pipeline_idx on public.stage (pipeline_id, position);
+create index stage_company_idx on public.stage (company_id);
+
+create table public.card (
+  id uuid primary key default gen_random_uuid(),
+  stage_id uuid not null references public.stage(id) on delete cascade,
+  company_id bigint not null references public.company(id) on delete cascade,
+  title text not null,
+  company_name text,
+  owner text,
+  plan text,
+  status text default 'Ativo',
+  estimated_value numeric(14, 2),
+  messages_count integer not null default 0,
+  last_interaction_at timestamp with time zone,
+  next_action_at timestamp with time zone,
+  note text,
+  position integer not null default 0,
+  created_at timestamp with time zone not null default timezone('utc', now()),
+  updated_at timestamp with time zone not null default timezone('utc', now())
+);
+
+create index card_stage_idx on public.card (stage_id, position);
+create index card_company_idx on public.card (company_id);
+
+alter table public.pipeline enable row level security;
+alter table public.stage enable row level security;
+alter table public.card enable row level security;
+
+create policy pipeline_manage_own on public.pipeline
+  using (company_id in (
+    select id from public.company where company.id = pipeline.company_id and company.user_id = auth.uid()
+  ))
+  with check (company_id in (
+    select id from public.company where company.id = pipeline.company_id and company.user_id = auth.uid()
+  ));
+
+create policy stage_manage_own on public.stage
+  using (company_id in (
+    select id from public.company where company.id = stage.company_id and company.user_id = auth.uid()
+  ))
+  with check (company_id in (
+    select id from public.company where company.id = stage.company_id and company.user_id = auth.uid()
+  ));
+
+create policy card_manage_own on public.card
+  using (company_id in (
+    select id from public.company where company.id = card.company_id and company.user_id = auth.uid()
+  ))
+  with check (company_id in (
+    select id from public.company where company.id = card.company_id and company.user_id = auth.uid()
+  ));


### PR DESCRIPTION
## Summary
- adiciona a página **Funil de vendas** com board Kanban, estatísticas e diálogos para gerenciar funis, estágios e oportunidades
- cria endpoints REST e utilitários Supabase para CRUD de pipeline, estágios, cartões e movimentação via drag and drop
- provisiona as tabelas `pipeline`, `stage` e `card` com RLS e atualiza navegação e documentação do CRM

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5d636d9648333b6d9a7c0f6e8e09f