### PR TITLE
feat: add sales pipeline kanban board

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,7 @@ Este repositório contém uma aplicação [Next.js](https://nextjs.org/) prepara
 - [Chatwoot](https://www.chatwoot.com/)
 - [Vercel](https://vercel.com/)
 
+## 📈 Funil de vendas
+
+A partir da barra lateral do dashboard é possível acessar a nova página **Funil de vendas** e organizar oportunidades em um quadro Kanban responsivo. Crie diferentes funis por empresa, personalize os estágios e mova cartões entre colunas com _drag and drop_. Cada cartão aceita dados como cliente, valor estimado e observações, mantendo o histórico sincronizado com o Supabase para toda a equipe.
+

--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ Este repositório contém uma aplicação [Next.js](https://nextjs.org/) prepara
 
    Acesse [http://localhost:3000](http://localhost:3000) para ver o resultado.
 
+4. Sincronize o banco de dados do Supabase com as migrações do projeto:
+
+   ```bash
+   supabase migration up
+   ```
+
+   A migração `20250222000000_create_sales_pipeline_tables.sql` recria as políticas de RLS dos funis com comandos compatíveis com o PostgreSQL 15, garantindo que o ambiente local fique alinhado ao painel do Supabase.
+
 ## 📦 Deploy
 
 1. Gere o build de produção:

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -22,6 +22,7 @@ import {
   Menu,
   MessageSquare,
   BookOpen,
+  KanbanSquare,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { MAX_AGENTS_PER_COMPANY } from '@/lib/constants';
@@ -41,6 +42,7 @@ const mainItem: NavItem = {
 };
 
 const navItems: NavItem[] = [
+  { label: 'Funil de vendas', href: '/dashboard/funil-de-vendas', icon: <KanbanSquare size={20} /> },
   { label: 'Pagamentos', href: '/dashboard/payments', icon: <CreditCard size={20} /> },
   { label: 'Configuração', href: '/dashboard/config', icon: <Settings size={20} /> },
   { label: 'Documentação', href: '/dashboard/documentacao', icon: <BookOpen size={20} /> },

--- a/docs/BRANDING.md
+++ b/docs/BRANDING.md
@@ -26,3 +26,9 @@ A unidade base de espaçamento segue o padrão do Tailwind CSS (4 px). Organize
 - Utilize a versão em `#2F6F68` sobre fundos claros e a versão branca sobre fundos escuros.
 - Não distorça, rotacione ou altere as cores oficiais.
 
+## Aplicação no funil de vendas
+- Utilize `--primary` para títulos de colunas e indicadores de estágio no board Kanban.
+- Reserve `--secondary` para cartões em estado neutro e componentes de apoio (contagens, etiquetas auxiliares).
+- Mantenha o contraste mínimo de 4.5:1 entre texto e fundo ao personalizar a experiência para novas empresas.
+- Prefira ícones outline e tipografia Geist em caixa título para os nomes de estágio, garantindo leitura rápida.
+

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -27,3 +27,5 @@ As seguintes tabelas requerem políticas de Row Level Security para garantir o i
 | `card` | Oportunidades somente visíveis e gerenciáveis pela empresa proprietária do funil |
 
 Certifique-se de que o RLS esteja habilitado e que as políticas correspondentes estejam configuradas no Supabase para cada tabela acima.
+
+> Ao aplicar as migrações do diretório `supabase/migrations`, as políticas dos objetos `pipeline`, `stage` e `card` são recriadas com o padrão `drop policy if exists` seguido de `create policy`. Esse fluxo evita erros no PostgreSQL 15 (utilizado pelo Supabase) e mantém os ambientes consistentes durante resets ou reprovisionamentos.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -22,5 +22,8 @@ As seguintes tabelas requerem políticas de Row Level Security para garantir o i
 | `agent_personality`, `agent_behavior`, `agent_onboarding`, `agent_specific_instructions`, `agent_knowledge_files` | Acesso restrito via relação com `agents.company_id` do usuário |
 | `payments` | Acesso apenas para registros com `company_id` pertencente ao usuário |
 | `tickets` | Acesso apenas para registros com `company_id` pertencente ao usuário |
+| `pipeline` | Usuário somente acessa funis cuja empresa esteja associada ao seu `auth.uid()` |
+| `stage` | Restringir aos estágios pertencentes aos funis da empresa do usuário |
+| `card` | Oportunidades somente visíveis e gerenciáveis pela empresa proprietária do funil |
 
 Certifique-se de que o RLS esteja habilitado e que as políticas correspondentes estejam configuradas no Supabase para cada tabela acima.

--- a/docs/crm.md
+++ b/docs/crm.md
@@ -1,0 +1,11 @@
+# Guia do CRM
+
+## Funil de vendas
+- A página **Funil de vendas** está disponível no dashboard e apresenta um quadro Kanban responsivo para organizar oportunidades.
+- Pipelines, estágios e cartões são filtrados automaticamente por empresa através das políticas de RLS descritas na migração `20250222000000_create_sales_pipeline_tables.sql`.
+- As operações de arrastar e soltar atualizam a ordenação (`position`) e sincronizam o Supabase usando mutações otimizadas.
+
+## Boas práticas de manutenção
+- Sempre que ajustar as políticas de segurança, utilize o padrão `drop policy if exists` seguido de `create policy` para manter a compatibilidade com o PostgreSQL 15.
+- Revise periodicamente os webhooks e automações conectados aos eventos do funil para garantir que respeitam o isolamento por `company_id`.
+- Ao introduzir novos campos nos cartões, considere o impacto nas integrações externas e comunique a alteração na documentação pública.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "agent-plugandplay",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/modifiers": "^9.0.0",
+        "@dnd-kit/sortable": "^10.0.0",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-select": "^2.2.5",
@@ -540,6 +543,73 @@
       "dependencies": {
         "@types/tough-cookie": "^4.0.5",
         "tough-cookie": "^4.1.4"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/modifiers": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
+      "integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
+    "@dnd-kit/sortable": "^10.0.0",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-select": "^2.2.5",

--- a/src/app/dashboard/funil-de-vendas/page.tsx
+++ b/src/app/dashboard/funil-de-vendas/page.tsx
@@ -1,0 +1,1159 @@
+"use client";
+
+import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react";
+import * as Dialog from "@radix-ui/react-dialog";
+import {
+  DndContext,
+  DragEndEvent,
+  PointerSensor,
+  closestCorners,
+  useDroppable,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  arrayMove,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Card as UiCard } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import { supabasebrowser } from "@/lib/supabaseClient";
+import { Loader2, Edit2, Trash2, Plus, X } from "lucide-react";
+import { toast } from "sonner";
+
+interface Company {
+  id: number;
+  company_name: string | null;
+}
+
+interface PipelineCard {
+  id: string;
+  title: string;
+  customer_name: string | null;
+  value: number | null;
+  description: string | null;
+  position: number;
+  stage_id: string;
+  pipeline_id: string;
+}
+
+interface PipelineStage {
+  id: string;
+  name: string;
+  position: number;
+  cards: PipelineCard[];
+}
+
+interface Pipeline {
+  id: string;
+  name: string;
+  stages: PipelineStage[];
+}
+
+type SupabasePipelineResponse = {
+  id: string;
+  name: string;
+  stages: SupabaseStageResponse[] | null;
+};
+
+type SupabaseStageResponse = {
+  id: string;
+  name: string;
+  position: number;
+  cards: SupabaseCardResponse[] | null;
+};
+
+type SupabaseCardResponse = {
+  id: string;
+  title: string;
+  customer_name: string | null;
+  value: number | null;
+  description: string | null;
+  position: number;
+  stage_id: string;
+  pipeline_id: string;
+};
+
+type PipelineModalState = {
+  open: boolean;
+  mode: "create" | "edit";
+  pipeline?: Pipeline | null;
+};
+
+type StageModalState = {
+  open: boolean;
+  mode: "create" | "edit";
+  stage?: PipelineStage | null;
+};
+
+type CardModalState = {
+  open: boolean;
+  mode: "create" | "edit";
+  stageId?: string;
+  card?: PipelineCard | null;
+};
+
+export default function SalesPipelinePage() {
+  const [company, setCompany] = useState<Company | null>(null);
+  const [pipelines, setPipelines] = useState<Pipeline[]>([]);
+  const [selectedPipelineId, setSelectedPipelineId] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isFetching, setIsFetching] = useState(false);
+  const [pipelineModal, setPipelineModal] = useState<PipelineModalState>({
+    open: false,
+    mode: "create",
+  });
+  const [stageModal, setStageModal] = useState<StageModalState>({
+    open: false,
+    mode: "create",
+  });
+  const [cardModal, setCardModal] = useState<CardModalState>({
+    open: false,
+    mode: "create",
+  });
+  const [formName, setFormName] = useState("");
+  const [cardForm, setCardForm] = useState({
+    title: "",
+    customer_name: "",
+    value: "",
+    description: "",
+  });
+  const [isSaving, setIsSaving] = useState(false);
+  const [pipelineToDelete, setPipelineToDelete] = useState<Pipeline | null>(null);
+  const [stageToDelete, setStageToDelete] = useState<PipelineStage | null>(null);
+  const [cardToDelete, setCardToDelete] = useState<PipelineCard | null>(null);
+
+  useEffect(() => {
+    supabasebrowser.auth.getUser().then(async ({ data, error }) => {
+      if (error || !data?.user) {
+        toast.error("Não foi possível carregar seu perfil.");
+        setIsLoading(false);
+        return;
+      }
+      const { data: companyData, error: companyError } = await supabasebrowser
+        .from("company")
+        .select("id, company_name")
+        .eq("user_id", data.user.id)
+        .single();
+      if (companyError || !companyData) {
+        toast.error("Não foi possível carregar os dados da empresa.");
+        setIsLoading(false);
+        return;
+      }
+      setCompany(companyData as Company);
+      setIsLoading(false);
+    });
+  }, []);
+
+  const loadPipelines = useCallback(async () => {
+    if (!company?.id) return;
+    setIsFetching(true);
+    const { data, error } = await supabasebrowser
+      .from("pipeline")
+      .select(
+        `id, name, stages:stage(id, name, position, cards:card(id, title, customer_name, value, description, position, stage_id, pipeline_id))`
+      )
+      .eq("company_id", company.id)
+      .order("created_at", { ascending: true });
+
+    if (error) {
+      console.error(error);
+      toast.error("Não foi possível carregar os funis de vendas.");
+      setIsFetching(false);
+      return;
+    }
+
+    const parsed: Pipeline[] = ((data ?? []) as SupabasePipelineResponse[]).map((pipeline) => ({
+      id: pipeline.id,
+      name: pipeline.name,
+      stages: (pipeline.stages ?? [])
+        .map((stage) => ({
+          id: stage.id,
+          name: stage.name,
+          position: stage.position,
+          cards: (stage.cards ?? [])
+            .map((card) => ({
+              id: card.id,
+              title: card.title,
+              customer_name: card.customer_name,
+              value: card.value,
+              description: card.description,
+              position: card.position,
+              stage_id: card.stage_id,
+              pipeline_id: card.pipeline_id,
+            }))
+            .sort((a: PipelineCard, b: PipelineCard) => a.position - b.position),
+        }))
+        .sort((a: PipelineStage, b: PipelineStage) => a.position - b.position),
+    }));
+
+    setPipelines(parsed);
+    setSelectedPipelineId((current) => {
+      if (current && parsed.some((pipeline) => pipeline.id === current)) {
+        return current;
+      }
+      return parsed[0]?.id ?? null;
+    });
+    setIsFetching(false);
+  }, [company?.id]);
+
+  useEffect(() => {
+    if (!company?.id) return;
+    void loadPipelines();
+  }, [company?.id, loadPipelines]);
+
+  const selectedPipeline = useMemo(
+    () => pipelines.find((pipeline) => pipeline.id === selectedPipelineId) ?? null,
+    [pipelines, selectedPipelineId]
+  );
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 6 },
+    })
+  );
+
+  const openCreatePipeline = () => {
+    setFormName("");
+    setPipelineModal({ open: true, mode: "create" });
+  };
+
+  const openEditPipeline = (pipeline: Pipeline) => {
+    setFormName(pipeline.name);
+    setPipelineModal({ open: true, mode: "edit", pipeline });
+  };
+
+  const handlePipelineSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!company?.id) return;
+    const name = formName.trim();
+    if (!name) {
+      toast.error("Informe um nome para o funil.");
+      return;
+    }
+    setIsSaving(true);
+    if (pipelineModal.mode === "create") {
+      const { error } = await supabasebrowser
+        .from("pipeline")
+        .insert({ name, company_id: company.id });
+      if (error) {
+        console.error(error);
+        toast.error("Não foi possível criar o funil.");
+      } else {
+        toast.success("Funil criado com sucesso.");
+        setPipelineModal({ open: false, mode: "create" });
+        void loadPipelines();
+      }
+    } else if (pipelineModal.pipeline) {
+      const { error } = await supabasebrowser
+        .from("pipeline")
+        .update({ name })
+        .eq("id", pipelineModal.pipeline.id);
+      if (error) {
+        console.error(error);
+        toast.error("Não foi possível atualizar o funil.");
+      } else {
+        toast.success("Funil atualizado com sucesso.");
+        setPipelineModal({ open: false, mode: "create" });
+        void loadPipelines();
+      }
+    }
+    setIsSaving(false);
+  };
+
+  const openCreateStage = () => {
+    setFormName("");
+    setStageModal({ open: true, mode: "create" });
+  };
+
+  const openEditStage = (stage: PipelineStage) => {
+    setFormName(stage.name);
+    setStageModal({ open: true, mode: "edit", stage });
+  };
+
+  const handleStageSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!selectedPipeline) return;
+    const name = formName.trim();
+    if (!name) {
+      toast.error("Informe um nome para o estágio.");
+      return;
+    }
+    setIsSaving(true);
+    if (stageModal.mode === "create") {
+      const position = selectedPipeline.stages.length;
+      const { error } = await supabasebrowser
+        .from("stage")
+        .insert({ name, pipeline_id: selectedPipeline.id, position });
+      if (error) {
+        console.error(error);
+        toast.error("Não foi possível criar o estágio.");
+      } else {
+        toast.success("Estágio criado com sucesso.");
+        setStageModal({ open: false, mode: "create" });
+        void loadPipelines();
+      }
+    } else if (stageModal.stage) {
+      const { error } = await supabasebrowser
+        .from("stage")
+        .update({ name })
+        .eq("id", stageModal.stage.id);
+      if (error) {
+        console.error(error);
+        toast.error("Não foi possível atualizar o estágio.");
+      } else {
+        toast.success("Estágio atualizado com sucesso.");
+        setStageModal({ open: false, mode: "create" });
+        void loadPipelines();
+      }
+    }
+    setIsSaving(false);
+  };
+
+  const openCreateCard = (stageId: string) => {
+    setCardForm({ title: "", customer_name: "", value: "", description: "" });
+    setCardModal({ open: true, mode: "create", stageId });
+  };
+
+  const openEditCard = (card: PipelineCard) => {
+    setCardForm({
+      title: card.title,
+      customer_name: card.customer_name ?? "",
+      value: card.value != null ? String(card.value) : "",
+      description: card.description ?? "",
+    });
+    setCardModal({ open: true, mode: "edit", stageId: card.stage_id, card });
+  };
+
+  const handleCardSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!selectedPipeline || !company?.id) return;
+    const title = cardForm.title.trim();
+    if (!title) {
+      toast.error("Informe um título para a oportunidade.");
+      return;
+    }
+    const normalizedValue = cardForm.value
+      .replace(/\s/g, "")
+      .replace(/\.(?=\d{3}(?:\D|$))/g, "")
+      .replace(",", ".");
+    const value = normalizedValue ? Number(normalizedValue) : null;
+    if (normalizedValue && Number.isNaN(value)) {
+      toast.error("Informe um valor válido.");
+      return;
+    }
+    setIsSaving(true);
+    if (cardModal.mode === "create" && cardModal.stageId) {
+      const stage = selectedPipeline.stages.find((item) => item.id === cardModal.stageId);
+      const position = stage?.cards.length ?? 0;
+      const { error } = await supabasebrowser.from("card").insert({
+        title,
+        customer_name: cardForm.customer_name || null,
+        value,
+        description: cardForm.description || null,
+        pipeline_id: selectedPipeline.id,
+        company_id: company.id,
+        stage_id: cardModal.stageId,
+        position,
+      });
+      if (error) {
+        console.error(error);
+        toast.error("Não foi possível criar a oportunidade.");
+      } else {
+        toast.success("Oportunidade criada com sucesso.");
+        setCardModal({ open: false, mode: "create" });
+        void loadPipelines();
+      }
+    } else if (cardModal.card) {
+      const { error } = await supabasebrowser
+        .from("card")
+        .update({
+          title,
+          customer_name: cardForm.customer_name || null,
+          value,
+          description: cardForm.description || null,
+        })
+        .eq("id", cardModal.card.id);
+      if (error) {
+        console.error(error);
+        toast.error("Não foi possível atualizar a oportunidade.");
+      } else {
+        toast.success("Oportunidade atualizada com sucesso.");
+        setCardModal({ open: false, mode: "create" });
+        void loadPipelines();
+      }
+    }
+    setIsSaving(false);
+  };
+
+  const handlePipelineDelete = async () => {
+    if (!pipelineToDelete) return;
+    setIsSaving(true);
+    const { error } = await supabasebrowser.from("pipeline").delete().eq("id", pipelineToDelete.id);
+    if (error) {
+      console.error(error);
+      toast.error("Não foi possível remover o funil.");
+    } else {
+      toast.success("Funil removido com sucesso.");
+      setPipelineToDelete(null);
+      setSelectedPipelineId((current) => (current === pipelineToDelete.id ? null : current));
+      void loadPipelines();
+    }
+    setIsSaving(false);
+  };
+
+  const handleStageDelete = async () => {
+    if (!stageToDelete) return;
+    setIsSaving(true);
+    const { error } = await supabasebrowser.from("stage").delete().eq("id", stageToDelete.id);
+    if (error) {
+      console.error(error);
+      toast.error("Não foi possível remover o estágio.");
+    } else {
+      toast.success("Estágio removido com sucesso.");
+      setStageToDelete(null);
+      void loadPipelines();
+    }
+    setIsSaving(false);
+  };
+
+  const handleCardDelete = async () => {
+    if (!cardToDelete) return;
+    setIsSaving(true);
+    const { error } = await supabasebrowser.from("card").delete().eq("id", cardToDelete.id);
+    if (error) {
+      console.error(error);
+      toast.error("Não foi possível remover a oportunidade.");
+    } else {
+      toast.success("Oportunidade removida com sucesso.");
+      setCardToDelete(null);
+      void loadPipelines();
+    }
+    setIsSaving(false);
+  };
+
+  const persistCardPositions = useCallback(
+    async (stages: PipelineStage[]) => {
+      const updates = stages.flatMap((stage) =>
+        stage.cards.map((card, index) => ({ id: card.id, stage_id: stage.id, position: index }))
+      );
+      if (!updates.length) return;
+      const { error } = await supabasebrowser
+        .from("card")
+        .upsert(updates, { onConflict: "id" });
+      if (error) {
+        console.error(error);
+        toast.error("Não foi possível salvar a nova ordem das oportunidades.");
+        void loadPipelines();
+      }
+    },
+    [loadPipelines]
+  );
+
+  const handleDragEnd = async ({ active, over }: DragEndEvent) => {
+    if (!selectedPipeline || !over) return;
+    const activeId = String(active.id);
+    const overId = String(over.id);
+    if (activeId === overId) return;
+
+    const sourceStageIndex = selectedPipeline.stages.findIndex((stage) =>
+      stage.cards.some((card) => card.id === activeId)
+    );
+    if (sourceStageIndex === -1) return;
+    const sourceStage = selectedPipeline.stages[sourceStageIndex];
+    const activeCardIndex = sourceStage.cards.findIndex((card) => card.id === activeId);
+    if (activeCardIndex === -1) return;
+    const cardBeingMoved = sourceStage.cards[activeCardIndex];
+
+    let targetStageIndex = selectedPipeline.stages.findIndex((stage) => stage.id === overId);
+    let targetCardIndex: number | null = null;
+    if (targetStageIndex === -1) {
+      targetStageIndex = selectedPipeline.stages.findIndex((stage) =>
+        stage.cards.some((card) => card.id === overId)
+      );
+      if (targetStageIndex === -1) return;
+      const targetStage = selectedPipeline.stages[targetStageIndex];
+      targetCardIndex = targetStage.cards.findIndex((card) => card.id === overId);
+    } else {
+      targetCardIndex = null;
+    }
+
+    const targetStage = selectedPipeline.stages[targetStageIndex];
+
+    if (sourceStage.id === targetStage.id && targetCardIndex != null) {
+      const reorderedCards = arrayMove(sourceStage.cards, activeCardIndex, targetCardIndex);
+      const updatedStages = selectedPipeline.stages.map((stage) =>
+        stage.id === sourceStage.id ? { ...stage, cards: reorderedCards } : stage
+      );
+      setPipelines((prev) =>
+        prev.map((pipeline) =>
+          pipeline.id === selectedPipeline.id ? { ...pipeline, stages: updatedStages } : pipeline
+        )
+      );
+      await persistCardPositions(updatedStages);
+      return;
+    }
+
+    const newSourceCards = [...sourceStage.cards];
+    newSourceCards.splice(activeCardIndex, 1);
+    const newTargetCards = [...targetStage.cards];
+    const insertionIndex = targetCardIndex ?? newTargetCards.length;
+    newTargetCards.splice(insertionIndex, 0, { ...cardBeingMoved, stage_id: targetStage.id });
+
+    const updatedStages = selectedPipeline.stages.map((stage) => {
+      if (stage.id === sourceStage.id) {
+        return { ...stage, cards: newSourceCards };
+      }
+      if (stage.id === targetStage.id) {
+        return { ...stage, cards: newTargetCards };
+      }
+      return stage;
+    });
+
+    setPipelines((prev) =>
+      prev.map((pipeline) =>
+        pipeline.id === selectedPipeline.id ? { ...pipeline, stages: updatedStages } : pipeline
+      )
+    );
+    await persistCardPositions(updatedStages);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <Loader2 className="h-6 w-6 animate-spin text-[#2F6F68]" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">Funil de vendas</h1>
+          <p className="text-sm text-muted-foreground">
+            Organize seus processos comerciais com quadros Kanban e acompanhe cada oportunidade.
+          </p>
+        </div>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+          {pipelines.length > 0 ? (
+            <Select value={selectedPipelineId ?? ""} onValueChange={setSelectedPipelineId}>
+              <SelectTrigger className="w-full min-w-[220px] sm:w-60">
+                <SelectValue placeholder="Selecione um funil" />
+              </SelectTrigger>
+              <SelectContent>
+                {pipelines.map((pipeline) => (
+                  <SelectItem key={pipeline.id} value={pipeline.id}>
+                    {pipeline.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          ) : null}
+          <Button onClick={openCreatePipeline}>
+            <Plus className="h-4 w-4" />
+            Novo funil
+          </Button>
+        </div>
+      </header>
+
+      {isFetching ? (
+        <div className="flex min-h-[40vh] items-center justify-center">
+          <Loader2 className="h-6 w-6 animate-spin text-[#2F6F68]" />
+        </div>
+      ) : null}
+
+      {!isFetching && !selectedPipeline ? (
+        <UiCard className="p-8 text-center">
+          <h2 className="text-xl font-semibold">Crie seu primeiro funil</h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Estruture as etapas do seu processo comercial e comece a acompanhar leads com uma visão clara.
+          </p>
+          <Button className="mt-4" onClick={openCreatePipeline}>
+            <Plus className="h-4 w-4" />
+            Criar funil
+          </Button>
+        </UiCard>
+      ) : null}
+
+      {!isFetching && selectedPipeline ? (
+        <div className="space-y-6">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h2 className="text-xl font-semibold">{selectedPipeline.name}</h2>
+              <p className="text-sm text-muted-foreground">
+                {selectedPipeline.stages.length} estágio(s) ativos neste funil.
+              </p>
+            </div>
+            <div className="flex gap-2">
+              <Button variant="outline" onClick={() => openEditPipeline(selectedPipeline)}>
+                <Edit2 className="h-4 w-4" />
+                Renomear
+              </Button>
+              <Button variant="outline" onClick={() => setPipelineToDelete(selectedPipeline)}>
+                <Trash2 className="h-4 w-4" />
+                Excluir
+              </Button>
+            </div>
+          </div>
+
+          <DndContext sensors={sensors} collisionDetection={closestCorners} onDragEnd={handleDragEnd}>
+            <div className="flex gap-4 overflow-x-auto pb-4">
+              {selectedPipeline.stages.map((stage) => (
+                <SortableContext
+                  key={stage.id}
+                  items={stage.cards.map((card) => card.id)}
+                  strategy={verticalListSortingStrategy}
+                >
+                  <StageColumn
+                    stage={stage}
+                    onAddCard={() => openCreateCard(stage.id)}
+                    onEditStage={() => openEditStage(stage)}
+                    onDeleteStage={() => setStageToDelete(stage)}
+                  >
+                    {stage.cards.map((card) => (
+                      <KanbanCard
+                        key={card.id}
+                        card={card}
+                        onEdit={() => openEditCard(card)}
+                        onDelete={() => setCardToDelete(card)}
+                      />
+                    ))}
+                  </StageColumn>
+                </SortableContext>
+              ))}
+              <div className="flex h-full min-w-[280px] items-center justify-center rounded-lg border border-dashed bg-muted/30 p-4">
+                <Button variant="ghost" onClick={openCreateStage}>
+                  <Plus className="h-4 w-4" />
+                  Novo estágio
+                </Button>
+              </div>
+            </div>
+          </DndContext>
+        </div>
+      ) : null}
+
+      <PipelineDialog
+        state={pipelineModal}
+        onOpenChange={(open) =>
+          setPipelineModal((prev) => {
+            if (!open) setFormName("");
+            return { ...prev, open, ...(open ? {} : { pipeline: null }) };
+          })
+        }
+        formName={formName}
+        onFormNameChange={setFormName}
+        onSubmit={handlePipelineSubmit}
+        isSaving={isSaving}
+      />
+
+      <StageDialog
+        state={stageModal}
+        onOpenChange={(open) =>
+          setStageModal((prev) => {
+            if (!open) setFormName("");
+            return { ...prev, open, ...(open ? {} : { stage: null }) };
+          })
+        }
+        formName={formName}
+        onFormNameChange={setFormName}
+        onSubmit={handleStageSubmit}
+        isSaving={isSaving}
+      />
+
+      <CardDialog
+        state={cardModal}
+        onOpenChange={(open) =>
+          setCardModal((prev) => {
+            if (!open)
+              setCardForm({ title: "", customer_name: "", value: "", description: "" });
+            return { ...prev, open, ...(open ? {} : { card: null, stageId: undefined }) };
+          })
+        }
+        form={cardForm}
+        onFormChange={setCardForm}
+        onSubmit={handleCardSubmit}
+        isSaving={isSaving}
+      />
+
+      <ConfirmDialog
+        open={Boolean(pipelineToDelete)}
+        title="Remover funil"
+        description="Esta ação é irreversível e removerá também os estágios e oportunidades deste funil. Deseja continuar?"
+        confirmLabel="Remover"
+        onOpenChange={(open) => {
+          if (!open) setPipelineToDelete(null);
+        }}
+        onConfirm={handlePipelineDelete}
+        loading={isSaving}
+      />
+
+      <ConfirmDialog
+        open={Boolean(stageToDelete)}
+        title="Remover estágio"
+        description="Ao remover o estágio, todas as oportunidades associadas a ele serão excluídas. Deseja continuar?"
+        confirmLabel="Remover"
+        onOpenChange={(open) => {
+          if (!open) setStageToDelete(null);
+        }}
+        onConfirm={handleStageDelete}
+        loading={isSaving}
+      />
+
+      <ConfirmDialog
+        open={Boolean(cardToDelete)}
+        title="Remover oportunidade"
+        description="Você tem certeza de que deseja excluir esta oportunidade do funil?"
+        confirmLabel="Remover"
+        onOpenChange={(open) => {
+          if (!open) setCardToDelete(null);
+        }}
+        onConfirm={handleCardDelete}
+        loading={isSaving}
+      />
+    </div>
+  );
+}
+
+function StageColumn({
+  stage,
+  children,
+  onAddCard,
+  onEditStage,
+  onDeleteStage,
+}: {
+  stage: PipelineStage;
+  children: ReactNode;
+  onAddCard: () => void;
+  onEditStage: () => void;
+  onDeleteStage: () => void;
+}) {
+  const { setNodeRef, isOver } = useDroppable({ id: stage.id });
+  return (
+    <div
+      ref={setNodeRef}
+      className={cn(
+        "flex h-full min-h-[320px] w-72 flex-shrink-0 flex-col rounded-lg border bg-white p-4 shadow-sm",
+        isOver && "border-primary/60"
+      )}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          <h3 className="text-sm font-semibold">{stage.name}</h3>
+          <span className="text-xs text-muted-foreground">{stage.cards.length} oportunidade(s)</span>
+        </div>
+        <div className="flex gap-1">
+          <IconButton onClick={onEditStage} ariaLabel="Editar estágio">
+            <Edit2 className="h-3.5 w-3.5" />
+          </IconButton>
+          <IconButton onClick={onDeleteStage} ariaLabel="Excluir estágio">
+            <Trash2 className="h-3.5 w-3.5" />
+          </IconButton>
+        </div>
+      </div>
+      <div className="mt-4 flex-1 space-y-3 overflow-y-auto pr-1">
+        {children}
+      </div>
+      <Button variant="ghost" className="mt-4 w-full" onClick={onAddCard}>
+        <Plus className="h-4 w-4" />
+        Nova oportunidade
+      </Button>
+    </div>
+  );
+}
+
+function KanbanCard({
+  card,
+  onEdit,
+  onDelete,
+}: {
+  card: PipelineCard;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: card.id });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={cn(
+        "rounded-lg border bg-white p-3 text-left shadow-sm transition",
+        isDragging && "ring-2 ring-primary/40"
+      )}
+      {...attributes}
+      {...listeners}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h4 className="text-sm font-semibold text-foreground">{card.title}</h4>
+          {card.customer_name ? (
+            <p className="text-xs text-muted-foreground">{card.customer_name}</p>
+          ) : null}
+        </div>
+        <div className="flex gap-1">
+          <IconButton onClick={onEdit} ariaLabel="Editar oportunidade">
+            <Edit2 className="h-3.5 w-3.5" />
+          </IconButton>
+          <IconButton onClick={onDelete} ariaLabel="Excluir oportunidade">
+            <Trash2 className="h-3.5 w-3.5" />
+          </IconButton>
+        </div>
+      </div>
+      {card.value != null ? (
+        <p className="mt-2 text-xs font-medium text-[#2F6F68]">
+          Valor estimado: {formatCurrency(card.value)}
+        </p>
+      ) : null}
+      {card.description ? (
+        <p className="mt-2 text-xs text-muted-foreground">{card.description}</p>
+      ) : null}
+    </div>
+  );
+}
+
+function formatCurrency(value: number) {
+  return new Intl.NumberFormat("pt-BR", {
+    style: "currency",
+    currency: "BRL",
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+function IconButton({
+  children,
+  onClick,
+  ariaLabel,
+}: {
+  children: ReactNode;
+  onClick: () => void;
+  ariaLabel: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={ariaLabel}
+      className="inline-flex h-7 w-7 items-center justify-center rounded-md border bg-white text-muted-foreground shadow-sm transition hover:border-primary/50 hover:text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
+    >
+      {children}
+    </button>
+  );
+}
+
+function PipelineDialog({
+  state,
+  onOpenChange,
+  formName,
+  onFormNameChange,
+  onSubmit,
+  isSaving,
+}: {
+  state: PipelineModalState;
+  onOpenChange: (open: boolean) => void;
+  formName: string;
+  onFormNameChange: (value: string) => void;
+  onSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
+  isSaving: boolean;
+}) {
+  const title = state.mode === "create" ? "Criar funil" : "Editar funil";
+  const description =
+    state.mode === "create"
+      ? "Defina um nome para organizar suas oportunidades."
+      : "Atualize o nome exibido para este funil.";
+
+  return (
+    <Dialog.Root open={state.open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/30" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded-lg bg-white p-6 shadow-lg">
+          <div className="flex items-start justify-between">
+            <div>
+              <Dialog.Title className="text-lg font-semibold">{title}</Dialog.Title>
+              <Dialog.Description className="text-sm text-muted-foreground">
+                {description}
+              </Dialog.Description>
+            </div>
+            <Dialog.Close asChild>
+              <button
+                type="button"
+                aria-label="Fechar"
+                className="rounded-md p-1 text-muted-foreground transition hover:bg-muted"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </Dialog.Close>
+          </div>
+          <form className="mt-6 space-y-4" onSubmit={onSubmit}>
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium" htmlFor="pipeline-name">
+                Nome do funil
+              </label>
+              <Input
+                id="pipeline-name"
+                value={formName}
+                onChange={(event) => onFormNameChange(event.target.value)}
+                placeholder="Ex.: Funil comercial principal"
+              />
+            </div>
+            <div className="flex justify-end gap-2">
+              <Dialog.Close asChild>
+                <Button type="button" variant="ghost">
+                  Cancelar
+                </Button>
+              </Dialog.Close>
+              <Button type="submit" disabled={isSaving}>
+                {isSaving ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+                {state.mode === "create" ? "Criar" : "Salvar"}
+              </Button>
+            </div>
+          </form>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+
+function StageDialog({
+  state,
+  onOpenChange,
+  formName,
+  onFormNameChange,
+  onSubmit,
+  isSaving,
+}: {
+  state: StageModalState;
+  onOpenChange: (open: boolean) => void;
+  formName: string;
+  onFormNameChange: (value: string) => void;
+  onSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
+  isSaving: boolean;
+}) {
+  const title = state.mode === "create" ? "Adicionar estágio" : "Editar estágio";
+  const description =
+    state.mode === "create"
+      ? "Defina o nome do novo estágio do funil."
+      : "Atualize o nome exibido para este estágio.";
+
+  return (
+    <Dialog.Root open={state.open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/30" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded-lg bg-white p-6 shadow-lg">
+          <div className="flex items-start justify-between">
+            <div>
+              <Dialog.Title className="text-lg font-semibold">{title}</Dialog.Title>
+              <Dialog.Description className="text-sm text-muted-foreground">
+                {description}
+              </Dialog.Description>
+            </div>
+            <Dialog.Close asChild>
+              <button
+                type="button"
+                aria-label="Fechar"
+                className="rounded-md p-1 text-muted-foreground transition hover:bg-muted"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </Dialog.Close>
+          </div>
+          <form className="mt-6 space-y-4" onSubmit={onSubmit}>
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium" htmlFor="stage-name">
+                Nome do estágio
+              </label>
+              <Input
+                id="stage-name"
+                value={formName}
+                onChange={(event) => onFormNameChange(event.target.value)}
+                placeholder="Ex.: Contato inicial"
+              />
+            </div>
+            <div className="flex justify-end gap-2">
+              <Dialog.Close asChild>
+                <Button type="button" variant="ghost">
+                  Cancelar
+                </Button>
+              </Dialog.Close>
+              <Button type="submit" disabled={isSaving}>
+                {isSaving ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+                {state.mode === "create" ? "Adicionar" : "Salvar"}
+              </Button>
+            </div>
+          </form>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+
+function CardDialog({
+  state,
+  onOpenChange,
+  form,
+  onFormChange,
+  onSubmit,
+  isSaving,
+}: {
+  state: CardModalState;
+  onOpenChange: (open: boolean) => void;
+  form: { title: string; customer_name: string; value: string; description: string };
+  onFormChange: (value: { title: string; customer_name: string; value: string; description: string }) => void;
+  onSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
+  isSaving: boolean;
+}) {
+  const title = state.mode === "create" ? "Nova oportunidade" : "Editar oportunidade";
+  const description =
+    state.mode === "create"
+      ? "Cadastre rapidamente uma nova oportunidade neste estágio."
+      : "Atualize as informações desta oportunidade.";
+
+  return (
+    <Dialog.Root open={state.open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/30" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 w-full max-w-lg -translate-x-1/2 -translate-y-1/2 rounded-lg bg-white p-6 shadow-lg">
+          <div className="flex items-start justify-between">
+            <div>
+              <Dialog.Title className="text-lg font-semibold">{title}</Dialog.Title>
+              <Dialog.Description className="text-sm text-muted-foreground">
+                {description}
+              </Dialog.Description>
+            </div>
+            <Dialog.Close asChild>
+              <button
+                type="button"
+                aria-label="Fechar"
+                className="rounded-md p-1 text-muted-foreground transition hover:bg-muted"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </Dialog.Close>
+          </div>
+          <form className="mt-6 space-y-4" onSubmit={onSubmit}>
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-1.5">
+                <label className="text-sm font-medium" htmlFor="card-title">
+                  Título
+                </label>
+                <Input
+                  id="card-title"
+                  value={form.title}
+                  onChange={(event) => onFormChange({ ...form, title: event.target.value })}
+                  placeholder="Ex.: Proposta enviada"
+                />
+              </div>
+              <div className="space-y-1.5">
+                <label className="text-sm font-medium" htmlFor="card-customer">
+                  Cliente
+                </label>
+                <Input
+                  id="card-customer"
+                  value={form.customer_name}
+                  onChange={(event) => onFormChange({ ...form, customer_name: event.target.value })}
+                  placeholder="Nome da empresa ou contato"
+                />
+              </div>
+            </div>
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium" htmlFor="card-value">
+                Valor estimado (R$)
+              </label>
+              <Input
+                id="card-value"
+                value={form.value}
+                onChange={(event) => onFormChange({ ...form, value: event.target.value })}
+                placeholder="Ex.: 15000"
+                inputMode="decimal"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium" htmlFor="card-description">
+                Observações
+              </label>
+              <Textarea
+                id="card-description"
+                value={form.description}
+                onChange={(event) => onFormChange({ ...form, description: event.target.value })}
+                placeholder="Inclua detalhes importantes para esta oportunidade."
+                rows={4}
+              />
+            </div>
+            <div className="flex justify-end gap-2">
+              <Dialog.Close asChild>
+                <Button type="button" variant="ghost">
+                  Cancelar
+                </Button>
+              </Dialog.Close>
+              <Button type="submit" disabled={isSaving}>
+                {isSaving ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+                {state.mode === "create" ? "Adicionar" : "Salvar"}
+              </Button>
+            </div>
+          </form>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+
+function ConfirmDialog({
+  open,
+  title,
+  description,
+  confirmLabel,
+  onOpenChange,
+  onConfirm,
+  loading,
+}: {
+  open: boolean;
+  title: string;
+  description: string;
+  confirmLabel: string;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+  loading: boolean;
+}) {
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/30" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 w-full max-w-sm -translate-x-1/2 -translate-y-1/2 rounded-lg bg-white p-6 shadow-lg">
+          <Dialog.Title className="text-lg font-semibold">{title}</Dialog.Title>
+          <Dialog.Description className="mt-2 text-sm text-muted-foreground">
+            {description}
+          </Dialog.Description>
+          <div className="mt-6 flex justify-end gap-2">
+            <Dialog.Close asChild>
+              <Button type="button" variant="ghost">
+                Cancelar
+              </Button>
+            </Dialog.Close>
+            <Button variant="destructive" onClick={onConfirm} disabled={loading}>
+              {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+              {confirmLabel}
+            </Button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+

--- a/supabase/migrations/20250222000000_create_sales_pipeline_tables.sql
+++ b/supabase/migrations/20250222000000_create_sales_pipeline_tables.sql
@@ -68,7 +68,9 @@ alter table public.pipeline enable row level security;
 alter table public.stage enable row level security;
 alter table public.card enable row level security;
 
-create policy if not exists "Pipeline acesso por empresa" on public.pipeline
+drop policy if exists "Pipeline acesso por empresa" on public.pipeline;
+
+create policy "Pipeline acesso por empresa" on public.pipeline
   for select using (
     exists (
       select 1
@@ -78,7 +80,9 @@ create policy if not exists "Pipeline acesso por empresa" on public.pipeline
     )
   );
 
-create policy if not exists "Pipeline inserção por empresa" on public.pipeline
+drop policy if exists "Pipeline inserção por empresa" on public.pipeline;
+
+create policy "Pipeline inserção por empresa" on public.pipeline
   for insert with check (
     exists (
       select 1
@@ -88,7 +92,9 @@ create policy if not exists "Pipeline inserção por empresa" on public.pipeline
     )
   );
 
-create policy if not exists "Pipeline atualização por empresa" on public.pipeline
+drop policy if exists "Pipeline atualização por empresa" on public.pipeline;
+
+create policy "Pipeline atualização por empresa" on public.pipeline
   for update using (
     exists (
       select 1
@@ -106,7 +112,9 @@ create policy if not exists "Pipeline atualização por empresa" on public.pipel
     )
   );
 
-create policy if not exists "Pipeline exclusão por empresa" on public.pipeline
+drop policy if exists "Pipeline exclusão por empresa" on public.pipeline;
+
+create policy "Pipeline exclusão por empresa" on public.pipeline
   for delete using (
     exists (
       select 1
@@ -116,7 +124,9 @@ create policy if not exists "Pipeline exclusão por empresa" on public.pipeline
     )
   );
 
-create policy if not exists "Stage acesso por empresa" on public.stage
+drop policy if exists "Stage acesso por empresa" on public.stage;
+
+create policy "Stage acesso por empresa" on public.stage
   for select using (
     exists (
       select 1
@@ -127,7 +137,9 @@ create policy if not exists "Stage acesso por empresa" on public.stage
     )
   );
 
-create policy if not exists "Stage inserção por empresa" on public.stage
+drop policy if exists "Stage inserção por empresa" on public.stage;
+
+create policy "Stage inserção por empresa" on public.stage
   for insert with check (
     exists (
       select 1
@@ -138,7 +150,9 @@ create policy if not exists "Stage inserção por empresa" on public.stage
     )
   );
 
-create policy if not exists "Stage atualização por empresa" on public.stage
+drop policy if exists "Stage atualização por empresa" on public.stage;
+
+create policy "Stage atualização por empresa" on public.stage
   for update using (
     exists (
       select 1
@@ -158,7 +172,9 @@ create policy if not exists "Stage atualização por empresa" on public.stage
     )
   );
 
-create policy if not exists "Stage exclusão por empresa" on public.stage
+drop policy if exists "Stage exclusão por empresa" on public.stage;
+
+create policy "Stage exclusão por empresa" on public.stage
   for delete using (
     exists (
       select 1
@@ -169,7 +185,9 @@ create policy if not exists "Stage exclusão por empresa" on public.stage
     )
   );
 
-create policy if not exists "Card acesso por empresa" on public.card
+drop policy if exists "Card acesso por empresa" on public.card;
+
+create policy "Card acesso por empresa" on public.card
   for select using (
     exists (
       select 1
@@ -180,7 +198,9 @@ create policy if not exists "Card acesso por empresa" on public.card
     )
   );
 
-create policy if not exists "Card inserção por empresa" on public.card
+drop policy if exists "Card inserção por empresa" on public.card;
+
+create policy "Card inserção por empresa" on public.card
   for insert with check (
     exists (
       select 1
@@ -191,7 +211,9 @@ create policy if not exists "Card inserção por empresa" on public.card
     )
   );
 
-create policy if not exists "Card atualização por empresa" on public.card
+drop policy if exists "Card atualização por empresa" on public.card;
+
+create policy "Card atualização por empresa" on public.card
   for update using (
     exists (
       select 1
@@ -211,7 +233,9 @@ create policy if not exists "Card atualização por empresa" on public.card
     )
   );
 
-create policy if not exists "Card exclusão por empresa" on public.card
+drop policy if exists "Card exclusão por empresa" on public.card;
+
+create policy "Card exclusão por empresa" on public.card
   for delete using (
     exists (
       select 1

--- a/supabase/migrations/20250222000000_create_sales_pipeline_tables.sql
+++ b/supabase/migrations/20250222000000_create_sales_pipeline_tables.sql
@@ -1,0 +1,223 @@
+create table if not exists public.pipeline (
+  id uuid not null default gen_random_uuid(),
+  created_at timestamp with time zone not null default now(),
+  updated_at timestamp with time zone not null default now(),
+  company_id bigint not null references public.company(id) on delete cascade,
+  name text not null,
+  constraint pipeline_pkey primary key (id)
+);
+
+create table if not exists public.stage (
+  id uuid not null default gen_random_uuid(),
+  created_at timestamp with time zone not null default now(),
+  updated_at timestamp with time zone not null default now(),
+  pipeline_id uuid not null references public.pipeline(id) on delete cascade,
+  name text not null,
+  position integer not null default 0,
+  constraint stage_pkey primary key (id)
+);
+
+create table if not exists public.card (
+  id uuid not null default gen_random_uuid(),
+  created_at timestamp with time zone not null default now(),
+  updated_at timestamp with time zone not null default now(),
+  company_id bigint not null references public.company(id) on delete cascade,
+  pipeline_id uuid not null references public.pipeline(id) on delete cascade,
+  stage_id uuid not null references public.stage(id) on delete cascade,
+  title text not null,
+  customer_name text null,
+  description text null,
+  value numeric(14, 2) null,
+  position integer not null default 0,
+  constraint card_pkey primary key (id)
+);
+
+create or replace function public.set_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+create trigger pipeline_set_updated_at
+  before update on public.pipeline
+  for each row
+  execute function public.set_updated_at();
+
+create trigger stage_set_updated_at
+  before update on public.stage
+  for each row
+  execute function public.set_updated_at();
+
+create trigger card_set_updated_at
+  before update on public.card
+  for each row
+  execute function public.set_updated_at();
+
+create index if not exists stage_pipeline_id_idx on public.stage(pipeline_id);
+create index if not exists stage_position_idx on public.stage(position);
+create index if not exists card_stage_id_idx on public.card(stage_id);
+create index if not exists card_pipeline_id_idx on public.card(pipeline_id);
+create index if not exists card_company_id_idx on public.card(company_id);
+create index if not exists card_position_idx on public.card(position);
+
+alter table public.pipeline enable row level security;
+alter table public.stage enable row level security;
+alter table public.card enable row level security;
+
+create policy if not exists "Pipeline acesso por empresa" on public.pipeline
+  for select using (
+    exists (
+      select 1
+      from public.company c
+      where c.id = pipeline.company_id
+        and c.user_id = auth.uid()
+    )
+  );
+
+create policy if not exists "Pipeline inserção por empresa" on public.pipeline
+  for insert with check (
+    exists (
+      select 1
+      from public.company c
+      where c.id = pipeline.company_id
+        and c.user_id = auth.uid()
+    )
+  );
+
+create policy if not exists "Pipeline atualização por empresa" on public.pipeline
+  for update using (
+    exists (
+      select 1
+      from public.company c
+      where c.id = pipeline.company_id
+        and c.user_id = auth.uid()
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from public.company c
+      where c.id = pipeline.company_id
+        and c.user_id = auth.uid()
+    )
+  );
+
+create policy if not exists "Pipeline exclusão por empresa" on public.pipeline
+  for delete using (
+    exists (
+      select 1
+      from public.company c
+      where c.id = pipeline.company_id
+        and c.user_id = auth.uid()
+    )
+  );
+
+create policy if not exists "Stage acesso por empresa" on public.stage
+  for select using (
+    exists (
+      select 1
+      from public.pipeline p
+      join public.company c on c.id = p.company_id
+      where p.id = stage.pipeline_id
+        and c.user_id = auth.uid()
+    )
+  );
+
+create policy if not exists "Stage inserção por empresa" on public.stage
+  for insert with check (
+    exists (
+      select 1
+      from public.pipeline p
+      join public.company c on c.id = p.company_id
+      where p.id = stage.pipeline_id
+        and c.user_id = auth.uid()
+    )
+  );
+
+create policy if not exists "Stage atualização por empresa" on public.stage
+  for update using (
+    exists (
+      select 1
+      from public.pipeline p
+      join public.company c on c.id = p.company_id
+      where p.id = stage.pipeline_id
+        and c.user_id = auth.uid()
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from public.pipeline p
+      join public.company c on c.id = p.company_id
+      where p.id = stage.pipeline_id
+        and c.user_id = auth.uid()
+    )
+  );
+
+create policy if not exists "Stage exclusão por empresa" on public.stage
+  for delete using (
+    exists (
+      select 1
+      from public.pipeline p
+      join public.company c on c.id = p.company_id
+      where p.id = stage.pipeline_id
+        and c.user_id = auth.uid()
+    )
+  );
+
+create policy if not exists "Card acesso por empresa" on public.card
+  for select using (
+    exists (
+      select 1
+      from public.pipeline p
+      join public.company c on c.id = p.company_id
+      where p.id = card.pipeline_id
+        and c.user_id = auth.uid()
+    )
+  );
+
+create policy if not exists "Card inserção por empresa" on public.card
+  for insert with check (
+    exists (
+      select 1
+      from public.pipeline p
+      join public.company c on c.id = p.company_id
+      where p.id = card.pipeline_id
+        and c.user_id = auth.uid()
+    )
+  );
+
+create policy if not exists "Card atualização por empresa" on public.card
+  for update using (
+    exists (
+      select 1
+      from public.pipeline p
+      join public.company c on c.id = p.company_id
+      where p.id = card.pipeline_id
+        and c.user_id = auth.uid()
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from public.pipeline p
+      join public.company c on c.id = p.company_id
+      where p.id = card.pipeline_id
+        and c.user_id = auth.uid()
+    )
+  );
+
+create policy if not exists "Card exclusão por empresa" on public.card
+  for delete using (
+    exists (
+      select 1
+      from public.pipeline p
+      join public.company c on c.id = p.company_id
+      where p.id = card.pipeline_id
+        and c.user_id = auth.uid()
+    )
+  );


### PR DESCRIPTION
## Summary
- add a sales pipeline dashboard page with kanban interactions, dialogs and drag and drop powered by dnd-kit
- register the new navigation link and document the feature and security requirements
- create Supabase tables and RLS policies for pipelines, stages and cards

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5f6c8652883338d56dd53ccdb3c8e