### PR TITLE
Remove filtros rápidos do Kanban

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ O painel do CRM agora conta com a página **Funil de vendas**, acessível pela s
 
 - Criar, editar e excluir funis para diferentes jornadas comerciais (menu de três pontinhos no topo da página).
 - Organizar etapas personalizadas para cada funil, definindo todos os estágios diretamente no modal de criação/edição e reordenando oportunidades por _drag and drop_ com `@hello-pangea/dnd`.
+- Visualizar o quadro do funil sem faixas de filtros rápidos, mantendo o foco na movimentação das oportunidades.
 - Arrastar cards para estágios vazios utilizando a área destacada de destino, mantendo o comportamento consistente entre drag and drop e o seletor do modal.
 - Registrar informações relevantes em cards (MRR, responsável, status, última interação e próximas ações).
 - Digitar continuamente nos campos dos estágios e dos cards sem perda de foco, com os modais liberando o board assim que são fechados.

--- a/docs/crm.md
+++ b/docs/crm.md
@@ -27,5 +27,6 @@ As tabelas criadas para suportar o módulo ficam no schema público do Supabase:
 - Estágios são manipulados dentro do modal principal, evitando diálogos adicionais; a confirmação de exclusão permanece apenas para funis e cards.
 - A contagem de oportunidades por estágio é recalculada automaticamente após cada operação.
 - O botão **Cancelar** fecha o modal sem persistir mudanças e libera imediatamente a interação com o restante da interface.
+- O quadro prioriza a visualização das colunas do funil, sem exibir filtros rápidos que desviem a atenção das oportunidades.
 - Campos de estágios e cards preservam o foco durante a digitação e, ao fechar os modais por **Cancelar** ou **Salvar**, o board volta a aceitar interações imediatamente; o front-end utiliza o componente `Modal` dedicado para desmontar completamente cada diálogo assim que ele é fechado, reiniciar o formulário, restaurar o `overflow` do documento e remover a camada escura na mesma renderização. A substituição do mecanismo de _drag and drop_ por `@hello-pangea/dnd` elimina os bloqueios residuais que ocorriam após cancelar ou salvar um funil.
 - A implementação foi modularizada em componentes (`StageColumn`, `PipelineDialog`, `CardDialog` e `Modal`), reduzindo duplicação de lógica e garantindo que estados e sobreposições sejam resetados em cada ciclo de abertura.

--- a/src/app/dashboard/funil-de-vendas/page.tsx
+++ b/src/app/dashboard/funil-de-vendas/page.tsx
@@ -12,7 +12,7 @@ import {
 } from '@/components/ui/select'
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import { supabasebrowser } from '@/lib/supabaseClient'
-import { Filter, Loader2, MoreHorizontal, Plus } from 'lucide-react'
+import { Loader2, MoreHorizontal, Plus } from 'lucide-react'
 import { toast } from 'sonner'
 import { CardDialog } from './components/card-dialog'
 import { PipelineDialog } from './components/pipeline-dialog'
@@ -737,21 +737,6 @@ export default function SalesPipelinePage() {
                 </SelectContent>
               </Select>
             </div>
-          </div>
-
-          <div className="flex flex-wrap gap-2 text-sm text-gray-600">
-            <Button variant="outline" className="flex items-center gap-2 border-dashed">
-              <Filter className="h-4 w-4" /> Filtros rápidos
-            </Button>
-            <Button variant="ghost" className="text-gray-500 hover:text-gray-900">
-              Última atividade
-            </Button>
-            <Button variant="ghost" className="text-gray-500 hover:text-gray-900">
-              Proprietário
-            </Button>
-            <Button variant="ghost" className="text-gray-500 hover:text-gray-900">
-              Intervalo de datas
-            </Button>
           </div>
 
           <div className="-mx-2 overflow-x-auto pb-6">


### PR DESCRIPTION
## Summary
- remove the quick filter button row from the Kanban board to keep the pipeline focused on oportunidades
- atualiza README e documentação do CRM para refletir a remoção dos filtros rápidos

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6a779aa7483338a973227a8e000c3