### PR TITLE
Ajusta contraste do cabeçalho e estado vazio do funil

### DIFF
--- a/docs/crm.md
+++ b/docs/crm.md
@@ -28,6 +28,7 @@ As tabelas criadas para suportar o módulo ficam no schema público do Supabase:
 - A contagem de oportunidades por estágio é recalculada automaticamente após cada operação.
 - O botão **Cancelar** fecha o modal sem persistir mudanças e libera imediatamente a interação com o restante da interface.
 - O quadro prioriza a visualização das colunas do funil, sem exibir filtros rápidos que desviem a atenção das oportunidades.
+- Cabeçalhos de estágio e estados vazios usam tons de cinza com contraste mínimo de 4,5:1, garantindo leitura confortável mesmo sobre fundos translúcidos.
 - Campos de estágios e cards preservam o foco durante a digitação e, ao fechar os modais por **Cancelar** ou **Salvar**, o board volta a aceitar interações imediatamente; o front-end utiliza o componente `Modal` dedicado para desmontar completamente cada diálogo assim que ele é fechado, reiniciar o formulário, restaurar o `overflow` do documento e remover a camada escura na mesma renderização. A substituição do mecanismo de _drag and drop_ por `@hello-pangea/dnd` elimina os bloqueios residuais que ocorriam após cancelar ou salvar um funil.
 - A implementação foi modularizada em componentes (`StageColumn`, `PipelineDialog`, `CardDialog` e `Modal`), reduzindo duplicação de lógica e garantindo que estados e sobreposições sejam resetados em cada ciclo de abertura.
 - Em telas pequenas, o board kanban faz uso de rolagem horizontal com _snap_ por estágio, permitindo navegar pelas colunas sem quebrar o layout ou comprometer a leitura dos cards.

--- a/src/app/dashboard/funil-de-vendas/components/stage-column.tsx
+++ b/src/app/dashboard/funil-de-vendas/components/stage-column.tsx
@@ -33,7 +33,7 @@ export function StageColumn({
     >
       <div className="mb-4 flex items-start justify-between gap-2">
         <div>
-          <p className="text-xs uppercase tracking-wide text-gray-400">Estágio</p>
+          <p className="text-xs uppercase tracking-wide text-gray-600">Estágio</p>
           <h3 className="text-lg font-semibold text-gray-900">{stage.name}</h3>
           <p className="text-xs text-gray-500">{cards.length} oportunidades</p>
         </div>
@@ -50,7 +50,7 @@ export function StageColumn({
             )}
           >
             {isLoading ? (
-              <div className="flex h-32 items-center justify-center text-gray-400">
+              <div className="flex h-32 items-center justify-center text-gray-600">
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Carregando
               </div>
             ) : cards.length ? (
@@ -64,7 +64,7 @@ export function StageColumn({
                 />
               ))
             ) : (
-              <div className="flex h-24 items-center justify-center rounded-lg border border-dashed border-slate-300 bg-white/60 text-xs font-medium uppercase tracking-wide text-slate-400">
+              <div className="flex h-24 items-center justify-center rounded-lg border border-dashed border-slate-300 bg-white/70 text-xs font-medium uppercase tracking-wide text-slate-600">
                 Arraste oportunidades para cá
               </div>
             )}


### PR DESCRIPTION
## Resumo
- aumenta o contraste do cabeçalho dos estágios e do estado vazio no funil de vendas
- documenta os novos tons adotados para garantir legibilidade

## Testes
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68d6b384dbdc8333bec6fe5c9f15004a