### PR TITLE
Remover tag dos cards do funil e ajustar truncamento de texto

### DIFF
--- a/docs/BRANDING.md
+++ b/docs/BRANDING.md
@@ -32,7 +32,8 @@ A unidade base de espaçamento segue o padrão do Tailwind CSS (4 px). Organize
 
 ## Diretrizes para o funil de vendas
 - Os cards do funil utilizam cantos arredondados de 16 px, sombra suave e espaçamento interno de 16 px.
-- Indicadores de status (tags, risco, responsável) devem seguir a paleta principal com variações em azul, roxo e verde claro.
+- Indicadores de status (status textual, risco e métricas) devem seguir a paleta principal com variações em azul, roxo e verde claro.
+- O cabeçalho do card prioriza título e empresa, agora com truncamento de linhas para preservar a leitura sem exibir a antiga tag.
 - O cabeçalho de cada estágio apresenta contagem de oportunidades em tipografia pequena e discreta.
 - Ações de gerenciamento do funil ficam agrupadas no menu de três pontinhos do cabeçalho; os estágios exibem apenas título e contagem para manter o foco nas oportunidades.
 - Formulários modais devem preservar o foco dos campos durante a digitação e, ao cancelar ou salvar, desmontar o diálogo, limpar os campos e remover a sobreposição esmaecida com leve _blur_. Os componentes (`PipelineDialog`, `CardDialog` e `Modal`) agora só ficam montados enquanto estiverem visíveis, aplicando o portal personalizado para bloquear o _scroll_ temporariamente e restabelecer o `body` ao fechar; isso reforça a percepção de fluidez e evita o bloqueio residual observado anteriormente. Mantenha a identidade visual alinhada entre eles ao aplicar ajustes.

--- a/docs/crm.md
+++ b/docs/crm.md
@@ -28,8 +28,9 @@ A página **Funil de vendas** centraliza os funis comerciais da empresa logada. 
 - Limite de cinco funis por empresa e dez estágios por funil para manter o gerenciamento enxuto.
 - Gestão de estágios diretamente no modal de criação/edição do funil, com campos para adicionar, renomear e remover etapas antes de salvar.
 - Transferência de oportunidades entre estágios pelo modal de edição, escolhendo o destino no seletor dedicado, inclusive para colunas vazias.
-- Cadastro e atualização de cards com campos de contato, tag, status, responsável, métricas de mensagens e datas importantes.
+- Cadastro e atualização de cards com campos de contato, status, responsável, métricas de mensagens e datas importantes. O campo de tag continua disponível no formulário apenas para fins internos e não é mais exibido no card.
 - Campos de funil, estágios e cards com limites de caracteres para preservar a legibilidade das colunas.
+- Títulos, empresas e responsáveis dos cards recebem truncamento automático para evitar estouro visual dentro das colunas.
 - Reordenação de cards por _drag and drop_ com `@hello-pangea/dnd`, garantindo atualização imediata da coluna/posição no Supabase e evitando o bloqueio de cliques observado com a implementação anterior.
 - Área de drop dedicada nas colunas vazias, permitindo transferir cards por arraste mesmo quando o estágio não possui oportunidades.
 

--- a/src/app/dashboard/funil-de-vendas/components/deal-card-item.tsx
+++ b/src/app/dashboard/funil-de-vendas/components/deal-card-item.tsx
@@ -39,30 +39,27 @@ export function DealCardItem({ card, index, onEdit, onDelete }: DealCardItemProp
           )}
         >
           <div className="flex items-start justify-between gap-2">
-            <div className="space-y-1">
-              <h4 className="text-sm font-semibold text-gray-900">{card.title}</h4>
+            <div className="min-w-0 space-y-1">
+              <h4 className="clamp-2-lines text-sm font-semibold text-gray-900" title={card.title}>
+                {card.title}
+              </h4>
               {card.company_name ? (
-                <p className="text-xs text-gray-500">{card.company_name}</p>
+                <p className="text-xs text-gray-500" title={card.company_name}>
+                  <span className="block truncate">{card.company_name}</span>
+                </p>
               ) : null}
             </div>
-            <div className="flex items-center gap-1">
-              {card.tag ? (
-                <span className="rounded-full bg-blue-50 px-2 py-1 text-[11px] font-semibold uppercase tracking-wide text-blue-600">
-                  {card.tag}
-                </span>
-              ) : null}
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-7 w-7 text-gray-500 hover:text-gray-800"
-                onClick={(event) => {
-                  event.stopPropagation()
-                  onEdit(card)
-                }}
-              >
-                <MoreHorizontal className="h-4 w-4" />
-              </Button>
-            </div>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7 text-gray-500 hover:text-gray-800"
+              onClick={(event) => {
+                event.stopPropagation()
+                onEdit(card)
+              }}
+            >
+              <MoreHorizontal className="h-4 w-4" />
+            </Button>
           </div>
 
           <div className="mt-3 flex flex-wrap items-center gap-2 text-xs">
@@ -87,19 +84,21 @@ export function DealCardItem({ card, index, onEdit, onDelete }: DealCardItemProp
 
           <div className="mt-4 space-y-2 text-xs text-gray-500">
             {card.owner ? (
-              <div className="flex items-center gap-2">
+              <div className="flex min-w-0 items-center gap-2">
                 <User className="h-3.5 w-3.5 text-gray-400" />
-                <span>{card.owner}</span>
+                <span className="flex-1 truncate" title={card.owner}>
+                  {card.owner}
+                </span>
               </div>
             ) : null}
             {lastContact ? (
-              <div className="flex items-center gap-2">
+              <div className="flex min-w-0 items-center gap-2">
                 <MessageSquare className="h-3.5 w-3.5 text-gray-400" />
                 <span>Último contato: {lastContact}</span>
               </div>
             ) : null}
             {nextAction ? (
-              <div className="flex items-center gap-2 text-indigo-600">
+              <div className="flex min-w-0 items-center gap-2 text-indigo-600">
                 <Clock className="h-3.5 w-3.5" />
                 <span>Próxima ação: {nextAction}</span>
               </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -161,5 +161,12 @@ body,
   .animate-float {
     animation: float 3s ease-in-out infinite;
   }
+
+  .clamp-2-lines {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
 }
 


### PR DESCRIPTION
## Resumo
- remove a exibição da tag nos cards do funil e acrescenta truncamento em título, empresa e responsável
- adiciona utilitário global para clamp de duas linhas e garante layout sem overflow
- atualiza diretrizes de CRM e branding para refletir ausência da tag e nova regra de truncamento

## Testes
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6ca0f1eac8333963f522fabb48b53