### PR TITLE
feat: adicionar atualização automática do funil

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ O painel do CRM agora conta com a página **Funil de vendas**, acessível pela s
 - Fechar o modal com **Cancelar** ou **Salvar** para descartar ou confirmar alterações com segurança; os diálogos utilizam um componente `Modal` próprio que aplica o _portal_ manualmente, desmonta o conteúdo assim que deixa de estar visível, restaura o `overflow` do `body` e remove a sobreposição na mesma renderização. Em conjunto com o mecanismo de drag and drop `@hello-pangea/dnd`, o board permanece interativo após qualquer salvamento ou cancelamento, sem travamentos residuais.
 - A página é segmentada em componentes reutilizáveis (`StageColumn`, `PipelineDialog`, `CardDialog` e `Modal`), o que mantém o código enxuto e garante que cada modal seja desmontado rapidamente após salvar ou cancelar.
 - Em dispositivos móveis, o board kanban utiliza rolagem horizontal com alinhamento por estágio para manter a leitura confortável sem perder a estrutura original.
+- Um botão de atualização ao lado das opções do funil recarrega as colunas sob demanda, fica indisponível por 10 segundos após cada clique e conta com uma rotina automática que força a atualização do board a cada 5 minutos.
 
 Os dados são salvos em tabelas dedicadas (`pipeline`, `stage` e `card`) e vinculados à empresa autenticada via Supabase.
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ O painel do CRM agora conta com a página **Funil de vendas**, acessível pela s
 - Fechar o modal com **Cancelar** ou **Salvar** para descartar ou confirmar alterações com segurança; os diálogos utilizam um componente `Modal` próprio que aplica o _portal_ manualmente, desmonta o conteúdo assim que deixa de estar visível, restaura o `overflow` do `body` e remove a sobreposição na mesma renderização. Em conjunto com o mecanismo de drag and drop `@hello-pangea/dnd`, o board permanece interativo após qualquer salvamento ou cancelamento, sem travamentos residuais.
 - A página é segmentada em componentes reutilizáveis (`StageColumn`, `PipelineDialog`, `CardDialog` e `Modal`), o que mantém o código enxuto e garante que cada modal seja desmontado rapidamente após salvar ou cancelar.
 - Em dispositivos móveis, o board kanban utiliza rolagem horizontal com alinhamento por estágio para manter a leitura confortável sem perder a estrutura original.
-- Um botão de atualização ao lado das opções do funil recarrega as colunas sob demanda, fica indisponível por 10 segundos após cada clique e conta com uma rotina automática que força a atualização do board a cada 5 minutos.
+- Um botão de atualização ao lado das opções do funil recarrega as colunas sob demanda, fica indisponível por 10 segundos após cada clique, tem o cooldown reiniciado quando o usuário troca de funil e conta com uma rotina automática que força a atualização do board a cada 5 minutos.
 
 Os dados são salvos em tabelas dedicadas (`pipeline`, `stage` e `card`) e vinculados à empresa autenticada via Supabase.
 

--- a/docs/crm.md
+++ b/docs/crm.md
@@ -33,7 +33,7 @@ A página **Funil de vendas** centraliza os funis comerciais da empresa logada. 
 - Títulos, empresas e responsáveis dos cards recebem truncamento automático para evitar estouro visual dentro das colunas.
 - Reordenação de cards por _drag and drop_ com `@hello-pangea/dnd`, garantindo atualização imediata da coluna/posição no Supabase e evitando o bloqueio de cliques observado com a implementação anterior.
 - Área de drop dedicada nas colunas vazias, permitindo transferir cards por arraste mesmo quando o estágio não possui oportunidades.
-- Botão de atualização dedicado ao funil, com bloqueio de 10 segundos entre cliques e rotina automática que força a recarga do board a cada 5 minutos.
+- Botão de atualização dedicado ao funil, com bloqueio de 10 segundos entre cliques, cooldown reiniciado automaticamente ao alternar de funil e rotina automática que força a recarga do board a cada 5 minutos.
 
 ## Estrutura de dados
 As tabelas criadas para suportar o módulo ficam no schema público do Supabase:

--- a/docs/crm.md
+++ b/docs/crm.md
@@ -33,6 +33,7 @@ A página **Funil de vendas** centraliza os funis comerciais da empresa logada. 
 - Títulos, empresas e responsáveis dos cards recebem truncamento automático para evitar estouro visual dentro das colunas.
 - Reordenação de cards por _drag and drop_ com `@hello-pangea/dnd`, garantindo atualização imediata da coluna/posição no Supabase e evitando o bloqueio de cliques observado com a implementação anterior.
 - Área de drop dedicada nas colunas vazias, permitindo transferir cards por arraste mesmo quando o estágio não possui oportunidades.
+- Botão de atualização dedicado ao funil, com bloqueio de 10 segundos entre cliques e rotina automática que força a recarga do board a cada 5 minutos.
 
 ## Estrutura de dados
 As tabelas criadas para suportar o módulo ficam no schema público do Supabase:


### PR DESCRIPTION
## Summary
- adicionar botão de atualização manual no cabeçalho do funil com bloqueio de 10 segundos entre recargas
- implementar rotina automática para recarregar o board do funil a cada 5 minutos
- documentar o novo fluxo de atualização no README e no guia do CRM

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6d09260488333b74dab36eadb1517