### PR TITLE
Fix Chatwoot SSO method and ensure CRM embed uses full height

### DIFF
--- a/docs/crm.md
+++ b/docs/crm.md
@@ -12,10 +12,12 @@ O módulo de CRM agora carrega o Chatwoot diretamente dentro do dashboard em um 
 1. Manter as variáveis de ambiente `CHATWOOT_BASE_URL` e `CHATWOOT_PLATFORM_TOKEN` configuradas.
 2. Garantir que o campo `chatwoot_user_id` esteja preenchido na tabela `company` para o usuário autenticado.
 3. Confirmar que a rota `/api/chatwoot/sso` responda com um objeto `{ url: string }`. Respostas inválidas exibem o estado de erro padrão.
+4. A rota interna aciona o endpoint `POST /platform/api/v1/users/:id/login` do Chatwoot utilizando o `api_access_token`. Retornos sem `url` ou com falha de autenticação exibem o fallback de erro.
 
 ## Boas práticas de UI
 - Evite adicionar cabeçalhos ou descrições extras no módulo para preservar a experiência imersiva.
 - Caso seja necessário exibir avisos, utilize os componentes de alerta globais do dashboard, evitando sobrepor elementos dentro do iframe.
+- Mantenha o contêiner do CRM com altura mínima equivalente à área útil (`100svh - 10rem`) para que o iframe ocupe toda a tela disponível sem barras vazias.
 
 # CRM e Funil de vendas
 

--- a/src/app/api/chatwoot/sso/route.ts
+++ b/src/app/api/chatwoot/sso/route.ts
@@ -43,6 +43,7 @@ export async function GET() {
     const resp = await fetch(
       `${baseUrl}/platform/api/v1/users/${company.chatwoot_user_id}/login`,
       {
+        method: "POST",
         headers: {
           api_access_token: `${token}`,
         },

--- a/src/app/dashboard/crm/page.tsx
+++ b/src/app/dashboard/crm/page.tsx
@@ -71,20 +71,20 @@ export default function DashboardCrmPage() {
         key={state.url}
         src={state.url}
         title="CRM Evoluke"
-        className="h-full w-full"
+        className="flex-1 min-h-[calc(100svh-10rem)] w-full"
         allow="camera; microphone; clipboard-read; clipboard-write"
       />
     );
   } else if (state.status === "loading") {
     content = (
-      <div className="flex h-full w-full flex-col items-center justify-center gap-3 p-6 text-center text-sm text-gray-600">
+      <div className="flex min-h-[calc(100svh-10rem)] w-full flex-1 flex-col items-center justify-center gap-3 p-6 text-center text-sm text-gray-600">
         <Loader2 className="h-6 w-6 animate-spin text-[#2F6F68]" />
         <p>Conectando com o CRM...</p>
       </div>
     );
   } else {
     content = (
-      <div className="flex h-full w-full flex-col items-center justify-center gap-4 p-6 text-center text-sm text-gray-600">
+      <div className="flex min-h-[calc(100svh-10rem)] w-full flex-1 flex-col items-center justify-center gap-4 p-6 text-center text-sm text-gray-600">
         <p>{state.message}</p>
         <Button onClick={handleReload}>Tentar novamente</Button>
       </div>
@@ -92,7 +92,7 @@ export default function DashboardCrmPage() {
   }
 
   return (
-    <section className="relative flex w-full flex-1 overflow-hidden rounded-lg border bg-white min-h-[calc(100svh-10rem)]">
+    <section className="relative flex w-full overflow-hidden rounded-lg border bg-white">
       {content}
     </section>
   );


### PR DESCRIPTION
## Summary
- update the Chatwoot SSO route to call the login endpoint with POST so the platform issues a valid session URL
- stretch the CRM iframe and its loading/error states to occupy the available viewport height inside the dashboard card
- document the POST requirement for the SSO handshake and the sizing rule that keeps the embed in full screen

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6d9e624508333a45b49c6bacfc2d2