### PR TITLE
Handle non-JSON Chatwoot SSO responses

### DIFF
--- a/docs/crm.md
+++ b/docs/crm.md
@@ -11,7 +11,7 @@ O módulo de CRM agora carrega o Chatwoot diretamente dentro do dashboard em um 
 ## Requisitos para o SSO
 1. Manter as variáveis de ambiente `CHATWOOT_BASE_URL` e `CHATWOOT_PLATFORM_TOKEN` configuradas.
 2. Garantir que o campo `chatwoot_user_id` esteja preenchido na tabela `company` para o usuário autenticado.
-3. Confirmar que a rota `/api/chatwoot/sso` responda com um objeto `{ url: string }`. Respostas inválidas exibem o estado de erro padrão.
+3. Confirmar que a rota `/api/chatwoot/sso` responda com um objeto `{ url: string }`. Respostas inválidas exibem o estado de erro padrão e geram logs indicando o tipo de conteúdo retornado quando não for JSON.
 
 ## Boas práticas de UI
 - Evite adicionar cabeçalhos ou descrições extras no módulo para preservar a experiência imersiva.

--- a/src/app/api/chatwoot/sso/route.ts
+++ b/src/app/api/chatwoot/sso/route.ts
@@ -49,15 +49,24 @@ export async function GET() {
       }
     );
 
-    const text = await resp.text();
-    let data: { url?: string } = {};
-    try {
-      data = JSON.parse(text);
-    } catch (err) {
-      console.error("[Chatwoot SSO] Error parsing response", err);
+    const contentType = resp.headers.get("content-type") ?? "";
+    const rawBody = await resp.text();
+    let data: { url?: string } | null = null;
+
+    if (contentType.includes("application/json")) {
+      try {
+        data = JSON.parse(rawBody);
+      } catch (err) {
+        console.error("[Chatwoot SSO] Error parsing JSON response", err);
+      }
+    } else {
+      console.error("[Chatwoot SSO] Unexpected content-type", {
+        contentType,
+        snippet: rawBody.slice(0, 200),
+      });
     }
 
-    if (!resp.ok || !data.url) {
+    if (!resp.ok || !data?.url) {
       return NextResponse.json(
         { error: "SSO indisponível" },
         { status: resp.status || 500 }


### PR DESCRIPTION
## Summary
- guard the Chatwoot SSO route against non-JSON responses and log unexpected payload details
- document the new logging behavior for invalid SSO responses in the CRM guide

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6dd1e73c4833393f76bc4e1834498