### PR TITLE
Atualiza menu contextual dos cards do funil de vendas

### DIFF
--- a/docs/crm.md
+++ b/docs/crm.md
@@ -10,6 +10,7 @@ A página **Funil de vendas** centraliza os funis comerciais da empresa logada. 
 - Gestão de estágios diretamente no modal de criação/edição do funil, com campos para adicionar, renomear, escolher a cor com um seletor nativo e remover etapas antes de salvar.
 - Cada estágio recebe uma cor de fundo armazenada no campo `stage.color`, aplicada diretamente como plano de fundo da coluna no board.
 - Transferência de oportunidades entre estágios pelo modal de edição, escolhendo o destino no seletor dedicado, inclusive para colunas vazias.
+- Menu de contexto nos cards com ações de transferência direta para outros funis (sempre posicionando a oportunidade no primeiro estágio disponível) e remoção rápida.
 - Cadastro e atualização de cards com campos de contato, status, responsável, métricas de mensagens e datas importantes. O campo de tag continua disponível no formulário apenas para fins internos e não é mais exibido no card.
 - Campos de funil, estágios e cards com limites de caracteres para preservar a legibilidade das colunas.
 - Títulos, empresas e responsáveis dos cards recebem truncamento automático para evitar estouro visual dentro das colunas.
@@ -36,6 +37,7 @@ As tabelas criadas para suportar o módulo ficam no schema público do Supabase:
 ## Considerações de UX
 - Quando não há funis cadastrados, o usuário vê um _empty state_ orientado à criação do primeiro funil.
 - As ações de funil (novo, editar e excluir) ficam agrupadas no menu de três pontinhos no cabeçalho da página.
+- Os cards usam um menu de três pontinhos dedicado para transferências entre funis e remoção, mantendo o botão principal reservado para abrir os detalhes.
 - Estágios são manipulados dentro do modal principal, evitando diálogos adicionais; a confirmação de exclusão permanece apenas para funis e cards.
 - A contagem de oportunidades por estágio é recalculada automaticamente após cada operação.
 - O botão **Cancelar** fecha o modal sem persistir mudanças e libera imediatamente a interação com o restante da interface.

--- a/src/app/dashboard/funil-de-vendas/components/deal-card-item.tsx
+++ b/src/app/dashboard/funil-de-vendas/components/deal-card-item.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Draggable } from '@hello-pangea/dnd'
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import {
@@ -11,19 +12,29 @@ import {
   MoreHorizontal,
   User,
 } from 'lucide-react'
-import { DealCard } from '../types'
+import { DealCard, Pipeline } from '../types'
 import { formatCurrency, formatShortDate } from '../helpers'
 
 type DealCardItemProps = {
   card: DealCard
   index: number
+  pipelines: Pipeline[]
   onEdit: (card: DealCard) => void
   onDelete: (card: DealCard) => void
+  onTransfer: (card: DealCard, pipelineId: string) => void
 }
 
-export function DealCardItem({ card, index, onEdit, onDelete }: DealCardItemProps) {
+export function DealCardItem({
+  card,
+  index,
+  pipelines,
+  onEdit,
+  onDelete,
+  onTransfer,
+}: DealCardItemProps) {
   const lastContact = formatShortDate(card.last_message_at)
   const nextAction = formatShortDate(card.next_action_at)
+  const otherPipelines = pipelines.filter((pipeline) => pipeline.id !== card.pipeline_id)
 
   return (
     <Draggable draggableId={card.id} index={index}>
@@ -49,17 +60,65 @@ export function DealCardItem({ card, index, onEdit, onDelete }: DealCardItemProp
                 </p>
               ) : null}
             </div>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-7 w-7 text-gray-500 hover:text-gray-800"
-              onClick={(event) => {
-                event.stopPropagation()
-                onEdit(card)
-              }}
-            >
-              <MoreHorizontal className="h-4 w-4" />
-            </Button>
+            <DropdownMenu.Root>
+              <DropdownMenu.Trigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7 text-gray-500 hover:text-gray-800"
+                  onClick={(event) => {
+                    event.stopPropagation()
+                  }}
+                >
+                  <MoreHorizontal className="h-4 w-4" />
+                </Button>
+              </DropdownMenu.Trigger>
+              <DropdownMenu.Portal>
+                <DropdownMenu.Content
+                  align="end"
+                  className="z-50 min-w-[200px] rounded-md border border-slate-200 bg-white p-1.5 text-sm shadow-lg"
+                >
+                  {otherPipelines.length ? (
+                    <DropdownMenu.Sub>
+                      <DropdownMenu.SubTrigger className="flex cursor-pointer items-center justify-between gap-2 rounded-md px-3 py-2 text-left text-gray-700 outline-none transition hover:bg-slate-100 focus:bg-slate-100">
+                        Transferir para outro funil
+                      </DropdownMenu.SubTrigger>
+                      <DropdownMenu.Portal>
+                        <DropdownMenu.SubContent className="z-50 min-w-[220px] rounded-md border border-slate-200 bg-white p-1.5 text-sm shadow-lg">
+                          {otherPipelines.map((pipeline) => (
+                            <DropdownMenu.Item
+                              key={pipeline.id}
+                              className="cursor-pointer rounded-md px-3 py-2 text-gray-700 outline-none transition hover:bg-slate-100 focus:bg-slate-100"
+                              onSelect={() => {
+                                onTransfer(card, pipeline.id)
+                              }}
+                            >
+                              {pipeline.name}
+                            </DropdownMenu.Item>
+                          ))}
+                        </DropdownMenu.SubContent>
+                      </DropdownMenu.Portal>
+                    </DropdownMenu.Sub>
+                  ) : (
+                    <DropdownMenu.Item
+                      disabled
+                      className="cursor-not-allowed rounded-md px-3 py-2 text-gray-400"
+                    >
+                      Nenhum outro funil disponível
+                    </DropdownMenu.Item>
+                  )}
+                  <DropdownMenu.Separator className="my-1 h-px bg-slate-200" />
+                  <DropdownMenu.Item
+                    className="cursor-pointer rounded-md px-3 py-2 text-destructive outline-none transition hover:bg-destructive/10 focus:bg-destructive/10"
+                    onSelect={() => {
+                      onDelete(card)
+                    }}
+                  >
+                    Remover oportunidade
+                  </DropdownMenu.Item>
+                </DropdownMenu.Content>
+              </DropdownMenu.Portal>
+            </DropdownMenu.Root>
           </div>
 
           <div className="mt-3 flex flex-wrap items-center gap-2 text-xs">
@@ -105,17 +164,7 @@ export function DealCardItem({ card, index, onEdit, onDelete }: DealCardItemProp
             ) : null}
           </div>
 
-          <div className="mt-4 flex items-center justify-between text-[11px] text-gray-400">
-            <button
-              type="button"
-              className="font-medium text-destructive hover:underline"
-              onClick={(event) => {
-                event.stopPropagation()
-                onDelete(card)
-              }}
-            >
-              Remover
-            </button>
+          <div className="mt-4 flex justify-end text-[11px] text-gray-400">
             <button
               type="button"
               className="inline-flex items-center gap-1 font-medium text-primary hover:underline"

--- a/src/app/dashboard/funil-de-vendas/components/stage-column.tsx
+++ b/src/app/dashboard/funil-de-vendas/components/stage-column.tsx
@@ -4,7 +4,7 @@ import { Droppable } from '@hello-pangea/dnd'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { Loader2, Plus } from 'lucide-react'
-import { DealCard, DEFAULT_STAGE_COLOR, Stage } from '../types'
+import { DealCard, DEFAULT_STAGE_COLOR, Pipeline, Stage } from '../types'
 import { DealCardItem } from './deal-card-item'
 
 type StageColumnProps = {
@@ -13,6 +13,8 @@ type StageColumnProps = {
   onAddCard: (stageId: string) => void
   onEditCard: (card: DealCard) => void
   onDeleteCard: (card: DealCard) => void
+  onTransferCard: (card: DealCard, pipelineId: string) => void
+  pipelines: Pipeline[]
   isLoading: boolean
 }
 
@@ -22,6 +24,8 @@ export function StageColumn({
   onAddCard,
   onEditCard,
   onDeleteCard,
+  onTransferCard,
+  pipelines,
   isLoading,
 }: StageColumnProps) {
   return (
@@ -60,8 +64,10 @@ export function StageColumn({
                   key={card.id}
                   card={card}
                   index={index}
+                  pipelines={pipelines}
                   onEdit={onEditCard}
                   onDelete={onDeleteCard}
+                  onTransfer={onTransferCard}
                 />
               ))
             ) : (


### PR DESCRIPTION
## Resumo
- Ajusta o menu dos cards para exibir opções de transferência para outros funis e remoção direta
- Implementa a rotina de transferência de oportunidades, posicionando-as no primeiro estágio do funil de destino e reindexando a coluna de origem
- Atualiza a documentação do CRM detalhando o novo menu contextual dos cards

## Testes
- npm run lint (com avisos já existentes em arquivos não relacionados)


------
https://chatgpt.com/codex/tasks/task_e_68d7094d5be0833380ba0e9c40299045