### PR TITLE
Move InitiateCheckout para clique do link de pagamento

### DIFF
--- a/src/app/dashboard/payments/[id]/page.tsx
+++ b/src/app/dashboard/payments/[id]/page.tsx
@@ -21,6 +21,29 @@ interface Payment {
     payment_link: string | null;
 }
 
+declare global {
+    interface Window {
+        fbq?: (...args: unknown[]) => void;
+    }
+}
+
+const trackInitiateCheckout = (payment: Payment) => {
+    try {
+        if (typeof window === "undefined" || typeof window.fbq !== "function") {
+            return;
+        }
+
+        window.fbq("track", "InitiateCheckout", {
+            value: payment.amount,
+            currency: "BRL",
+            content_ids: [payment.id],
+            content_type: "payment",
+        });
+    } catch (error) {
+        console.error("Erro ao enviar evento do Pixel:", error);
+    }
+};
+
 export default function PaymentPage() {
     const params = useParams();
     const id = Array.isArray(params.id) ? params.id[0] : params.id;
@@ -214,6 +237,11 @@ export default function PaymentPage() {
                                 target="_blank"
                                 rel="noopener noreferrer"
                                 className="block w-full text-center text-blue-600 underline"
+                                onClick={() => {
+                                    if (payment) {
+                                        trackInitiateCheckout(payment);
+                                    }
+                                }}
                             >
                                 Abrir link de pagamento
                             </a>

--- a/src/app/dashboard/payments/page.tsx
+++ b/src/app/dashboard/payments/page.tsx
@@ -20,29 +20,6 @@ type User = {
   id: string;
 };
 
-declare global {
-  interface Window {
-    fbq?: (...args: unknown[]) => void;
-  }
-}
-
-const trackInitiateCheckout = (payment: Payment) => {
-  try {
-    if (typeof window === "undefined" || typeof window.fbq !== "function") {
-      return;
-    }
-
-    window.fbq("track", "InitiateCheckout", {
-      value: payment.amount,
-      currency: "BRL",
-      content_ids: [payment.id],
-      content_type: "payment",
-    });
-  } catch (error) {
-    console.error("Erro ao enviar evento do Pixel:", error);
-  }
-};
-
 
 export default function PaymentsPage() {
   const router = useRouter();
@@ -98,7 +75,6 @@ export default function PaymentsPage() {
   if (!user || !payments) return null;
 
   const handlePay = (payment: Payment) => {
-    trackInitiateCheckout(payment);
     setIsNavigating(true);
     try {
       router.push(`/dashboard/payments/${payment.id}/`);


### PR DESCRIPTION
## Resumo
- remove o disparo do pixel ao acionar a navegação para os detalhes do pagamento
- envia o evento InitiateCheckout ao abrir o link externo de pagamento

## Testes
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7097bb09483339d686037ea871611