### PR TITLE
Remove N8N dependency from agent creation flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ Este repositório contém uma aplicação [Next.js](https://nextjs.org/) prepara
    ```
 
 2. Faça o deploy na [Vercel](https://vercel.com/) (via CLI ou integração com Git). O processo padrão consiste em:
-   - Configurar as variáveis de ambiente no painel da Vercel (incluindo `N8N_WEBHOOK_URL`, `N8N_AGENT_WEBHOOK_URL` e `N8N_WEBHOOK_TOKEN`, usadas pelos endpoints internos `/api/knowledge-base/upload` e `/api/agents/create`). Certifique-se de que `N8N_AGENT_WEBHOOK_URL` já aponte diretamente para o endpoint final do fluxo do N8N, sem depender de sufixos adicionados pela aplicação.
-   - Ajustar o fluxo do N8N para consumir os campos `agent_id`, `agent_internal_name`, `chatwoot_id` e `chatwoot_user_id` enviados no corpo do webhook de criação de agentes.
+   - Configurar as variáveis de ambiente no painel da Vercel (incluindo `N8N_WEBHOOK_URL` e `N8N_WEBHOOK_TOKEN`, usadas pelo endpoint interno `/api/knowledge-base/upload`, além de `N8N_CRM_WEBHOOK_URL` caso as automações do funil estejam habilitadas).
+   - Provisionar a caixa e o usuário correspondentes diretamente no Chatwoot antes de criar novos agentes, pois o fluxo do N8N não é mais acionado automaticamente pela API.
    - Realizar o push para o branch principal para disparar o deploy automático **ou** utilizar o comando `vercel --prod`.
 
-> O fluxo do N8N deve validar o token enviado no header `Authorization` antes de aceitar o upload.
+> Os fluxos do N8N que recebem arquivos da base de conhecimento devem validar o token enviado no header `Authorization` antes de aceitar o upload.
 
 ## 🧭 Funil de vendas
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -3,7 +3,7 @@
 ## Uso do Service Role
 As rotas que utilizam `supabaseadmin` executam operações privilegiadas. Antes de cada acesso é necessário validar explicitamente o usuário autenticado e a empresa associada. Avaliar a migração para chamadas com privilégios mínimos, utilizando RPCs ou o cliente autenticado com RLS sempre que possível, reduzindo a necessidade do Service Role.
 
-Ao integrar com fluxos externos como o N8N, defina `N8N_AGENT_WEBHOOK_URL` com a URL completa do webhook publicado (incluindo o caminho exato fornecido pelo N8N). A API agora não acrescenta sufixos automaticamente, portanto qualquer divergência ou caminho relativo incorreto resultará em falhas na criação do agente. Mantenha o token em `N8N_WEBHOOK_TOKEN` obrigatório e valide-o no fluxo para impedir uso indevido do endpoint. O webhook recebe os campos `agent_id`, `agent_internal_name`, `chatwoot_id` e `chatwoot_user_id`; trate todos os valores como dados sensíveis da empresa, aplicando sanitização antes de replicá-los em sistemas externos.
+Ao integrar com fluxos externos como o N8N, mantenha `N8N_WEBHOOK_URL` e `N8N_WEBHOOK_TOKEN` restritos a uploads da base de conhecimento e utilize `N8N_CRM_WEBHOOK_URL` apenas quando as automações do funil de vendas estiverem habilitadas. A criação de agentes não dispara mais webhooks externos, portanto o provisionamento no Chatwoot deve ocorrer diretamente na plataforma ou via integrações próprias controladas pela equipe.
 
 Rotas atuais que dependem do `supabaseadmin`:
 


### PR DESCRIPTION
## Summary
- remove the N8N create-box webhook invocation from the agent creation API and keep the Chatwoot validation path
- document that Chatwoot provisioning is now manual and adjust references to the remaining N8N webhooks

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d71fc0d4fc8333a274eef53bd24512