### PR TITLE
Add company expiration card to payments dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Os dados são salvos em tabelas dedicadas (`pipeline`, `stage` — agora com a c
 ## 💳 Pagamentos
 
 - Cada empresa possui um histórico único de cobranças: o primeiro pagamento é criado automaticamente quando o usuário provisiona o primeiro agente de IA e não existe nenhum registro prévio para a empresa na tabela `payments`.
+- A página apresenta um card dedicado à assinatura corporativa, exibindo a data de expiração consolidada em `company.subscription_expires_at` e destacando visualmente se a vigência está ativa ou expirada.
 - Novos agentes reutilizam o mesmo cadastro de pagamento da empresa, evitando a geração de cobranças duplicadas ao longo da expansão do time de IA.
 - Os registros de cobrança ficam associados apenas ao `company_id`; nenhum `agent_id` é armazenado na tabela `payments`, reforçando que a assinatura é sempre corporativa.
 - A ativação dos agentes só ocorre quando a assinatura corporativa está paga e dentro da validade; o painel ignora cobranças futuras pendentes e utiliza a última fatura paga com vencimento vigente para liberar o botão de ativar.

--- a/src/app/dashboard/payments/page.tsx
+++ b/src/app/dashboard/payments/page.tsx
@@ -4,7 +4,7 @@
 import { supabasebrowser } from '@/lib/supabaseClient';
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Card, CardHeader, CardTitle, CardContent, CardDescription } from "@/components/ui/card";
 import { toast } from "sonner";
 
 type Payment = {
@@ -14,17 +14,23 @@ type Payment = {
   created_at: string;
   due_date: string;
   reference: string;
+  company?: { id: string };
 };
 
 type User = {
   id: string;
 };
 
+type Company = {
+  id: string;
+  subscription_expires_at: string | null;
+};
 
 export default function PaymentsPage() {
   const router = useRouter();
   const [payments, setPayments] = useState<Payment[]>([]);
   const [user, setUser] = useState<User | null>(null);
+  const [company, setCompany] = useState<Company | null>(null);
   const [isNavigating, setIsNavigating] = useState(false);
 
 
@@ -70,7 +76,26 @@ export default function PaymentsPage() {
     fetchPayments();
   }, [user]);
 
+  useEffect(() => {
+    if (!user?.id) return;
 
+    const fetchCompany = async () => {
+      const { data, error } = await supabasebrowser
+        .from('company')
+        .select('id, subscription_expires_at')
+        .eq('user_id', user.id)
+        .maybeSingle();
+
+      if (error) {
+        console.error('Erro ao buscar dados da empresa:', error);
+        return;
+      }
+
+      setCompany(data);
+    };
+
+    fetchCompany();
+  }, [user]);
 
   if (!user || !payments) return null;
 
@@ -85,8 +110,40 @@ export default function PaymentsPage() {
     }
   };
 
+  const subscriptionDate = company?.subscription_expires_at
+    ? new Date(company.subscription_expires_at)
+    : null;
+  const isValidSubscriptionDate = subscriptionDate && !Number.isNaN(subscriptionDate.getTime());
+  const formattedSubscriptionDate = isValidSubscriptionDate
+    ? subscriptionDate.toLocaleDateString("pt-BR")
+    : 'Sem assinatura ativa';
+  const isExpired = isValidSubscriptionDate ? subscriptionDate.getTime() < Date.now() : true;
+
   return (
     <div className="p-4 space-y-6 w-full max-w-5xl mx-auto">
+      <Card>
+        <CardHeader>
+          <CardTitle>Assinatura corporativa</CardTitle>
+          <CardDescription>Data de expiração vinculada à empresa logada.</CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="text-sm text-muted-foreground">Válida até</p>
+            <p className="text-2xl font-semibold">{formattedSubscriptionDate}</p>
+          </div>
+          <span
+            className={`px-3 py-1 text-sm font-medium rounded-full ${
+              isValidSubscriptionDate
+                ? isExpired
+                  ? 'bg-red-100 text-red-800'
+                  : 'bg-green-100 text-green-800'
+                : 'bg-muted text-muted-foreground'
+            }`}
+          >
+            {isValidSubscriptionDate ? (isExpired ? 'Expirada' : 'Ativa') : 'Indisponível'}
+          </span>
+        </CardContent>
+      </Card>
       <Card>
         <CardHeader>
           <CardTitle>Controle de Pagamentos</CardTitle>


### PR DESCRIPTION
## Resumo
- adiciona um card de assinatura corporativa na página de pagamentos exibindo a data de expiração da empresa
- busca os dados da empresa autenticada para validar e sinalizar o status da vigência
- documenta no README o destaque da expiração dentro do painel de pagamentos

## Testes
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7332f442483339101014fa91e4914