### PR TITLE
Fix agent activation check for Google tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ Os dados são salvos em tabelas dedicadas (`pipeline`, `stage` — agora com a c
 - O menu do agente concentra-se apenas nos atributos individuais (status e tipo), deixando a conferência da assinatura corporativa centralizada no fluxo de ativação.
 - O vencimento consolidado fica armazenado em `company.subscription_expires_at`, permitindo que toda a aplicação valide a expiração corporativa sem depender de campos na tabela `agents`.
 
+## 📅 Integração com Google Calendar
+
+- A checagem que libera a ativação de agentes SDR considera apenas a existência de um registro em `agent_google_tokens` vinculado pelo campo `agent_id`, garantindo compatibilidade com o modelo sem coluna `id`.
+
 ## 🔗 Links Úteis
 
 - [Next.js](https://nextjs.org/docs)

--- a/components/agents/ActivateAgentButton.tsx
+++ b/components/agents/ActivateAgentButton.tsx
@@ -50,7 +50,7 @@ export default function ActivateAgentButton({ agentId, onActivated }: Props) {
         error: googleTokensError,
       } = await supabasebrowser
         .from("agent_google_tokens")
-        .select("id")
+        .select("agent_id")
         .eq("agent_id", agentId)
         .limit(1);
 


### PR DESCRIPTION
## Summary
- update the Google Calendar activation guard to verify agent_google_tokens using the agent_id column
- document that SDR activation validates Google Calendar vinculation pelo agent_id

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d73f3791ec833398c7611dca4e9ad1