### PR TITLE
Garantir ativação exclusiva de agente por empresa

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Os dados são salvos em tabelas dedicadas (`pipeline`, `stage` — agora com a c
 - Novos agentes reutilizam o mesmo cadastro de pagamento da empresa, evitando a geração de cobranças duplicadas ao longo da expansão do time de IA.
 - Os registros de cobrança ficam associados apenas ao `company_id`; nenhum `agent_id` é armazenado na tabela `payments`, reforçando que a assinatura é sempre corporativa.
 - A ativação dos agentes só ocorre quando a assinatura corporativa está paga e dentro da validade; o painel ignora cobranças futuras pendentes e utiliza a última fatura paga com vencimento vigente para liberar o botão de ativar.
+- Apenas um agente de IA pode permanecer ativo por empresa; ao ativar um novo agente, o sistema desativa automaticamente os demais agentes corporativos para evitar conflitos na operação.
 - O menu do agente concentra-se apenas nos atributos individuais (status e tipo), deixando a conferência da assinatura corporativa centralizada no fluxo de ativação.
 - O vencimento consolidado fica armazenado em `company.subscription_expires_at`, permitindo que toda a aplicação valide a expiração corporativa sem depender de campos na tabela `agents`.
 - Falhas ao buscar o histórico de cobranças exibem uma notificação de erro, evitando que a página fique silenciosamente desatualizada quando o Supabase estiver indisponível.

--- a/components/agents/ActivateAgentButton.tsx
+++ b/components/agents/ActivateAgentButton.tsx
@@ -137,6 +137,18 @@ export default function ActivateAgentButton({ agentId, onActivated }: Props) {
       return;
     }
 
+    const { error: deactivateError } = await supabasebrowser
+      .from("agents")
+      .update({ is_active: false })
+      .eq("company_id", agent.company_id)
+      .neq("id", agentId);
+
+    if (deactivateError) {
+      toast.error("Erro ao desativar outros agentes da empresa.");
+      setLoading(false);
+      return;
+    }
+
     const { error } = await supabasebrowser
       .from("agents")
       .update({ is_active: true })

--- a/docs/crm.md
+++ b/docs/crm.md
@@ -9,6 +9,7 @@ A página **Funil de vendas** centraliza os funis comerciais da empresa logada. 
 - Limite de cinco funis por empresa e dez estágios por funil para manter o gerenciamento enxuto.
 - Gestão de estágios diretamente no modal de criação/edição do funil, com campos para adicionar, renomear, escolher a cor com um seletor nativo e remover etapas antes de salvar.
 - Agentes SDR só podem ser ativados após autenticar o Google Calendar vinculado, garantindo que apenas representantes com agenda conectada ofereçam horários disponíveis aos leads.
+- Cada empresa mantém apenas um agente de IA ativo por vez; ativar um novo agente desativa automaticamente os demais associados à mesma companhia.
 - Cada estágio recebe uma cor de fundo armazenada no campo `stage.color`, aplicada diretamente como plano de fundo da coluna no board.
 - Transferência de oportunidades entre estágios pelo modal de edição, escolhendo o destino no seletor dedicado, inclusive para colunas vazias.
 - Menu de contexto nos cards com ações de transferência direta para outros funis (sempre posicionando a oportunidade no primeiro estágio disponível) e remoção rápida.


### PR DESCRIPTION
## Resumo
- desativa automaticamente outros agentes da mesma empresa antes de ativar um novo
- documenta a limitação de um agente ativo por empresa no README e no guia do CRM

## Testes
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d74340cae88333aceea1f16e616bd3