### PR TITLE
Use icon for notification read action

### DIFF
--- a/components/notifications/NotificationBell.tsx
+++ b/components/notifications/NotificationBell.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
-import { Bell } from 'lucide-react';
+import { Bell, Check } from 'lucide-react';
 import { useNotifications } from './NotificationProvider';
 import { cn } from '@/components/ui/utils';
 
@@ -41,8 +41,14 @@ export default function NotificationBell() {
               >
                 <span className="flex-1">{n.message}</span>
                 {!n.read_at && (
-                  <button onClick={() => markAsRead(n.id)} className="text-xs text-blue-600">
-                    Marcar como lido
+                  <button
+                    type="button"
+                    onClick={() => markAsRead(n.id)}
+                    className="inline-flex items-center justify-center text-blue-600 hover:text-blue-700"
+                    aria-label="Marcar notificação como lida"
+                  >
+                    <Check className="h-4 w-4" />
+                    <span className="sr-only">Marcar notificação como lida</span>
                   </button>
                 )}
               </div>


### PR DESCRIPTION
## Summary
- replace the textual "Marcar como lido" action with a check icon while preserving accessibility labels

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7437f9bf08333928e584b429a5b6c