### PR TITLE
Atualiza referência do pagamento inicial com data atual

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Os dados são salvos em tabelas dedicadas (`pipeline`, `stage` — agora com a c
 ## 💳 Pagamentos
 
 - Cada empresa possui um histórico único de cobranças: o primeiro pagamento é criado automaticamente quando o usuário provisiona o primeiro agente de IA e não existe nenhum registro prévio para a empresa na tabela `payments`.
+- O campo `reference` do primeiro pagamento segue o formato `Mensalidade (dd/MM/aaaa)` e utiliza a data corrente da criação para facilitar a identificação da fatura.
 - A página apresenta um card dedicado à assinatura corporativa, exibindo a data de expiração consolidada em `company.subscription_expires_at`, respeitando uma carência de 1 dia antes de considerar a vigência expirada e mantendo a etiqueta "Ativa" durante esse período de tolerância.
 - Novos agentes reutilizam o mesmo cadastro de pagamento da empresa, evitando a geração de cobranças duplicadas ao longo da expansão do time de IA.
 - Os registros de cobrança ficam associados apenas ao `company_id`; nenhum `agent_id` é armazenado na tabela `payments`, reforçando que a assinatura é sempre corporativa.

--- a/src/app/api/agents/create/route.ts
+++ b/src/app/api/agents/create/route.ts
@@ -412,6 +412,13 @@ export async function POST(request: Request) {
     const dueDate = new Date();
     dueDate.setDate(dueDate.getDate() + 30);
     const dueDateIso = dueDate.toISOString();
+    const today = new Date();
+    const formattedDate = new Intl.DateTimeFormat("pt-BR", {
+      day: "2-digit",
+      month: "2-digit",
+      year: "numeric",
+    }).format(today);
+    const paymentReference = `Mensalidade (${formattedDate})`;
 
     const {
       data: paymentData,
@@ -422,7 +429,7 @@ export async function POST(request: Request) {
         company_id: company.id,
         amount: AGENT_PRICE,
         due_date: dueDateIso,
-        reference: "Mensalidade Agent Plug and Play",
+        reference: paymentReference,
       })
       .select("id, amount, due_date")
       .single();


### PR DESCRIPTION
## Summary
- gera a referência do primeiro pagamento usando o formato "Mensalidade (dd/MM/aaaa)" com a data corrente
- documenta no README o novo padrão de referência exibido nas faturas iniciais

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7499b9dfc8333868aa38aafc76489