### PR TITLE
Remove Chatwoot widget from landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ Os dados são salvos em tabelas dedicadas (`pipeline`, `stage` — agora com a c
 
 - A checagem que libera a ativação de agentes SDR considera apenas a existência de um registro em `agent_google_tokens` vinculado pelo campo `agent_id`, garantindo compatibilidade com o modelo sem coluna `id`.
 
+## 💬 Atendimento com Chatwoot
+
+- A integração com o Chatwoot permanece disponível dentro da plataforma autenticada, porém o widget público foi removido da landing page para evitar carregamento desnecessário de scripts externos.
+
 ## 🔗 Links Úteis
 
 - [Next.js](https://nextjs.org/docs)

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,13 +3,11 @@ import Hero from "@/components/landing/Hero";
 import Features from "@/components/landing/Features";
 import Stats from "@/components/landing/Stats";
 import Benefit from "@/components/landing/Benefit";
-import Testimonials from "@/components/landing/Testimonials";
 import FAQ from "@/components/landing/FAQ";
 import FinalCTA from "@/components/landing/FinalCTA";
 import Footer from "@/components/landing/Footer";
 import Pricing from "@/components/landing/Pricing";
 import type { Metadata } from "next";
-import Script from "next/script";
 
 const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
 
@@ -40,22 +38,6 @@ export const metadata: Metadata = {
 export default function HomePage() {
   return (
     <>
-      <Script id="tracelead-chatwoot" strategy="afterInteractive">
-        {`(function(d,t) {
-      var BASE_URL="https://platform.tracelead.com.br";
-      var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
-      g.src=BASE_URL+"/packs/js/sdk.js";
-      g.defer = true;
-      g.async = true;
-      s.parentNode.insertBefore(g,s);
-      g.onload=function(){
-        window.chatwootSDK.run({
-          websiteToken: 'EioqiGzk1toeBkQgLiRNxMuG',
-          baseUrl: BASE_URL
-        })
-      }
-    })(document,"script");`}
-      </Script>
       <Header />
       <main className="flex flex-col">
         <Hero />


### PR DESCRIPTION
## Resumo
- remove o carregamento do widget do Chatwoot na landing page
- documenta que o atendimento com Chatwoot permanece apenas na plataforma autenticada

## Testes
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8207134f483338198b2651ecc1b6d