### PR TITLE
Highlight active agent in sidebar submenu

### DIFF
--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -293,7 +293,10 @@ export function Sidebar({ className }: { className?: string }) {
                     <span>{agent.name}</span>
                   </span>
                   {agent.is_active && (
-                    <span className="text-[10px] uppercase tracking-wide">Ativo</span>
+                    <span
+                      aria-hidden
+                      className="h-2 w-2 rounded-full bg-[#2F6F68]"
+                    />
                   )}
                 </Link>
               ))}
@@ -482,10 +485,22 @@ export function MobileSidebar() {
                   <Link
                     key={agent.id}
                     href={`/dashboard/agents/${agent.id}`}
-                    className="block px-4 py-2 text-sm hover:bg-gray-100"
+                    className={cn(
+                      'flex items-center justify-between gap-2 rounded px-4 py-2 text-sm hover:bg-gray-100',
+                      agent.is_active && 'bg-[#E3F5F0] text-[#2F6F68] font-semibold hover:bg-[#D7ECE4]',
+                    )}
                     onClick={() => setOpen(false)}
                   >
-                    🤖 {agent.name}
+                    <span className="flex items-center gap-2">
+                      <span aria-hidden>🤖</span>
+                      <span>{agent.name}</span>
+                    </span>
+                    {agent.is_active && (
+                      <span
+                        aria-hidden
+                        className="h-2 w-2 rounded-full bg-[#2F6F68]"
+                      />
+                    )}
                   </Link>
                 ))}
                 {agents.length < MAX_AGENTS_PER_COMPANY ? (


### PR DESCRIPTION
## Summary
- fetch each agent's active state when building the sidebar submenu
- visually emphasize the active AI agent with accent styling and a badge in the submenu list

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8230f4be08333a95df23a927a3f97