### PR TITLE
Garante funil padrão ao criar conta

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Este repositório contém uma aplicação [Next.js](https://nextjs.org/) prepara
 
 O painel do CRM agora conta com a página **Funil de vendas**, acessível pela sidebar do dashboard. Nela é possível:
 
-- Trabalhar sempre com o funil padrão **"Funil da do Agente"** (identificador `agent_default_pipeline`), criado automaticamente para cada empresa com os estágios fixos **Entrada**, **Atendimento Humano** e **Qualificado**; ele permanece disponível como referência, não pode ser editado ou excluído e já chega com a paleta **#E0F2FE**, **#FCE7F3** e **#FEF3C7** aplicada a cada coluna.
+- Trabalhar sempre com o funil padrão **"Funil da do Agente"** (identificador `agent_default_pipeline`), criado automaticamente assim que o usuário finaliza a criação da conta para cada empresa, com os estágios fixos **Entrada**, **Atendimento Humano** e **Qualificado**; ele permanece disponível como referência, não pode ser editado ou excluído e já chega com a paleta **#E0F2FE**, **#FCE7F3** e **#FEF3C7** aplicada a cada coluna.
 - Criar, editar e excluir funis para diferentes jornadas comerciais (menu de três pontinhos no topo da página).
 - Cada empresa pode manter até cinco funis ativos simultaneamente; cada funil aceita no máximo dez estágios.
 - Organizar etapas personalizadas para cada funil, definindo todos os estágios diretamente no modal de criação/edição e reordenando oportunidades por _drag and drop_ com `@hello-pangea/dnd`.

--- a/docs/crm.md
+++ b/docs/crm.md
@@ -32,9 +32,9 @@ As tabelas criadas para suportar o módulo ficam no schema público do Supabase:
 
 ### Funil padrão por empresa
 
-- Toda empresa recebe automaticamente o funil **"Funil da do Agente"**, identificado no banco de dados pelo campo `identifier = 'agent_default_pipeline'`.
+- Toda empresa recebe automaticamente o funil **"Funil da do Agente"** assim que a criação da conta é concluída, identificado no banco de dados pelo campo `identifier = 'agent_default_pipeline'`.
 - Os estágios deste funil são fixos e seguem a ordem: **Entrada**, **Atendimento Humano** e **Qualificado**, com as cores padrão **#E0F2FE**, **#FCE7F3** e **#FEF3C7** aplicadas respectivamente.
-- O front-end garante que o funil padrão exista antes de carregar o board, restaure os nomes/ordens configurados e o proteja contra exclusão ou edição.
+- O back-end garante a criação e sincronização inicial do funil ao finalizar o cadastro da empresa, enquanto o front-end continua verificando a estrutura antes de carregar o board, restaurando nomes/ordens configurados e protegendo-o contra exclusão ou edição.
 - Como apenas um funil pode utilizar este identificador por empresa, criações manuais sempre resultam em novos funis personalizados, mantendo o padrão intacto.
 
 ## Considerações de UX

--- a/src/app/api/profile/complete/route.ts
+++ b/src/app/api/profile/complete/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { supabaseadmin } from "@/lib/supabaseAdmin";
+import { ensureDefaultPipelineForCompany } from "@/lib/pipeline/server";
 import { getUserFromCookie } from "@/lib/auth";
 import {
   isValidCompanyName,
@@ -204,6 +205,22 @@ export async function POST(req: Request) {
 
   if (updateCompanyError) {
     return NextResponse.json({ error: updateCompanyError.message }, { status: 500 });
+  }
+
+  const companyId = Number(companyRecord.id);
+
+  if (!Number.isFinite(companyId)) {
+    return NextResponse.json({ error: "Empresa inválida" }, { status: 400 });
+  }
+
+  try {
+    await ensureDefaultPipelineForCompany(companyId);
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json(
+      { error: "Não foi possível criar o funil padrão da empresa" },
+      { status: 500 }
+    );
   }
 
   return NextResponse.json({ ok: true });

--- a/src/app/dashboard/funil-de-vendas/page.tsx
+++ b/src/app/dashboard/funil-de-vendas/page.tsx
@@ -40,14 +40,11 @@ import {
   PIPELINE_NAME_MAX_LENGTH,
   STAGE_NAME_MAX_LENGTH,
 } from './constants'
-
-const DEFAULT_PIPELINE_IDENTIFIER = 'agent_default_pipeline'
-const DEFAULT_PIPELINE_NAME = 'Funil da do Agente'
-const DEFAULT_STAGE_PRESETS = [
-  { name: 'Entrada', color: '#E0F2FE' },
-  { name: 'Atendimento Humano', color: '#FCE7F3' },
-  { name: 'Qualificado', color: '#FEF3C7' },
-]
+import {
+  DEFAULT_PIPELINE_IDENTIFIER,
+  DEFAULT_PIPELINE_NAME,
+  DEFAULT_STAGE_PRESETS,
+} from '@/lib/pipeline/defaults'
 
 function getStageCards(cards: DealCard[], stageId: string) {
   return cards

--- a/src/lib/pipeline/defaults.ts
+++ b/src/lib/pipeline/defaults.ts
@@ -1,0 +1,8 @@
+export const DEFAULT_PIPELINE_IDENTIFIER = 'agent_default_pipeline'
+export const DEFAULT_PIPELINE_NAME = 'Funil da do Agente'
+
+export const DEFAULT_STAGE_PRESETS = [
+  { name: 'Entrada', color: '#E0F2FE' },
+  { name: 'Atendimento Humano', color: '#FCE7F3' },
+  { name: 'Qualificado', color: '#FEF3C7' },
+] as const

--- a/src/lib/pipeline/server.ts
+++ b/src/lib/pipeline/server.ts
@@ -1,0 +1,143 @@
+import { supabaseadmin } from '@/lib/supabaseAdmin'
+import {
+  DEFAULT_PIPELINE_IDENTIFIER,
+  DEFAULT_PIPELINE_NAME,
+  DEFAULT_STAGE_PRESETS,
+} from './defaults'
+
+const HEX_COLOR_REGEX = /^#[0-9A-Fa-f]{6}$/
+const DEFAULT_STAGE_COLOR = '#F8FAFC'
+
+const normalizeStageColor = (value: string | null | undefined): string => {
+  if (typeof value !== 'string') {
+    return DEFAULT_STAGE_COLOR
+  }
+
+  return HEX_COLOR_REGEX.test(value) ? value.toUpperCase() : DEFAULT_STAGE_COLOR
+}
+
+export const ensureDefaultPipelineForCompany = async (
+  companyId: number
+): Promise<string> => {
+  const { data: existingDefault, error: existingDefaultError } = await supabaseadmin
+    .from('pipeline')
+    .select('id')
+    .eq('company_id', companyId)
+    .eq('identifier', DEFAULT_PIPELINE_IDENTIFIER)
+    .maybeSingle()
+
+  if (existingDefaultError) {
+    throw existingDefaultError
+  }
+
+  let pipelineId = existingDefault?.id ?? null
+
+  if (!pipelineId) {
+    const { data: legacyDefault, error: legacyDefaultError } = await supabaseadmin
+      .from('pipeline')
+      .select('id')
+      .eq('company_id', companyId)
+      .eq('name', DEFAULT_PIPELINE_NAME)
+      .maybeSingle()
+
+    if (legacyDefaultError) {
+      throw legacyDefaultError
+    }
+
+    if (legacyDefault?.id) {
+      const { error: attachIdentifierError } = await supabaseadmin
+        .from('pipeline')
+        .update({ identifier: DEFAULT_PIPELINE_IDENTIFIER, name: DEFAULT_PIPELINE_NAME })
+        .eq('id', legacyDefault.id)
+
+      if (attachIdentifierError) {
+        throw attachIdentifierError
+      }
+
+      pipelineId = legacyDefault.id
+    }
+  }
+
+  if (!pipelineId) {
+    const { data: createdPipeline, error: createPipelineError } = await supabaseadmin
+      .from('pipeline')
+      .insert({
+        company_id: companyId,
+        name: DEFAULT_PIPELINE_NAME,
+        description: null,
+        identifier: DEFAULT_PIPELINE_IDENTIFIER,
+      })
+      .select('id')
+      .single()
+
+    if (createPipelineError) {
+      throw createPipelineError
+    }
+
+    pipelineId = createdPipeline.id
+  }
+
+  const { data: existingStages, error: existingStagesError } = await supabaseadmin
+    .from('stage')
+    .select('id, name, position, color')
+    .eq('pipeline_id', pipelineId)
+    .order('position', { ascending: true })
+
+  if (existingStagesError) {
+    throw existingStagesError
+  }
+
+  const remainingStages = [...(existingStages ?? [])]
+  const updates: { id: string; name: string; position: number; color: string }[] = []
+  const inserts: { name: string; position: number; pipeline_id: string; color: string }[] = []
+
+  DEFAULT_STAGE_PRESETS.forEach(({ name, color }, index) => {
+    const normalizedColor = normalizeStageColor(color)
+    const matchIndex = remainingStages.findIndex((stage) => stage.name === name)
+
+    if (matchIndex >= 0) {
+      const matchedStage = remainingStages.splice(matchIndex, 1)[0]
+      const matchedColor = normalizeStageColor(matchedStage.color)
+
+      if (
+        matchedStage.name !== name ||
+        matchedStage.position !== index ||
+        matchedColor !== normalizedColor
+      ) {
+        updates.push({
+          id: matchedStage.id,
+          name,
+          position: index,
+          color: normalizedColor,
+        })
+      }
+    } else {
+      inserts.push({
+        name,
+        position: index,
+        pipeline_id: pipelineId,
+        color: normalizedColor,
+      })
+    }
+  })
+
+  for (const stage of updates) {
+    const { error: updateError } = await supabaseadmin
+      .from('stage')
+      .update({ name: stage.name, position: stage.position, color: stage.color })
+      .eq('id', stage.id)
+
+    if (updateError) {
+      throw updateError
+    }
+  }
+
+  if (inserts.length) {
+    const { error: insertError } = await supabaseadmin.from('stage').insert(inserts)
+    if (insertError) {
+      throw insertError
+    }
+  }
+
+  return pipelineId
+}


### PR DESCRIPTION
## Summary
- cria utilitários compartilhados com constantes do funil padrão
- garante pelo backend a criação e sincronização do funil padrão ao concluir o cadastro da empresa
- atualiza a página do funil e a documentação para refletir a criação imediata do funil padrão

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8637261448333a3e84f64d026813b