### PR TITLE
Allow auth forms to scroll on small screens

### DIFF
--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -30,8 +30,8 @@ export default function ForgotPasswordPage() {
   };
 
   return (
-    <div className="fixed inset-0 flex items-center justify-center bg-[#FAFAFA]">
-      <div className="w-full px-4 sm:max-w-md md:max-w-lg">
+    <div className="min-h-screen bg-[#FAFAFA] flex items-center justify-center px-4 py-12">
+      <div className="w-full sm:max-w-md md:max-w-lg">
         <form
           onSubmit={handleSubmit}
           className="w-full bg-white rounded-lg shadow p-6 space-y-4"
@@ -59,9 +59,9 @@ export default function ForgotPasswordPage() {
             Voltar ao login
           </Link>
         </p>
-      </form>
+        </form>
+      </div>
     </div>
-  </div>
   );
 }
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -101,8 +101,8 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="fixed inset-0 flex flex-col items-center justify-center bg-[#FAFAFA]">
-      <div className="w-full px-4 sm:max-w-md md:max-w-lg">
+    <div className="min-h-screen bg-[#FAFAFA] flex items-center justify-center px-4 py-12">
+      <div className="w-full sm:max-w-md md:max-w-lg">
         <Image
           src="/logo.png"
           alt="Evoluke logo"
@@ -189,14 +189,14 @@ export default function LoginPage() {
         </Button>
 
 
-        <p className="text-center text-sm">
-          Não possui conta?{" "}
-          <Link href="/signup" className="text-teal-600 hover:underline">
-            Cadastrar
-          </Link>
-        </p>
-      </form>
+          <p className="text-center text-sm">
+            Não possui conta?{" "}
+            <Link href="/signup" className="text-teal-600 hover:underline">
+              Cadastrar
+            </Link>
+          </p>
+        </form>
+      </div>
     </div>
-  </div>
   );
 }

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -82,8 +82,8 @@ export default function SignupPage() {
   };
 
   return (
-    <div className="fixed inset-0 flex items-center justify-center bg-[#FAFAFA]">
-      <div className="w-full px-4 sm:max-w-md md:max-w-lg">
+    <div className="min-h-screen bg-[#FAFAFA] flex items-center justify-center px-4 py-12">
+      <div className="w-full sm:max-w-md md:max-w-lg">
         <form
           onSubmit={handleSubmit}
           className="w-full bg-white rounded-lg shadow p-6 space-y-4"
@@ -178,8 +178,8 @@ export default function SignupPage() {
             Fazer login
           </Link>
         </p>
-      </form>
+        </form>
+      </div>
     </div>
-  </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace the fixed viewport wrappers on the login, signup and forgot password pages with scrollable containers so the forms remain accessible on small screens

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d87f60ceac8333b78dc2e2b855dbe1