### PR TITLE
Atualiza sidebar após criação de agente

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Os dados são salvos em tabelas dedicadas (`pipeline`, `stage` — agora com a c
 ## 🧱 Navegação do dashboard
 
 - O menu lateral reúne as ações de **Configuração**, **Suporte** e **Logout** em um submenu acessível pelo ícone de três pontos horizontais posicionado no rodapé da sidebar.
+- Ao criar um novo agente de IA, a aplicação dispara automaticamente a atualização da sidebar para exibir o atalho recém-criado sem exigir recarregamento manual da página.
 - O submenu mantém o foco na navegação principal, exibindo apenas os atalhos operacionais quando solicitado.
 - O primeiro atalho da barra lateral preserva o ícone de casa para destacar o retorno rápido ao dashboard principal.
 - A ordem dos atalhos prioriza o **Funil de vendas** antes de **Pagamentos**, mantendo o fluxo comercial em evidência.

--- a/src/app/dashboard/agents/new/page.tsx
+++ b/src/app/dashboard/agents/new/page.tsx
@@ -194,6 +194,10 @@ export default function NewAgentPage() {
 
       const agentId = data?.id;
 
+      if (typeof window !== "undefined") {
+        window.dispatchEvent(new Event("agentsUpdated"));
+      }
+
       if (typeof agentId === "string") {
         router.push(`/dashboard/agents/${agentId}`);
       }


### PR DESCRIPTION
## Summary
- dispara o evento `agentsUpdated` ao concluir a criação de um agente para recarregar a sidebar imediatamente
- registra na documentação do dashboard que a sidebar é atualizada automaticamente após criar um novo agente

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d89478b40483338bfc1c02900dd6af