### PR TITLE
Add informal and neutral voice tone options

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ Os dados são salvos em tabelas dedicadas (`pipeline`, `stage` — agora com a c
 - O primeiro atalho da barra lateral preserva o ícone de casa para destacar o retorno rápido ao dashboard principal.
 - A ordem dos atalhos prioriza o **Funil de vendas** antes de **Pagamentos**, mantendo o fluxo comercial em evidência.
 
+## 🎭 Personalidade do agente
+
+- A etapa de personalidade do agente agora oferece quatro opções de tom de voz: **Formal**, **Casual**, **Informal** e **Neutro**, permitindo alinhar o estilo de comunicação ao posicionamento da marca sem depender de instruções complementares.
+- A seleção do tom de voz continua obrigatória para salvar a personalidade; utilize o modo **Neutro** quando quiser respostas equilibradas que evitem regionalismos, enquanto o modo **Informal** libera construções mais descontraídas sem perder a clareza nas mensagens.
+
 ## 💳 Pagamentos
 
 - Cada empresa possui um histórico único de cobranças: o primeiro pagamento é criado automaticamente quando o usuário provisiona o primeiro agente de IA e não existe nenhum registro prévio para a empresa na tabela `payments`.

--- a/docs/BRANDING.md
+++ b/docs/BRANDING.md
@@ -17,6 +17,11 @@ Utilizamos variáveis CSS para garantir consistência. Valores atuais:
 ## Tipografia
 A família tipográfica oficial é **Geist**, nas variantes Sans e Mono. Utilize Geist Sans para textos e Geist Mono para trechos de código ou números alinhados.
 
+## Tom de voz do agente
+- Os agentes podem assumir tons **Formal**, **Casual**, **Informal** ou **Neutro**. Escolha o estilo alinhado à identidade verbal da marca antes de complementar as instruções.
+- Prefira o modo **Neutro** para mensagens objetivas com vocabulário equilibrado e use o modo **Informal** em conversas que comportem linguagem mais leve, mantendo o cuidado com gírias regionais.
+- Sempre que o tom precisar variar por canal, registre orientações específicas nas instruções complementares, reforçando a consistência do atendimento.
+
 ## Espaçamentos
 A unidade base de espaçamento segue o padrão do Tailwind CSS (4 px). Organize margens e paddings em múltiplos desta unidade: 4, 8, 12, 16, 24 px etc.
 

--- a/migration.sql
+++ b/migration.sql
@@ -69,8 +69,7 @@ create table public.agents (
   constraint agents_company_id_fkey foreign key (company_id) references company (id)
 ) TABLESPACE pg_default;
 
--- Enum para tom de voz dos agentes
-create type public.voice_tone as enum ('formal', 'casual');
+create type public.voice_tone as enum ('formal', 'casual', 'informal', 'neutro');
 
 -- Tabela de personalidade dos agentes
 create table public.agent_personality (

--- a/src/app/dashboard/agents/[id]/page.tsx
+++ b/src/app/dashboard/agents/[id]/page.tsx
@@ -206,6 +206,8 @@ export default function AgentDetailPage() {
                     <SelectContent>
                       <SelectItem value="formal">Formal</SelectItem>
                       <SelectItem value="casual">Casual</SelectItem>
+                      <SelectItem value="informal">Informal</SelectItem>
+                      <SelectItem value="neutro">Neutro</SelectItem>
                     </SelectContent>
                   </Select>
                   <p className="text-xs text-gray-500">Define estilo de resposta</p>

--- a/src/lib/agentTemplates.ts
+++ b/src/lib/agentTemplates.ts
@@ -1,6 +1,6 @@
 export interface AgentTemplate {
   personality: {
-    voice_tone: 'formal' | 'casual';
+    voice_tone: 'formal' | 'casual' | 'informal' | 'neutro';
     objective: string;
     limits: string;
     company_name: string;


### PR DESCRIPTION
## Summary
- extend the Supabase voice_tone enum and template typings to cover informal and neutral styles
- update the agent configuration form to expose the new tone options
- document the expanded tone options in the README and branding guide

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d894c8d2dc8333b1a140a6bed61aa3