### PR TITLE
Update sitemap coverage and robots sitemap hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Este repositório contém uma aplicação [Next.js](https://nextjs.org/) prepara
 
 - O sitemap disponível em `/sitemap.xml` replica automaticamente o domínio configurado em `NEXT_PUBLIC_APP_URL` e cataloga as páginas públicas da landing page, incluindo **/sobre-nos**, **/saiba-mais**, **/sob-demanda**, **/crm**, **/bni**, **/contact**, **/privacy**, **/terms** e as rotas de autenticação.
 - O arquivo `public/robots.txt` declara `Sitemap: https://evoluke.com.br/sitemap.xml`, permitindo que os buscadores identifiquem rapidamente o índice gerado; ajuste a URL caso o domínio canônico seja personalizado em outro ambiente.
+- O script JSON-LD de organização é inserido diretamente no HTML servido, garantindo que os buscadores tenham acesso imediato aos metadados estruturados sem depender de execução de JavaScript no cliente.
 
 ## 🧭 Funil de vendas
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ Este repositório contém uma aplicação [Next.js](https://nextjs.org/) prepara
 
 > A criação de agentes não envia mais webhooks ao N8N; qualquer automação adicional deve ser disparada a partir de outros fluxos específicos.
 
+## 🌐 SEO e descoberta
+
+- O sitemap disponível em `/sitemap.xml` replica automaticamente o domínio configurado em `NEXT_PUBLIC_APP_URL` e cataloga as páginas públicas da landing page, incluindo **/sobre-nos**, **/saiba-mais**, **/sob-demanda**, **/crm**, **/bni**, **/contact**, **/privacy**, **/terms** e as rotas de autenticação.
+- O arquivo `public/robots.txt` declara `Sitemap: https://evoluke.com.br/sitemap.xml`, permitindo que os buscadores identifiquem rapidamente o índice gerado; ajuste a URL caso o domínio canônico seja personalizado em outro ambiente.
+
 ## 🧭 Funil de vendas
 
 O painel do CRM agora conta com a página **Funil de vendas**, acessível pela sidebar do dashboard. Nela é possível:

--- a/components/landing/FAQ.tsx
+++ b/components/landing/FAQ.tsx
@@ -1,4 +1,4 @@
-const faqs = [
+export const FAQ_ITEMS = [
   {
     q: "O que é a Evoluke?",
     a: "Nossa tecnologia combina agentes de inteligência artificial que entendem as particularidades do seu negócio. Ao funcionar junto a uma plataforma de CRM multicanal, esses agentes automatizam o atendimento de maneira integrada. Isso permite processos mais eficientes e um relacionamento com clientes que cresce de forma inteligente e escalável.",
@@ -19,7 +19,7 @@ export default function FAQ() {
       <div className="mx-auto max-w-[920px] px-3 md:px-4 lg:px-6">
         <h2 className="mb-8 text-center text-3xl font-bold">Perguntas frequentes</h2>
         <div className="space-y-4">
-          {faqs.map((f) => (
+          {FAQ_ITEMS.map((f) => (
             <details key={f.q} className="rounded-md border p-4">
               <summary className="cursor-pointer">{f.q}</summary>
               <p className="mt-2 text-sm text-muted-foreground">{f.a}</p>

--- a/docs/BRANDING.md
+++ b/docs/BRANDING.md
@@ -31,6 +31,10 @@ A unidade base de espaçamento segue o padrão do Tailwind CSS (4 px). Organize
 - Utilize a versão em `#2F6F68` sobre fundos claros e a versão branca sobre fundos escuros.
 - Não distorça, rotacione ou altere as cores oficiais.
 
+## Presença em páginas públicas
+- Garanta que as variações do logotipo acompanhem todas as páginas institucionais listadas no sitemap (`/sobre-nos`, `/saiba-mais`, `/sob-demanda`, `/crm`, `/bni` e formulários de contato) para preservar consistência visual entre o conteúdo priorizado pelos buscadores.
+- Utilize títulos e subtítulos com palavras-chave naturais alinhadas à proposta de valor da marca; essa abordagem reforça o impacto do `robots.txt` e do sitemap, maximizando o aproveitamento do tráfego orgânico.
+
 ## Diretrizes para o funil de vendas
 - Os cards do funil utilizam cantos arredondados de 16 px, sombra suave e espaçamento interno de 16 px.
 - Indicadores de status (status textual, risco e métricas) devem seguir a paleta principal com variações em azul, roxo e verde claro.

--- a/docs/BRANDING.md
+++ b/docs/BRANDING.md
@@ -34,6 +34,7 @@ A unidade base de espaçamento segue o padrão do Tailwind CSS (4 px). Organize
 ## Presença em páginas públicas
 - Garanta que as variações do logotipo acompanhem todas as páginas institucionais listadas no sitemap (`/sobre-nos`, `/saiba-mais`, `/sob-demanda`, `/crm`, `/bni` e formulários de contato) para preservar consistência visual entre o conteúdo priorizado pelos buscadores.
 - Utilize títulos e subtítulos com palavras-chave naturais alinhadas à proposta de valor da marca; essa abordagem reforça o impacto do `robots.txt` e do sitemap, maximizando o aproveitamento do tráfego orgânico.
+- Mantenha o script JSON-LD de organização disponível diretamente no HTML inicial para que os mecanismos de busca leiam os metadados de branding mesmo em rastreadores sem execução de JavaScript.
 
 ## Diretrizes para o funil de vendas
 - Os cards do funil utilizam cantos arredondados de 16 px, sombra suave e espaçamento interno de 16 px.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -6,3 +6,5 @@ Disallow: /admin/
 Disallow: /private/
 Disallow: /api/
 
+Sitemap: https://evoluke.com.br/sitemap.xml
+

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -81,13 +81,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <head>
         <meta name="viewport" content="width=device-width,initial-scale=1" />
         <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
-        <Script
+        <script
           id="evoluke-organization-structured-data"
           type="application/ld+json"
-          strategy="afterInteractive"
-        >
-          {JSON.stringify(organizationStructuredData)}
-        </Script>
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(organizationStructuredData).replace(/</g, "\\u003c"),
+          }}
+        />
         <Script id="facebook-pixel" strategy="afterInteractive">
           {`
             !function(f,b,e,v,n,t,s)

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,19 +14,54 @@ const geistMono = Geist_Mono({ variable: "--font-geist-mono", subsets: ["latin"]
 const description =
   "A Evoluke oferece soluções de CRM integradas com inteligência artificial, personalizando atendimentos e automatizando processos para empresas.";
 
-export const metadata: Metadata = {
-  title: "Evoluke",
+const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? "https://evoluke.com.br";
+
+const organizationStructuredData = {
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  name: "Evoluke",
+  url: baseUrl,
+  logo: `${baseUrl}/logo.png`,
   description,
+  contactPoint: [
+    {
+      "@type": "ContactPoint",
+      contactType: "customer support",
+      availableLanguage: ["Portuguese"],
+    },
+  ],
+};
+
+export const metadata: Metadata = {
+  metadataBase: new URL(baseUrl),
+  title: {
+    default: "Evoluke | CRM com IA para atendimento omnicanal",
+    template: "%s | Evoluke",
+  },
+  description,
+  keywords: [
+    "CRM com IA",
+    "atendimento omnicanal",
+    "automação de vendas",
+    "chatbot inteligente",
+    "gestão de relacionamento com clientes",
+  ],
   robots: { index: true, follow: true },
+  category: "technology",
+  creator: "Evoluke",
+  publisher: "Evoluke",
+  alternates: {
+    canonical: "/",
+  },
   openGraph: {
-    title: "Evoluke",
+    title: "Evoluke | CRM com IA para atendimento omnicanal",
     description,
-    url: "https://evoluke.com.br",
+    url: baseUrl,
     siteName: "Evoluke",
     images: [
       {
-        url: "/logo.png",
-        alt: "Evoluke",
+        url: `${baseUrl}/logo.png`,
+        alt: "Logotipo da Evoluke",
       },
     ],
     locale: "pt_BR",
@@ -34,9 +69,9 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "Evoluke",
+    title: "Evoluke | CRM com IA para atendimento omnicanal",
     description,
-    images: ["/logo.png"],
+    images: [`${baseUrl}/logo.png`],
   },
 };
 
@@ -46,6 +81,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <head>
         <meta name="viewport" content="width=device-width,initial-scale=1" />
         <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+        <Script
+          id="evoluke-organization-structured-data"
+          type="application/ld+json"
+          strategy="afterInteractive"
+        >
+          {JSON.stringify(organizationStructuredData)}
+        </Script>
         <Script id="facebook-pixel" strategy="afterInteractive">
           {`
             !function(f,b,e,v,n,t,s)

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,43 +1,78 @@
+import Script from "next/script";
 import Header from "@/components/landing/Header";
 import Hero from "@/components/landing/Hero";
 import Features from "@/components/landing/Features";
 import Stats from "@/components/landing/Stats";
 import Benefit from "@/components/landing/Benefit";
-import FAQ from "@/components/landing/FAQ";
+import FAQ, { FAQ_ITEMS } from "@/components/landing/FAQ";
 import FinalCTA from "@/components/landing/FinalCTA";
 import Footer from "@/components/landing/Footer";
 import Pricing from "@/components/landing/Pricing";
 import type { Metadata } from "next";
 
-const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? "https://evoluke.com.br";
+const pageTitle = "CRM com IA para atendimento omnicanal";
+const pageDescription =
+  "Conheça a Evoluke, plataforma que une CRM omnicanal e inteligência artificial para automatizar processos, aumentar conversões e oferecer experiências personalizadas.";
+
+const faqStructuredData = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: FAQ_ITEMS.map((item) => ({
+    "@type": "Question",
+    name: item.q,
+    acceptedAnswer: {
+      "@type": "Answer",
+      text: item.a,
+    },
+  })),
+};
 
 export const metadata: Metadata = {
   metadataBase: new URL(baseUrl),
   alternates: {
     canonical: "/",
   },
-  title: "Evoluke",
-  description:
-    "A Evoluke oferece soluções de CRM integradas com inteligência artificial, personalizando atendimentos e automatizando processos para empresas.",
+  title: pageTitle,
+  description: pageDescription,
+  keywords: [
+    "CRM com inteligência artificial",
+    "atendimento automatizado",
+    "agente virtual para vendas",
+    "plataforma omnicanal",
+    "automação de atendimento ao cliente",
+  ],
   openGraph: {
-    title: "Evoluke",
-    description:
-      "A Evoluke oferece soluções de CRM integradas com inteligência artificial, personalizando atendimentos e automatizando processos para empresas.",
+    title: pageTitle,
+    description: pageDescription,
     url: baseUrl,
     siteName: "Evoluke",
+    images: [
+      {
+        url: `${baseUrl}/logo.png`,
+        alt: "Logotipo da Evoluke",
+      },
+    ],
     type: "website",
   },
   twitter: {
     card: "summary_large_image",
-    title: "Evoluke",
-    description:
-      "A Evoluke oferece soluções de CRM integradas com inteligência artificial, personalizando atendimentos e automatizando processos para empresas.",
+    title: pageTitle,
+    description: pageDescription,
+    images: [`${baseUrl}/logo.png`],
   },
 };
 
 export default function HomePage() {
   return (
     <>
+      <Script
+        id="evoluke-homepage-faq-structured-data"
+        type="application/ld+json"
+        strategy="afterInteractive"
+      >
+        {JSON.stringify(faqStructuredData)}
+      </Script>
       <Header />
       <main className="flex flex-col">
         <Hero />

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -9,8 +9,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { path: "saiba-mais", changefreq: "monthly", priority: 0.75 },
     { path: "sob-demanda", changefreq: "monthly", priority: 0.75 },
     { path: "pricing", changefreq: "monthly", priority: 0.8 },
-    { path: "crm", changefreq: "monthly", priority: 0.7 },
-    { path: "bni", changefreq: "monthly", priority: 0.65 },
     { path: "contact", changefreq: "monthly", priority: 0.6 },
     { path: "privacy", changefreq: "yearly", priority: 0.5 },
     { path: "terms", changefreq: "yearly", priority: 0.5 },

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -5,14 +5,21 @@ export default function sitemap(): MetadataRoute.Sitemap {
 
   const routes = [
     { path: "", changefreq: "weekly", priority: 1 },
+    { path: "sobre-nos", changefreq: "monthly", priority: 0.8 },
+    { path: "saiba-mais", changefreq: "monthly", priority: 0.75 },
+    { path: "sob-demanda", changefreq: "monthly", priority: 0.75 },
     { path: "pricing", changefreq: "monthly", priority: 0.8 },
+    { path: "crm", changefreq: "monthly", priority: 0.7 },
+    { path: "bni", changefreq: "monthly", priority: 0.65 },
+    { path: "contact", changefreq: "monthly", priority: 0.6 },
+    { path: "privacy", changefreq: "yearly", priority: 0.5 },
+    { path: "terms", changefreq: "yearly", priority: 0.5 },
     { path: "login", changefreq: "monthly", priority: 0.5 },
     { path: "signup", changefreq: "monthly", priority: 0.5 },
     { path: "forgot-password", changefreq: "yearly", priority: 0.3 },
     { path: "verify-email", changefreq: "yearly", priority: 0.3 },
     { path: "update-password", changefreq: "yearly", priority: 0.3 },
     { path: "complete-profile", changefreq: "yearly", priority: 0.3 },
-    { path: "terms", changefreq: "yearly", priority: 0.3 },
   ];
 
   const lastModified = new Date();


### PR DESCRIPTION
## Summary
- expand the sitemap to list the public marketing and policy pages with tuned change frequencies
- document the canonical sitemap URL in robots.txt and update branding guidelines for consistent SEO use
- describe the sitemap and robots behaviour in the README for future marketing updates

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9aaf457348333ab1c5e33bb957f65