### PR TITLE
Adicionar página de ferramentas e calculadora de margem

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ Este repositório contém uma aplicação [Next.js](https://nextjs.org/) prepara
 - O script JSON-LD de organização é inserido diretamente no HTML servido, garantindo que os buscadores tenham acesso imediato aos metadados estruturados sem depender de execução de JavaScript no cliente.
 - A imagem de destaque da seção hero utiliza `fetchpriority="high"`, `priority` e dimensões responsivas para ser pré-carregada logo no documento inicial, assegurando que a métrica de **Largest Contentful Paint (LCP)** seja atendida sem carregamento lento.
 
+## 🛠️ Ferramentas para leads
+
+- A landing page recebeu a seção **Ferramentas**, disponível no menu principal e acessível diretamente pela rota `/tools`, com cards otimizados para SEO destacando benefícios e CTAs de conversão.
+- A primeira ferramenta lançada é a **Calculadora de margem e precificação** (`/tools/calculadora-margem`), que valida entradas positivas, impede margens acima de 100% e apresenta preço sugerido, margem real e lucro unitário com formatação em português.
+- Cada página de ferramenta reforça a captura de leads ao incentivar login/criação de conta para salvar simulações e direciona para os planos premium com botões de destaque.
+
 ## 🧭 Funil de vendas
 
 O painel do CRM agora conta com a página **Funil de vendas**, acessível pela sidebar do dashboard. Nela é possível:

--- a/components/landing/Header.tsx
+++ b/components/landing/Header.tsx
@@ -3,11 +3,12 @@
 import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useState } from "react";
-import { Menu, X } from "lucide-react";
+import { ChevronDown, Menu, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 export default function Header() {
   const [open, setOpen] = useState(false);
+  const [toolsMenuOpen, setToolsMenuOpen] = useState(false);
 
   useEffect(() => {
     document.body.style.overflow = open ? "hidden" : "";
@@ -43,6 +44,45 @@ export default function Header() {
               <Link href="/sob-demanda" className="hover:text-primary">
                 Sob demanda
               </Link>
+            </li>
+            <li
+              className="relative"
+              onMouseEnter={() => setToolsMenuOpen(true)}
+              onMouseLeave={() => setToolsMenuOpen(false)}
+              onFocusCapture={() => setToolsMenuOpen(true)}
+              onBlur={(event) => {
+                const nextFocus = event.relatedTarget as Node | null;
+                if (!nextFocus || !event.currentTarget.contains(nextFocus)) {
+                  setToolsMenuOpen(false);
+                }
+              }}
+            >
+              <button
+                type="button"
+                className="hover:text-primary flex items-center gap-1"
+                aria-haspopup="true"
+                aria-expanded={toolsMenuOpen}
+                onClick={() => setToolsMenuOpen((current) => !current)}
+              >
+                Ferramentas
+                <ChevronDown className="h-4 w-4" aria-hidden="true" />
+              </button>
+              {toolsMenuOpen ? (
+                <div className="absolute left-0 top-full z-20 mt-2 w-64 rounded-lg border bg-background p-2 shadow-lg">
+                  <Link
+                    href="/tools"
+                    className="hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 block rounded-md px-3 py-2 text-left"
+                  >
+                    Visão geral das ferramentas
+                  </Link>
+                  <Link
+                    href="/tools/calculadora-margem"
+                    className="hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 block rounded-md px-3 py-2 text-left"
+                  >
+                    Calculadora de margem
+                  </Link>
+                </div>
+              ) : null}
             </li>
           </ul>
         </nav>
@@ -92,6 +132,18 @@ export default function Header() {
             <Link href="/sob-demanda" onClick={() => setOpen(false)}>
               Sob demanda
             </Link>
+            <div className="flex flex-col items-center gap-2">
+              <Link href="/tools" onClick={() => setOpen(false)} className="font-semibold">
+                Ferramentas
+              </Link>
+              <Link
+                href="/tools/calculadora-margem"
+                onClick={() => setOpen(false)}
+                className="text-sm text-muted-foreground"
+              >
+                Calculadora de margem
+              </Link>
+            </div>
             <Link href="/contact" onClick={() => setOpen(false)}>
               Contato
             </Link>

--- a/components/tools/MarginCalculatorForm.tsx
+++ b/components/tools/MarginCalculatorForm.tsx
@@ -1,0 +1,246 @@
+"use client";
+
+import { useMemo, useState, type ChangeEvent, type FormEvent } from "react";
+import { Calculator, Percent } from "lucide-react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+type CalculatorResult = {
+  totalCost: number;
+  suggestedPrice: number;
+  realMargin: number;
+  unitProfit: number;
+};
+
+type FieldName = "directCost" | "allocatedExpenses" | "taxes" | "desiredMargin";
+
+const currencyFormatter = new Intl.NumberFormat("pt-BR", {
+  style: "currency",
+  currency: "BRL",
+  maximumFractionDigits: 2,
+});
+
+const percentFormatter = new Intl.NumberFormat("pt-BR", {
+  style: "percent",
+  maximumFractionDigits: 2,
+});
+
+function sanitizeNumber(value: string) {
+  return Number(value.replace(/\s/g, "").replace(/\./g, "").replace(/,/g, "."));
+}
+
+export function MarginCalculatorForm() {
+  const [fields, setFields] = useState<Record<FieldName, string>>({
+    directCost: "",
+    allocatedExpenses: "",
+    taxes: "",
+    desiredMargin: "",
+  });
+  const [result, setResult] = useState<CalculatorResult | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const isButtonDisabled = useMemo(
+    () =>
+      fields.directCost.trim() === "" ||
+      fields.allocatedExpenses.trim() === "" ||
+      fields.taxes.trim() === "" ||
+      fields.desiredMargin.trim() === "",
+    [fields]
+  );
+
+  const handleInputChange = (name: FieldName) => (event: ChangeEvent<HTMLInputElement>) => {
+    setFields((current) => ({
+      ...current,
+      [name]: event.target.value,
+    }));
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const directCost = sanitizeNumber(fields.directCost);
+    const allocatedExpenses = sanitizeNumber(fields.allocatedExpenses);
+    const taxes = sanitizeNumber(fields.taxes);
+    const desiredMarginPercentage = sanitizeNumber(fields.desiredMargin);
+
+    if ([directCost, allocatedExpenses, taxes, desiredMarginPercentage].some(Number.isNaN)) {
+      setErrorMessage("Preencha todos os campos com números válidos.");
+      setResult(null);
+      return;
+    }
+
+    if (directCost <= 0) {
+      setErrorMessage("O custo direto precisa ser um número positivo.");
+      setResult(null);
+      return;
+    }
+
+    if (allocatedExpenses < 0 || taxes < 0) {
+      setErrorMessage("Despesas e impostos não podem ser negativos.");
+      setResult(null);
+      return;
+    }
+
+    if (desiredMarginPercentage < 0) {
+      setErrorMessage("Informe uma margem desejada positiva.");
+      setResult(null);
+      return;
+    }
+
+    if (desiredMarginPercentage >= 100) {
+      setErrorMessage("A margem precisa ser menor que 100%.");
+      setResult(null);
+      return;
+    }
+
+    const desiredMargin = desiredMarginPercentage / 100;
+    const totalCost = directCost + allocatedExpenses + taxes;
+    const suggestedPrice = totalCost / (1 - desiredMargin);
+    const unitProfit = suggestedPrice - totalCost;
+    const realMargin = unitProfit / suggestedPrice;
+
+    setResult({ totalCost, suggestedPrice, unitProfit, realMargin });
+    setErrorMessage(null);
+  };
+
+  return (
+    <section className="mx-auto flex max-w-5xl flex-col gap-10 px-4 py-16 sm:py-20">
+      <div className="grid items-start gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(0,0.9fr)]">
+        <div>
+          <span className="text-primary font-semibold uppercase tracking-wide">Ferramenta gratuita</span>
+          <h1 className="mt-3 text-3xl font-bold leading-tight text-foreground sm:text-4xl">
+            Calculadora de margem: descubra o preço certo em segundos
+          </h1>
+          <p className="mt-4 text-lg text-muted-foreground">
+            Informe o custo direto, despesas alocadas, impostos e a margem desejada para calcular automaticamente o preço de venda
+            recomendado. O resultado mostra a margem real e o lucro unitário para facilitar sua decisão de precificação.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-3 text-sm text-muted-foreground">
+            <span className="inline-flex items-center gap-2 rounded-full border border-primary/20 px-3 py-1">
+              <Calculator className="h-4 w-4" aria-hidden="true" />
+              Precificação inteligente
+            </span>
+            <span className="inline-flex items-center gap-2 rounded-full border border-primary/20 px-3 py-1">
+              <Percent className="h-4 w-4" aria-hidden="true" />
+              Margem real em tempo real
+            </span>
+          </div>
+        </div>
+        <Card className="shadow-xl">
+          <CardHeader>
+            <CardTitle className="text-2xl font-semibold">Simule sua margem agora</CardTitle>
+            <CardDescription>
+              Todos os campos aceitam valores decimais com vírgula ou ponto. Informe a margem como percentual (ex.: 20 para 20%).
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div>
+                <label htmlFor="directCost" className="text-sm font-medium text-foreground">
+                  Custo direto (R$)
+                </label>
+                <Input
+                  id="directCost"
+                  inputMode="decimal"
+                  value={fields.directCost}
+                  onChange={handleInputChange("directCost")}
+                  placeholder="Ex.: 1200,50"
+                  required
+                />
+              </div>
+              <div>
+                <label htmlFor="allocatedExpenses" className="text-sm font-medium text-foreground">
+                  Despesas fixas alocadas (R$)
+                </label>
+                <Input
+                  id="allocatedExpenses"
+                  inputMode="decimal"
+                  value={fields.allocatedExpenses}
+                  onChange={handleInputChange("allocatedExpenses")}
+                  placeholder="Ex.: 350,00"
+                  required
+                />
+              </div>
+              <div>
+                <label htmlFor="taxes" className="text-sm font-medium text-foreground">
+                  Impostos ou tributos (R$)
+                </label>
+                <Input
+                  id="taxes"
+                  inputMode="decimal"
+                  value={fields.taxes}
+                  onChange={handleInputChange("taxes")}
+                  placeholder="Ex.: 180,75"
+                  required
+                />
+              </div>
+              <div>
+                <label htmlFor="desiredMargin" className="text-sm font-medium text-foreground">
+                  Margem desejada (%)
+                </label>
+                <Input
+                  id="desiredMargin"
+                  inputMode="decimal"
+                  value={fields.desiredMargin}
+                  onChange={handleInputChange("desiredMargin")}
+                  placeholder="Ex.: 20"
+                  required
+                />
+              </div>
+              {errorMessage ? <p className="text-sm font-semibold text-destructive">{errorMessage}</p> : null}
+              <Button type="submit" size="lg" className="w-full" disabled={isButtonDisabled}>
+                Calcular preço sugerido
+              </Button>
+            </form>
+          </CardContent>
+        </Card>
+      </div>
+
+      {result ? (
+        <Card className="border-primary/20 bg-primary/5 shadow-lg">
+          <CardHeader className="pb-4">
+            <CardTitle className="text-2xl font-semibold text-primary">
+              Resultado da precificação
+            </CardTitle>
+            <CardDescription>
+              Utilize os valores para ajustar ofertas, negociar com fornecedores ou apresentar projeções em propostas comerciais.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-4 sm:grid-cols-3">
+            <div>
+              <span className="text-sm text-muted-foreground">Preço sugerido</span>
+              <p className="text-2xl font-bold text-foreground">{currencyFormatter.format(result.suggestedPrice)}</p>
+            </div>
+            <div>
+              <span className="text-sm text-muted-foreground">Margem real</span>
+              <p className="text-2xl font-bold text-foreground">{percentFormatter.format(result.realMargin)}</p>
+            </div>
+            <div>
+              <span className="text-sm text-muted-foreground">Lucro unitário</span>
+              <p className="text-2xl font-bold text-foreground">{currencyFormatter.format(result.unitProfit)}</p>
+            </div>
+          </CardContent>
+        </Card>
+      ) : null}
+
+      <Card className="border-primary/20 bg-card/90 shadow-lg">
+        <CardHeader>
+          <CardTitle className="text-2xl font-semibold">Potencialize seus resultados</CardTitle>
+          <CardDescription>
+            Salve os cálculos ao fazer login e conheça o plano premium para testar precificação em massa, cenários automáticos e
+            relatórios financeiros.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-3 sm:flex-row">
+          <Button asChild variant="outline" size="lg" className="w-full sm:w-auto">
+            <a href="/login">Entrar para salvar simulações</a>
+          </Button>
+          <Button asChild size="lg" className="w-full sm:w-auto">
+            <a href="/pricing">Conhecer plano premium</a>
+          </Button>
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/src/app/tools/calculadora-margem/page.tsx
+++ b/src/app/tools/calculadora-margem/page.tsx
@@ -1,0 +1,43 @@
+import type { Metadata } from "next";
+import { MarginCalculatorForm } from "@/components/tools/MarginCalculatorForm";
+
+const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? "https://evoluke.com.br";
+const pageTitle = "Calculadora de margem e precificação gratuita";
+const pageDescription =
+  "Simule custos, impostos e margens para descobrir o preço ideal de venda e o lucro unitário da sua empresa.";
+
+export const metadata: Metadata = {
+  metadataBase: new URL(baseUrl),
+  alternates: {
+    canonical: "/tools/calculadora-margem",
+  },
+  title: pageTitle,
+  description: pageDescription,
+  keywords: [
+    "calculadora de margem",
+    "calculadora de precificação",
+    "lucro unitário",
+    "formação de preço",
+    "gestão financeira para pequenas empresas",
+  ],
+  openGraph: {
+    title: pageTitle,
+    description: pageDescription,
+    url: `${baseUrl}/tools/calculadora-margem`,
+    siteName: "Evoluke",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: pageTitle,
+    description: pageDescription,
+  },
+};
+
+export default function MarginCalculatorPage() {
+  return (
+    <main className="bg-gradient-to-b from-background to-muted/30">
+      <MarginCalculatorForm />
+    </main>
+  );
+}

--- a/src/app/tools/page.tsx
+++ b/src/app/tools/page.tsx
@@ -1,0 +1,132 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import { ArrowRight, Calculator } from "lucide-react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? "https://evoluke.com.br";
+const pageTitle = "Ferramentas gratuitas para calcular margem e otimizar preços";
+const pageDescription =
+  "Acesse ferramentas gratuitas da Evoluke para estruturar sua precificação, calcular margens reais e planejar ofertas premium.";
+
+export const metadata: Metadata = {
+  metadataBase: new URL(baseUrl),
+  alternates: {
+    canonical: "/tools",
+  },
+  title: pageTitle,
+  description: pageDescription,
+  keywords: [
+    "ferramentas empresariais",
+    "calculadora de margem",
+    "precificação inteligente",
+    "gestão financeira",
+    "crm evoluke",
+  ],
+  openGraph: {
+    title: pageTitle,
+    description: pageDescription,
+    url: `${baseUrl}/tools`,
+    siteName: "Evoluke",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: pageTitle,
+    description: pageDescription,
+  },
+};
+
+const tools = [
+  {
+    title: "Calculadora de margem e precificação",
+    description:
+      "Descubra o preço de venda ideal e visualize imediatamente o impacto na margem e no lucro unitário.",
+    href: "/tools/calculadora-margem",
+    icon: Calculator,
+    highlight: "Nova",
+  },
+];
+
+export default function ToolsLandingPage() {
+  return (
+    <main className="bg-gradient-to-b from-background to-muted/40">
+      <section className="mx-auto max-w-5xl px-4 py-16 sm:py-20">
+        <span className="text-primary font-semibold uppercase tracking-wide">Ferramentas</span>
+        <h1 className="mt-3 text-3xl font-bold leading-tight text-foreground sm:text-4xl">
+          Acelere sua estratégia com ferramentas gratuitas da Evoluke
+        </h1>
+        <p className="mt-4 max-w-3xl text-lg text-muted-foreground">
+          Comece pelas calculadoras gratuitas para validar suas margens e aprenda como elevar o faturamento. Ao criar uma conta,
+          você desbloqueia recursos premium, como precificação em massa, cenários automáticos e relatórios em tempo real.
+        </p>
+        <div className="mt-8 flex flex-wrap gap-3">
+          <Link href="/signup">
+            <Button size="lg">Criar conta grátis</Button>
+          </Link>
+          <Link href="/pricing" className="flex items-center text-primary hover:text-primary/80">
+            Planos premium
+            <ArrowRight className="ml-2 h-4 w-4" aria-hidden="true" />
+          </Link>
+        </div>
+      </section>
+
+      <section className="bg-background/80">
+        <div className="mx-auto grid max-w-5xl gap-6 px-4 py-12 sm:grid-cols-2 lg:grid-cols-3">
+          {tools.map((tool) => (
+            <Card key={tool.href} className="relative overflow-hidden border-primary/10">
+              {tool.highlight ? (
+                <span className="bg-primary/10 text-primary absolute right-4 top-4 rounded-full px-3 py-1 text-xs font-semibold uppercase">
+                  {tool.highlight}
+                </span>
+              ) : null}
+              <CardHeader className="pb-2">
+                <tool.icon className="text-primary h-10 w-10" aria-hidden="true" />
+                <CardTitle className="text-xl font-semibold">{tool.title}</CardTitle>
+                <CardDescription className="text-base text-muted-foreground">
+                  {tool.description}
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="pt-0">
+                <Link
+                  href={tool.href}
+                  className="text-primary hover:text-primary/80 inline-flex items-center font-semibold"
+                  aria-label={`Acessar ${tool.title}`}
+                >
+                  Acessar ferramenta
+                  <ArrowRight className="ml-2 h-4 w-4" aria-hidden="true" />
+                </Link>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-5xl px-4 py-16 sm:py-20">
+        <div className="grid gap-8 rounded-2xl border border-primary/10 bg-card p-8 shadow-lg sm:grid-cols-2">
+          <div>
+            <h2 className="text-2xl font-semibold text-foreground">
+              Transforme insights em lucro recorrente
+            </h2>
+            <p className="mt-3 text-muted-foreground">
+              Use as ferramentas para entregar valor imediato e colete leads qualificados. Depois, convide sua equipe para testar o
+              plano premium com automações de CRM, agentes de IA e integrações omnicanal.
+            </p>
+          </div>
+          <div className="flex flex-col justify-center gap-3">
+            <Link href="/login">
+              <Button variant="outline" size="lg" className="w-full">
+                Entrar e salvar meus cálculos
+              </Button>
+            </Link>
+            <Link href="/pricing">
+              <Button size="lg" className="w-full">
+                Conhecer o plano premium
+              </Button>
+            </Link>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- criar hub de ferramentas em `/tools` com metadados de SEO e CTA para planos premium
- disponibilizar a calculadora de margem com validação de entradas, resultados formatados e incentivo à captura de leads
- atualizar o menu principal e a documentação para divulgar a nova seção de ferramentas

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9d1e32254833384df176faf54330a