### PR TITLE
Add pricing tools hub with margin calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ Este repositório contém uma aplicação [Next.js](https://nextjs.org/) prepara
 - O script JSON-LD de organização é inserido diretamente no HTML servido, garantindo que os buscadores tenham acesso imediato aos metadados estruturados sem depender de execução de JavaScript no cliente.
 - A imagem de destaque da seção hero utiliza `fetchpriority="high"`, `priority` e dimensões responsivas para ser pré-carregada logo no documento inicial, assegurando que a métrica de **Largest Contentful Paint (LCP)** seja atendida sem carregamento lento.
 
+## 🛠 Ferramentas de gestão
+
+- A rota `/tools` concentra as ferramentas abertas ao público para captar leads e apresentar recursos premium. Ela reúne cards com descrição da proposta de valor, chamadas para cadastro e atalhos para cada solução publicada.
+- A página `/tools/calculadora-margem` disponibiliza uma calculadora de margem de lucro que recebe custos diretos, despesas alocadas, tributos e margem desejada. O fluxo valida números positivos, impede margens a partir de 100% e retorna preço sugerido, margem real e lucro unitário, exibindo um convite para cadastro após o cálculo.
+- Cada nova ferramenta adicionada ao diretório `src/app/tools` deve ser vinculada ao menu "Ferramentas" da landing page para garantir que o público encontre as experiências mais recentes e que o SEO acompanhe a expansão do catálogo.
+
 ## 🧭 Funil de vendas
 
 O painel do CRM agora conta com a página **Funil de vendas**, acessível pela sidebar do dashboard. Nela é possível:

--- a/components/landing/Header.tsx
+++ b/components/landing/Header.tsx
@@ -3,14 +3,38 @@
 import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useState } from "react";
-import { Menu, X } from "lucide-react";
+import { Menu, X, ChevronDown } from "lucide-react";
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { Button } from "@/components/ui/button";
+
+type ToolLink = {
+  href: string;
+  label: string;
+  description: string;
+};
+
+const toolLinks: ToolLink[] = [
+  {
+    href: "/tools",
+    label: "Central de ferramentas",
+    description: "Conheça todas as soluções digitais da Evoluke",
+  },
+  {
+    href: "/tools/calculadora-margem",
+    label: "Calculadora de margem",
+    description: "Defina preços de venda com segurança e agilidade",
+  },
+];
 
 export default function Header() {
   const [open, setOpen] = useState(false);
+  const [toolsMobileOpen, setToolsMobileOpen] = useState(false);
 
   useEffect(() => {
     document.body.style.overflow = open ? "hidden" : "";
+    if (!open) {
+      setToolsMobileOpen(false);
+    }
     return () => {
       document.body.style.overflow = "";
     };
@@ -43,6 +67,38 @@ export default function Header() {
               <Link href="/sob-demanda" className="hover:text-primary">
                 Sob demanda
               </Link>
+            </li>
+            <li>
+              <DropdownMenu.Root>
+                <DropdownMenu.Trigger asChild>
+                  <button
+                    className="flex items-center gap-1 rounded-md px-2 py-1 text-sm font-medium transition hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
+                    aria-haspopup="menu"
+                  >
+                    Ferramentas
+                    <ChevronDown className="h-4 w-4" aria-hidden />
+                  </button>
+                </DropdownMenu.Trigger>
+                <DropdownMenu.Portal>
+                  <DropdownMenu.Content
+                    align="center"
+                    sideOffset={12}
+                    className="z-50 min-w-[240px] rounded-lg border border-border bg-background p-2 text-sm shadow-lg"
+                  >
+                    {toolLinks.map((tool) => (
+                      <DropdownMenu.Item key={tool.href} asChild>
+                        <Link
+                          href={tool.href}
+                          className="block rounded-md px-3 py-2 transition hover:bg-primary/5 focus:bg-primary/5"
+                        >
+                          <span className="block font-medium text-foreground">{tool.label}</span>
+                          <span className="block text-xs text-muted-foreground">{tool.description}</span>
+                        </Link>
+                      </DropdownMenu.Item>
+                    ))}
+                  </DropdownMenu.Content>
+                </DropdownMenu.Portal>
+              </DropdownMenu.Root>
             </li>
           </ul>
         </nav>
@@ -92,6 +148,36 @@ export default function Header() {
             <Link href="/sob-demanda" onClick={() => setOpen(false)}>
               Sob demanda
             </Link>
+            <div className="w-full">
+              <button
+                type="button"
+                className="flex w-full items-center justify-between rounded-md border border-muted-foreground/20 px-4 py-2 text-base font-medium"
+                onClick={() => setToolsMobileOpen((prev) => !prev)}
+                aria-expanded={toolsMobileOpen}
+                aria-controls="mobile-tools-menu"
+              >
+                Ferramentas
+                <ChevronDown className={`h-5 w-5 transition ${toolsMobileOpen ? "rotate-180" : ""}`} aria-hidden />
+              </button>
+              {toolsMobileOpen && (
+                <div id="mobile-tools-menu" className="mt-2 space-y-2 rounded-md border border-muted-foreground/10 p-3 text-left text-base">
+                  {toolLinks.map((tool) => (
+                    <Link
+                      key={tool.href}
+                      href={tool.href}
+                      className="block rounded-md px-2 py-2 text-sm text-foreground transition hover:bg-primary/10"
+                      onClick={() => {
+                        setOpen(false);
+                        setToolsMobileOpen(false);
+                      }}
+                    >
+                      <span className="block font-medium">{tool.label}</span>
+                      <span className="block text-xs text-muted-foreground">{tool.description}</span>
+                    </Link>
+                  ))}
+                </div>
+              )}
+            </div>
             <Link href="/contact" onClick={() => setOpen(false)}>
               Contato
             </Link>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -8,6 +8,8 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { path: "sobre-nos", changefreq: "monthly", priority: 0.8 },
     { path: "saiba-mais", changefreq: "monthly", priority: 0.75 },
     { path: "sob-demanda", changefreq: "monthly", priority: 0.75 },
+    { path: "tools", changefreq: "weekly", priority: 0.7 },
+    { path: "tools/calculadora-margem", changefreq: "weekly", priority: 0.7 },
     { path: "pricing", changefreq: "monthly", priority: 0.8 },
     { path: "contact", changefreq: "monthly", priority: 0.6 },
     { path: "privacy", changefreq: "yearly", priority: 0.5 },

--- a/src/app/tools/calculadora-margem/margin-calculator.tsx
+++ b/src/app/tools/calculadora-margem/margin-calculator.tsx
@@ -1,0 +1,289 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { AlertCircle, CheckCircle2, ShieldCheck } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/components/ui/utils";
+
+type CalculatorResult = {
+  totalCost: number;
+  suggestedPrice: number;
+  realMargin: number;
+  unitProfit: number;
+};
+
+const currencyFormatter = new Intl.NumberFormat("pt-BR", {
+  style: "currency",
+  currency: "BRL",
+});
+
+const percentageFormatter = new Intl.NumberFormat("pt-BR", {
+  style: "percent",
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+const leadCopy = {
+  title: "Transforme a calculadora em uma vantagem competitiva",
+  description:
+    "Cadastre-se para salvar históricos, exportar resultados e acessar recursos premium como precificação em massa, cenários avançados e relatórios automatizados.",
+};
+
+export function MarginCalculator() {
+  const [directCost, setDirectCost] = useState("");
+  const [allocatedExpenses, setAllocatedExpenses] = useState("");
+  const [taxes, setTaxes] = useState("");
+  const [desiredMargin, setDesiredMargin] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<CalculatorResult | null>(null);
+  const [leadEmail, setLeadEmail] = useState("");
+  const [leadFeedback, setLeadFeedback] = useState<string | null>(null);
+
+  const hasResult = useMemo(() => Boolean(result), [result]);
+
+  const parseCurrency = (value: string) => {
+    const sanitized = value.trim().replace(/\s+/g, "").replace(/\./g, "").replace(",", ".");
+    const parsed = Number(sanitized);
+    return Number.isFinite(parsed) ? parsed : NaN;
+  };
+
+  const parsePercentage = (value: string) => {
+    const sanitized = value.trim().replace(/\s+/g, "").replace(/\./g, "").replace(",", ".");
+    const parsed = Number(sanitized);
+    return Number.isFinite(parsed) ? parsed : NaN;
+  };
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const directCostValue = parseCurrency(directCost);
+    const allocatedExpensesValue = parseCurrency(allocatedExpenses || "0");
+    const taxesValue = parseCurrency(taxes || "0");
+    const desiredMarginValue = parsePercentage(desiredMargin);
+
+    if (
+      [directCostValue, allocatedExpensesValue, taxesValue, desiredMarginValue].some(
+        (value) => Number.isNaN(value) || value < 0,
+      )
+    ) {
+      setError("Preencha todos os campos com números positivos. Utilize ponto ou vírgula para casas decimais.");
+      setResult(null);
+      return;
+    }
+
+    if (directCostValue === 0) {
+      setError("O custo direto precisa ser maior que zero para gerar o preço de venda.");
+      setResult(null);
+      return;
+    }
+
+    if (desiredMarginValue >= 100) {
+      setError("A margem desejada precisa ser menor que 100%.");
+      setResult(null);
+      return;
+    }
+
+    if (desiredMarginValue < 0) {
+      setError("Informe uma margem desejada positiva.");
+      setResult(null);
+      return;
+    }
+
+    const desiredMarginRate = desiredMarginValue / 100;
+    const totalCost = directCostValue + allocatedExpensesValue + taxesValue;
+    const suggestedPrice = totalCost / (1 - desiredMarginRate);
+    const unitProfit = suggestedPrice - totalCost;
+    const realMargin = unitProfit / suggestedPrice;
+
+    setResult({ totalCost, suggestedPrice, realMargin, unitProfit });
+    setError(null);
+  };
+
+  const handleLeadSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!leadEmail.trim()) {
+      setLeadFeedback("Informe um e-mail válido para receber as novidades.");
+      return;
+    }
+
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+    if (!emailRegex.test(leadEmail.trim())) {
+      setLeadFeedback("E-mail inválido. Tente novamente usando um endereço corporativo.");
+      return;
+    }
+
+    setLeadFeedback(
+      "Obrigado! Em breve enviaremos conteúdos exclusivos sobre precificação e as próximas ferramentas premium.",
+    );
+    setLeadEmail("");
+  };
+
+  return (
+    <div className="space-y-8">
+      <Card className="shadow-none">
+        <CardHeader>
+          <CardTitle className="text-2xl">Preencha os custos para gerar o preço sugerido</CardTitle>
+          <CardDescription>
+            Consideramos custos diretos, despesas fixas alocadas e tributos para entregar a recomendação mais próxima da realidade
+            do seu negócio.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form className="grid gap-6" onSubmit={handleSubmit} noValidate>
+            <div className="grid gap-2">
+              <label className="text-sm font-medium" htmlFor="direct-cost">
+                Custo direto (R$)
+              </label>
+              <Input
+                id="direct-cost"
+                inputMode="decimal"
+                placeholder="Ex.: 125,90"
+                value={directCost}
+                onChange={(event) => setDirectCost(event.target.value)}
+                required
+                aria-describedby="direct-cost-help"
+              />
+              <p id="direct-cost-help" className="text-xs text-muted-foreground">
+                Some matéria-prima, mão de obra direta ou aquisição do produto.
+              </p>
+            </div>
+
+            <div className="grid gap-2">
+              <label className="text-sm font-medium" htmlFor="allocated-expenses">
+                Despesas fixas alocadas (R$)
+              </label>
+              <Input
+                id="allocated-expenses"
+                inputMode="decimal"
+                placeholder="Ex.: 32,50"
+                value={allocatedExpenses}
+                onChange={(event) => setAllocatedExpenses(event.target.value)}
+                aria-describedby="allocated-expenses-help"
+              />
+              <p id="allocated-expenses-help" className="text-xs text-muted-foreground">
+                Rateio de aluguel, equipe administrativa, energia e outros custos indiretos do período.
+              </p>
+            </div>
+
+            <div className="grid gap-2">
+              <label className="text-sm font-medium" htmlFor="taxes">
+                Impostos ou tributos aplicáveis (R$)
+              </label>
+              <Input
+                id="taxes"
+                inputMode="decimal"
+                placeholder="Ex.: 18,40"
+                value={taxes}
+                onChange={(event) => setTaxes(event.target.value)}
+                aria-describedby="taxes-help"
+              />
+              <p id="taxes-help" className="text-xs text-muted-foreground">
+                Inclua ICMS, ISS, PIS, COFINS ou outros encargos relacionados à venda.
+              </p>
+            </div>
+
+            <div className="grid gap-2">
+              <label className="text-sm font-medium" htmlFor="desired-margin">
+                Margem desejada (%)
+              </label>
+              <Input
+                id="desired-margin"
+                inputMode="decimal"
+                placeholder="Ex.: 20"
+                value={desiredMargin}
+                onChange={(event) => setDesiredMargin(event.target.value)}
+                required
+                aria-describedby="desired-margin-help"
+              />
+              <p id="desired-margin-help" className="text-xs text-muted-foreground">
+                Informe o percentual de lucro esperado sobre o preço final. Utilize números menores que 100.
+              </p>
+            </div>
+
+            {error && (
+              <div className="flex items-start gap-3 rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive">
+                <AlertCircle className="mt-0.5 h-4 w-4" aria-hidden />
+                <p>{error}</p>
+              </div>
+            )}
+
+            <Button type="submit" className="justify-center">
+              Calcular preço sugerido
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+
+      {hasResult && result && (
+        <Card className="border-primary/40 bg-primary/5 shadow-none">
+          <CardHeader className="gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="space-y-1">
+              <CardTitle className="text-2xl">Resultado da precificação</CardTitle>
+              <CardDescription>Utilize estes valores para ajustar catálogos, propostas e metas de vendas.</CardDescription>
+            </div>
+            <CheckCircle2 className="h-8 w-8 text-primary" aria-hidden />
+          </CardHeader>
+          <CardContent className="grid gap-4 sm:grid-cols-3">
+            <div className="rounded-lg bg-background p-4 text-center shadow-sm">
+              <p className="text-sm font-semibold text-muted-foreground">Preço de venda sugerido</p>
+              <p className="mt-2 text-2xl font-bold">{currencyFormatter.format(result.suggestedPrice)}</p>
+            </div>
+            <div className="rounded-lg bg-background p-4 text-center shadow-sm">
+              <p className="text-sm font-semibold text-muted-foreground">Margem real estimada</p>
+              <p className="mt-2 text-2xl font-bold">{percentageFormatter.format(result.realMargin)}</p>
+            </div>
+            <div className="rounded-lg bg-background p-4 text-center shadow-sm">
+              <p className="text-sm font-semibold text-muted-foreground">Lucro unitário previsto</p>
+              <p className="mt-2 text-2xl font-bold">{currencyFormatter.format(result.unitProfit)}</p>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      <Card className={cn("shadow-none", hasResult ? "border-primary/30" : "border-border") }>
+        <CardHeader className="gap-4">
+          <div className="flex items-start gap-3">
+            <ShieldCheck className="mt-1 h-6 w-6 text-primary" aria-hidden />
+            <div>
+              <CardTitle className="text-xl">{leadCopy.title}</CardTitle>
+              <CardDescription>{leadCopy.description}</CardDescription>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <form className="flex flex-col gap-3 sm:flex-row" onSubmit={handleLeadSubmit} noValidate>
+            <label className="sr-only" htmlFor="lead-email">
+              E-mail corporativo
+            </label>
+            <Input
+              id="lead-email"
+              type="email"
+              inputMode="email"
+              placeholder="seuemail@empresa.com"
+              value={leadEmail}
+              onChange={(event) => {
+                setLeadEmail(event.target.value);
+                setLeadFeedback(null);
+              }}
+            />
+            <Button type="submit" className="whitespace-nowrap">
+              Quero liberar recursos premium
+            </Button>
+          </form>
+          {leadFeedback && (
+            <p className="mt-2 text-sm text-muted-foreground">{leadFeedback}</p>
+          )}
+          <p className="mt-4 text-xs text-muted-foreground">
+            Ao se inscrever você concorda em receber comunicações da Evoluke. Você poderá cancelar a assinatura a qualquer
+            momento.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/tools/calculadora-margem/metadata-heading.tsx
+++ b/src/app/tools/calculadora-margem/metadata-heading.tsx
@@ -1,0 +1,14 @@
+export function MetadataHeading() {
+  return (
+    <header className="space-y-4 text-center sm:text-left">
+      <p className="text-sm font-semibold uppercase tracking-wide text-primary">Calculadora gratuita</p>
+      <h1 className="text-3xl font-bold sm:text-4xl">
+        Calculadora de margem de lucro e precificação para empresas
+      </h1>
+      <p className="text-base text-muted-foreground">
+        Informe os valores do seu negócio para descobrir o preço de venda sugerido, a margem real alcançada e o lucro unitário
+        estimado. Use os resultados para definir estratégias de precificação mais competitivas e lucrativas.
+      </p>
+    </header>
+  );
+}

--- a/src/app/tools/calculadora-margem/page.tsx
+++ b/src/app/tools/calculadora-margem/page.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from "next";
+
+import { MetadataHeading } from "./metadata-heading";
+import { MarginCalculator } from "./margin-calculator";
+
+export const metadata: Metadata = {
+  title: "Calculadora de margem de lucro e precificação | Evoluke",
+  description:
+    "Calcule o preço de venda ideal a partir dos custos diretos, despesas alocadas, impostos e margem desejada. Descubra a margem real e o lucro unitário em segundos.",
+  keywords: [
+    "calculadora de margem",
+    "precificação",
+    "preço de venda",
+    "margem de lucro",
+    "lucro unitário",
+    "gestão financeira",
+  ],
+  alternates: {
+    canonical: "/tools/calculadora-margem",
+  },
+};
+
+export default function MarginCalculatorPage() {
+  return (
+    <div className="space-y-10">
+      <MetadataHeading />
+      <MarginCalculator />
+    </div>
+  );
+}

--- a/src/app/tools/layout.tsx
+++ b/src/app/tools/layout.tsx
@@ -1,0 +1,11 @@
+import type { ReactNode } from "react";
+
+export default function ToolsLayout({ children }: { children: ReactNode }) {
+  return (
+    <main className="bg-background">
+      <div className="mx-auto w-full max-w-5xl px-4 py-12 sm:px-6 lg:px-8">
+        {children}
+      </div>
+    </main>
+  );
+}

--- a/src/app/tools/page.tsx
+++ b/src/app/tools/page.tsx
@@ -1,0 +1,92 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import { ArrowRight, Calculator, Mail } from "lucide-react";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+export const metadata: Metadata = {
+  title: "Ferramentas inteligentes para empresas | Evoluke",
+  description:
+    "Central de ferramentas da Evoluke com calculadoras e recursos de gestão para ajudar empresas a precificar melhor e aumentar a lucratividade.",
+  keywords: [
+    "ferramentas empresariais",
+    "calculadora de margem",
+    "precificação",
+    "gestão financeira",
+    "Evoluke",
+  ],
+  alternates: {
+    canonical: "/tools",
+  },
+};
+
+const tools = [
+  {
+    slug: "calculadora-margem",
+    title: "Calculadora de margem e precificação",
+    description:
+      "Simule rapidamente o preço de venda ideal, visualize a margem real obtida e planeje cenários de lucro unitário.",
+    icon: Calculator,
+  },
+];
+
+export default function ToolsPage() {
+  return (
+    <section className="space-y-12">
+      <header className="space-y-4 text-center">
+        <p className="text-sm font-semibold uppercase tracking-wide text-primary">Ferramentas Evoluke</p>
+        <h1 className="text-3xl font-bold sm:text-4xl">
+          Calcule margens de lucro e otimize sua precificação em minutos
+        </h1>
+        <p className="mx-auto max-w-3xl text-base text-muted-foreground">
+          Explore nossa central de ferramentas digitais pensadas para gestores e empreendedores que desejam ganhar tempo,
+          entender a rentabilidade real de cada produto e criar ofertas mais competitivas.
+        </p>
+      </header>
+
+      <div className="grid gap-6 sm:grid-cols-2">
+        {tools.map((tool) => (
+          <Card key={tool.slug} className="h-full border-primary/10 shadow-none transition hover:border-primary/40">
+            <CardHeader>
+              <tool.icon className="h-8 w-8 text-primary" aria-hidden />
+              <CardTitle className="text-2xl font-semibold">{tool.title}</CardTitle>
+              <CardDescription>{tool.description}</CardDescription>
+            </CardHeader>
+            <CardContent className="flex flex-col gap-6">
+              <div className="rounded-md bg-muted/60 p-4 text-sm text-muted-foreground">
+                Ideal para criar estratégias de precificação assertivas e identificar oportunidades de aumento de lucro em cada
+                venda.
+              </div>
+              <Button asChild className="self-start">
+                <Link href={`/tools/${tool.slug}`} aria-label={`Acessar ${tool.title}`}>
+                  Abrir ferramenta
+                  <ArrowRight className="ml-2 h-4 w-4" aria-hidden />
+                </Link>
+              </Button>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <aside className="rounded-lg border border-primary/20 bg-primary/5 p-6">
+        <div className="flex flex-col gap-4 text-center sm:flex-row sm:items-center sm:justify-between sm:text-left">
+          <div className="flex flex-col gap-2">
+            <p className="text-sm font-semibold uppercase tracking-wide text-primary">Novas soluções em breve</p>
+            <h2 className="text-2xl font-bold">Receba novidades sobre ferramentas premium</h2>
+            <p className="max-w-2xl text-sm text-muted-foreground">
+              Inscreva-se para saber quando lançarmos precificação em massa, simulações avançadas, relatórios automatizados e
+              outras experiências exclusivas.
+            </p>
+          </div>
+          <Button asChild variant="outline" className="border-primary/50 text-primary hover:bg-primary hover:text-primary-foreground">
+            <Link href="/signup" aria-label="Criar conta gratuita e acessar novidades">
+              <Mail className="mr-2 h-4 w-4" aria-hidden />
+              Quero ser avisado
+            </Link>
+          </Button>
+        </div>
+      </aside>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add public tools hub highlighting premium lead capture opportunities
- implement margin and pricing calculator with validation, results, and lead form
- expose tools navigation entry and update sitemap and documentation for new pages

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9d1e32254833384df176faf54330a