### PR TITLE
Enable Google AdSense script on tools page

### DIFF
--- a/src/app/tools/calculadora-margem/page.tsx
+++ b/src/app/tools/calculadora-margem/page.tsx
@@ -55,6 +55,13 @@ const jsonLd = {
 export default function MarginCalculatorPage() {
   return (
     <div className="mx-auto max-w-6xl px-4 py-16 sm:px-6 lg:px-8">
+      <Script
+        id="google-adsense"
+        async
+        src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9486959611066829"
+        strategy="afterInteractive"
+        crossOrigin="anonymous"
+      />
       <Script id="margin-calculator-jsonld" type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
       <header className="max-w-3xl space-y-4">
         <span className="inline-flex items-center rounded-full border border-primary/20 bg-primary/5 px-3 py-1 text-xs font-semibold uppercase tracking-wider text-primary">

--- a/src/app/tools/page.tsx
+++ b/src/app/tools/page.tsx
@@ -20,6 +20,13 @@ const jsonLd = {
 export default function ToolsPage() {
   return (
     <div className="mx-auto max-w-5xl px-4 py-16 sm:px-6 lg:px-8">
+      <Script
+        id="google-adsense"
+        async
+        src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9486959611066829"
+        strategy="afterInteractive"
+        crossOrigin="anonymous"
+      />
       <Script id="tools-jsonld" type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
       <section className="space-y-6 text-center">
         <span className="inline-flex items-center rounded-full border border-primary/20 bg-primary/5 px-3 py-1 text-xs font-semibold uppercase tracking-wider text-primary">


### PR DESCRIPTION
## Summary
- add the Google AdSense loader script to the Tools page so ads can run

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9f2fd16e08333b0c30d0979bd6533