### PR TITLE
Ensure public pages define accurate canonical URLs

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -13,6 +13,9 @@ import {
 export const metadata: Metadata = {
   title: "Contato - Evoluke",
   description: "Informações de contato da Evoluke",
+  alternates: {
+    canonical: "/contact",
+  },
 };
 
 export default function ContactPage() {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -50,9 +50,6 @@ export const metadata: Metadata = {
   category: "technology",
   creator: "Evoluke",
   publisher: "Evoluke",
-  alternates: {
-    canonical: "/",
-  },
   openGraph: {
     title: "Evoluke | CRM com IA para atendimento omnicanal",
     description,

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -6,6 +6,9 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
   title: "Planos - Evoluke",
   description: "Veja nossos planos e escolha o melhor para sua empresa.",
+  alternates: {
+    canonical: "/pricing",
+  },
 };
 
 export default function PricingPage() {

--- a/src/app/saiba-mais/page.tsx
+++ b/src/app/saiba-mais/page.tsx
@@ -7,6 +7,9 @@ export const metadata: Metadata = {
   title: "Saiba Mais - Evoluke",
   description:
     "Conheça em detalhes o passo a passo de implantação, integrações e suporte do agente Evoluke para elevar o atendimento com IA.",
+  alternates: {
+    canonical: "/saiba-mais",
+  },
 };
 
 export default function SaibaMaisPage() {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,7 +1,7 @@
 import type { MetadataRoute } from "next";
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? "https://evoluke.com.br";
 
   const routes = [
     { path: "", changefreq: "weekly", priority: 1 },

--- a/src/app/sob-demanda/page.tsx
+++ b/src/app/sob-demanda/page.tsx
@@ -6,6 +6,9 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
   title: "Sob demanda - Evoluke",
   description: "Planos sob demanda da Evoluke",
+  alternates: {
+    canonical: "/sob-demanda",
+  },
 };
 
 export default function SobDemandaPage() {

--- a/src/app/sobre-nos/page.tsx
+++ b/src/app/sobre-nos/page.tsx
@@ -6,6 +6,9 @@ export const metadata: Metadata = {
   title: "Sobre Nós - Evoluke",
   description:
     "Saiba mais sobre a Evoluke e nossa missão de transformar o atendimento com tecnologia.",
+  alternates: {
+    canonical: "/sobre-nos",
+  },
 };
 
 export default function AboutPage() {

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -5,6 +5,9 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
   title: "Termos de Uso | Evoluke",
   description: "Termos de uso da plataforma Evoluke",
+  alternates: {
+    canonical: "/terms",
+  },
 };
 
 export default function TermsPage() {

--- a/src/app/tools/calculadora-margem/page.tsx
+++ b/src/app/tools/calculadora-margem/page.tsx
@@ -3,18 +3,21 @@ import type { Metadata } from "next";
 
 import CalculatorClient from "./CalculatorClient";
 
+const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? "https://evoluke.com.br";
+
 export const metadata: Metadata = {
+  metadataBase: new URL(baseUrl),
   title: "Calculadora de margem e precificação | Evoluke",
   description:
     "Calcule preço sugerido, margem real e lucro unitário em segundos e descubra como agentes de IA mantêm sua política comercial lucrativa.",
   alternates: {
-    canonical: "https://www.evoluke.com.br/tools/calculadora-margem",
+    canonical: "/tools/calculadora-margem",
   },
   openGraph: {
     title: "Calculadora de margem e precificação | Evoluke",
     description:
       "Informe custos, impostos e margem desejada para descobrir automaticamente o preço ideal de venda e o lucro unitário esperado.",
-    url: "https://www.evoluke.com.br/tools/calculadora-margem",
+    url: "/tools/calculadora-margem",
     type: "article",
     siteName: "Evoluke",
   },

--- a/src/app/tools/page.tsx
+++ b/src/app/tools/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import Script from "next/script";
+import type { Metadata } from "next";
 
 const jsonLd = {
   "@context": "https://schema.org",
@@ -15,6 +16,15 @@ const jsonLd = {
       url: "https://www.evoluke.com.br/tools/calculadora-margem",
     },
   ],
+};
+
+export const metadata: Metadata = {
+  title: "Ferramentas gratuitas - Evoluke",
+  description:
+    "Acesse calculadoras e recursos gratuitos da Evoluke para planejar precificação e estratégias comerciais com apoio de IA.",
+  alternates: {
+    canonical: "/tools",
+  },
 };
 
 export default function ToolsPage() {


### PR DESCRIPTION
## Summary
- remove the canonical URL from the root layout metadata to avoid propagating an incorrect default
- define page-specific canonical alternates for the public marketing routes, including the tools hub and calculator
- align the sitemap base URL with the production domain used by metadataBase so generated links stay consistent

## Testing
- npm run lint *(warnings about existing unused variables and Next.js recommendations)*

------
https://chatgpt.com/codex/tasks/task_e_68d9f5f26e388333a77b1995f37f4b55