### PR TITLE
Atualiza identificadores do AdSense na calculadora de margem

### DIFF
--- a/src/app/tools/calculadora-margem/CalculatorClient.tsx
+++ b/src/app/tools/calculadora-margem/CalculatorClient.tsx
@@ -265,6 +265,9 @@ declare global {
   }
 }
 
+const ADSENSE_CLIENT = process.env.NEXT_PUBLIC_ADSENSE_CLIENT ?? "ca-pub-9486959611066829";
+const ADSENSE_SLOT = process.env.NEXT_PUBLIC_ADSENSE_MARGIN_CALCULATOR_SLOT;
+
 function GoogleAdsenseBanner() {
   useEffect(() => {
     if (typeof window === "undefined") {
@@ -275,6 +278,11 @@ function GoogleAdsenseBanner() {
       const adsQueue = window.adsbygoogle ?? [];
       adsQueue.push({});
       window.adsbygoogle = adsQueue;
+      if (!ADSENSE_SLOT) {
+        console.warn(
+          "Google AdSense slot ID ausente. Configure NEXT_PUBLIC_ADSENSE_MARGIN_CALCULATOR_SLOT para renderizar anúncios."
+        );
+      }
     } catch (error) {
       console.error("Erro ao carregar anúncio do Google Ads", error);
     }
@@ -285,14 +293,14 @@ function GoogleAdsenseBanner() {
       <Script
         id="adsbygoogle-tools-calculator"
         strategy="afterInteractive"
-        src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-0000000000000000"
+        src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${ADSENSE_CLIENT}`}
         crossOrigin="anonymous"
       />
       <ins
         className="adsbygoogle block w-full"
         style={{ display: "block", minHeight: "60px" }}
-        data-ad-client="ca-pub-0000000000000000"
-        data-ad-slot="1234567890"
+        data-ad-client={ADSENSE_CLIENT}
+        data-ad-slot={ADSENSE_SLOT}
         data-ad-format="auto"
         data-full-width-responsive="true"
       />


### PR DESCRIPTION
## Summary
- atualiza o script do AdSense da calculadora de margem para usar o mesmo publisher ID padrão do site
- lê os identificadores de client e slot a partir de variáveis de ambiente no banner e adiciona alerta quando o slot não está configurado

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9f72b9904833389393bb391e4873b