### PR TITLE
Add Google AdSense account meta tag to layout head

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -77,6 +77,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="pt-BR" className={`${inter.variable} ${geistMono.variable}`}>
       <head>
         <meta name="viewport" content="width=device-width,initial-scale=1" />
+        <meta name="google-adsense-account" content="ca-pub-9486959611066829" />
         <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
         <script
           id="evoluke-organization-structured-data"


### PR DESCRIPTION
## Summary
- add the Google AdSense account meta tag to the application layout head so crawlers can detect it

## Testing
- npm run lint
- npm run build *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_68d9f73150b4833392f754085a5177ea