### PR TITLE
Add AdSense unit to margin calculator tool

### DIFF
--- a/src/app/tools/calculadora-margem/page.tsx
+++ b/src/app/tools/calculadora-margem/page.tsx
@@ -78,6 +78,20 @@ export default function MarginCalculatorPage() {
         </p>
       </header>
 
+      <div className="mt-8">
+        <ins
+          className="adsbygoogle"
+          style={{ display: "block" }}
+          data-ad-client="ca-pub-9486959611066829"
+          data-ad-slot="7060633998"
+          data-ad-format="auto"
+          data-full-width-responsive="true"
+        />
+        <Script id="margin-calculator-adsense" strategy="afterInteractive">
+          {`(adsbygoogle = window.adsbygoogle || []).push({});`}
+        </Script>
+      </div>
+
       <div className="mt-12">
         <CalculatorClient />
       </div>


### PR DESCRIPTION
## Summary
- add a Google AdSense unit to the margin calculator tool page so the calculator shows the configured ad slot

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9fa2023c883339104be2e087b171a