### PR TITLE
Move tools menu to footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Este repositório contém uma aplicação [Next.js](https://nextjs.org/) prepara
 
 ## 🧰 Ferramentas gratuitas
 
-- A navegação principal recebeu o menu **Ferramentas**, com submenu para destacar utilitários que geram valor imediato antes da contratação de um agente de IA; todos os links dessa seção abrem em uma nova aba para manter a navegação atual disponível. No menu móvel, o grupo fica recolhido por padrão e pode ser expandido sob demanda, enquanto os atalhos de âncora "Soluções" e "Modelos" foram removidos para reduzir distrações ao abrir o painel lateral.
+- O menu **Ferramentas** fica disponível exclusivamente no rodapé da landing page (desktop e mobile), reunindo atalhos para a coletânea completa e para a calculadora de margem em nova aba, mantendo o cabeçalho enxuto para priorizar rotas institucionais.
 - A pasta `src/app/tools` centraliza as ferramentas gratuitas. Cada recurso ganha metadados completos (`title`, `description`, `openGraph`, `twitter`) e marcações JSON-LD para reforçar a indexação orgânica.
 - A primeira entrega é a **Calculadora de margem e precificação** (`/tools/calculadora-margem`), que recebe custos diretos, despesas alocadas, impostos e margem desejada para devolver preço sugerido, margem real e lucro unitário.
 - A simulação é entregue imediatamente sem exigir e-mail, priorizando a experiência do visitante e mantendo os resultados visíveis logo após o preenchimento do formulário.

--- a/components/landing/Footer.tsx
+++ b/components/landing/Footer.tsx
@@ -1,8 +1,5 @@
 import Image from "next/image";
 import Link from "next/link";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-
 export default function Footer() {
   const year = new Date().getFullYear();
   return (
@@ -35,6 +32,26 @@ export default function Footer() {
               <li>
                 <Link href="/privacy" className="hover:text-primary">
                   Privacidade
+                </Link>
+              </li>
+            </ul>
+          </div>
+          <div>
+            <h4 className="mb-4 font-semibold">Ferramentas</h4>
+            <ul className="space-y-2">
+              <li>
+                <Link href="/tools" target="_blank" rel="noopener noreferrer" className="hover:text-primary">
+                  Todas as ferramentas
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="/tools/calculadora-margem"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="hover:text-primary"
+                >
+                  Calculadora de margem
                 </Link>
               </li>
             </ul>

--- a/components/landing/Header.tsx
+++ b/components/landing/Header.tsx
@@ -3,12 +3,11 @@
 import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useState } from "react";
-import { ChevronDown, Menu, X } from "lucide-react";
+import { Menu, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 export default function Header() {
   const [open, setOpen] = useState(false);
-  const [mobileToolsOpen, setMobileToolsOpen] = useState(false);
 
   useEffect(() => {
     document.body.style.overflow = open ? "hidden" : "";
@@ -17,15 +16,8 @@ export default function Header() {
     };
   }, [open]);
 
-  useEffect(() => {
-    if (!open) {
-      setMobileToolsOpen(false);
-    }
-  }, [open]);
-
   const closeMenu = () => {
     setOpen(false);
-    setMobileToolsOpen(false);
   };
 
   return (
@@ -55,34 +47,6 @@ export default function Header() {
               <Link href="/sob-demanda" className="hover:text-primary">
                 Sob demanda
               </Link>
-            </li>
-            <li className="group relative">
-              <Link
-                href="/tools"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex items-center gap-1 hover:text-primary focus:text-primary focus:outline-none"
-                aria-haspopup="true"
-              >
-                Ferramentas
-                <ChevronDown className="h-4 w-4 transition group-hover:-rotate-180 group-focus-within:-rotate-180" />
-              </Link>
-              <div className="invisible absolute left-1/2 top-full z-30 mt-3 w-64 -translate-x-1/2 rounded-2xl border border-slate-200 bg-white p-4 text-left opacity-0 shadow-xl transition group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100">
-                <Link
-                  href="/tools/calculadora-margem"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="block rounded-lg px-3 py-2 text-sm font-medium text-slate-700 transition hover:bg-primary/10 hover:text-primary"
-                >
-                  Calculadora de margem
-                  <span className="mt-1 block text-xs font-normal text-slate-500">
-                    Descubra preço sugerido, margem real e lucro unitário.
-                  </span>
-                </Link>
-                <div className="mt-3 rounded-lg border border-dashed border-slate-200 px-3 py-2 text-xs text-slate-500">
-                  Em breve: novos roteiros e calculadoras para apoiar seu time comercial com IA.
-                </div>
-              </div>
             </li>
           </ul>
         </nav>
@@ -126,45 +90,6 @@ export default function Header() {
             <Link href="/sob-demanda" onClick={closeMenu}>
               Sob demanda
             </Link>
-            <div className="w-full space-y-3 rounded-2xl border border-slate-200 bg-white/90 p-4 text-base text-slate-700">
-              <p className="text-xs font-semibold uppercase tracking-wide text-primary">Ferramentas</p>
-              <button
-                type="button"
-                onClick={() => setMobileToolsOpen((prev) => !prev)}
-                aria-expanded={mobileToolsOpen}
-                aria-controls="mobile-tools-submenu"
-                className="flex w-full items-center justify-between rounded-lg px-3 py-2 text-left text-sm font-semibold transition hover:bg-primary/10"
-              >
-                <span>Explorar ferramentas</span>
-                <ChevronDown
-                  className={`h-4 w-4 transition-transform ${mobileToolsOpen ? "-rotate-180" : ""}`}
-                  aria-hidden="true"
-                />
-              </button>
-              <div
-                id="mobile-tools-submenu"
-                className={`${mobileToolsOpen ? "space-y-2 pt-2" : "hidden"}`}
-              >
-                <Link
-                  href="/tools"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  onClick={closeMenu}
-                  className="block rounded-lg border border-transparent px-3 py-2 text-sm transition hover:border-primary/40 hover:bg-primary/10"
-                >
-                  Todas as ferramentas
-                </Link>
-                <Link
-                  href="/tools/calculadora-margem"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  onClick={closeMenu}
-                  className="block rounded-lg border border-transparent px-3 py-2 text-sm transition hover:border-primary/40 hover:bg-primary/10"
-                >
-                  Calculadora de margem
-                </Link>
-              </div>
-            </div>
             <Link href="/contact" onClick={closeMenu}>
               Contato
             </Link>


### PR DESCRIPTION
## Summary
- remove the Ferramentas dropdown from the header and simplify the mobile navigation state
- add a Ferramentas section to the landing page footer so the shortcuts stay available on desktop and mobile
- update the README to document that the tools menu now lives exclusively in the footer

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbe97ad9e4833392ed19e89792b35b