### PR TITLE
Adjust landing stats layout for mobile

### DIFF
--- a/components/landing/Stats.tsx
+++ b/components/landing/Stats.tsx
@@ -13,14 +13,14 @@ export default function Stats() {
   return (
     <section className="bg-gradient-to-r from-primary/5 to-primary/10 py-8 md:py-12 lg:py-16">
       <div className="mx-auto max-w-[1140px] px-3 md:px-4 lg:px-6">
-        <div className="grid gap-6 text-center sm:grid-cols-3">
+        <div className="grid grid-cols-3 gap-3 text-center sm:gap-6">
           {stats.map(({ icon: Icon, end, label }) => (
             <div key={label} className="flex flex-col items-center">
-              <Icon className="mb-2 h-8 w-8 text-primary" />
-              <p className="text-3xl font-bold">
+              <Icon className="mb-1 h-6 w-6 text-primary sm:mb-2 sm:h-8 sm:w-8" />
+              <p className="text-2xl font-bold sm:text-3xl">
                 <CountUp end={end} duration={2} enableScrollSpy scrollSpyOnce />+
               </p>
-              <p className="text-sm text-muted-foreground">{label}</p>
+              <p className="text-xs text-muted-foreground sm:text-sm">{label}</p>
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- force the landing stats grid into three columns on mobile to keep the metrics on a single line
- reduce icon, text, and spacing sizes on small screens so the stats fit comfortably

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc0699d224833380d17743fc81bf29