### PR TITLE
Remove Hotjar script from layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -100,18 +100,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             fbq('track', 'PageView');
           `}
         </Script>
-        <Script id="hotjar-tracking" strategy="afterInteractive">
-          {`
-            (function(h,o,t,j,a,r){
-              h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
-              h._hjSettings={hjid:6534233,hjsv:6};
-              a=o.getElementsByTagName('head')[0];
-              r=o.createElement('script');r.async=1;
-              r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
-              a.appendChild(r);
-            })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
-          `}
-        </Script>
       </head>
       <body className="font-sans antialiased h-full">
         <NotificationProvider>


### PR DESCRIPTION
## Summary
- remove the Hotjar tracking Script component from the global layout to stop loading the analytics snippet

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc74b981b083338ca12952149b6361